### PR TITLE
Fix/2.1.x/ecms 3813

### DIFF
--- a/delivery/wcm/assembly/pom.xml
+++ b/delivery/wcm/assembly/pom.xml
@@ -217,8 +217,8 @@
   <dependency><groupId>org.w3c</groupId><artifactId>sac</artifactId><version>${org.w3c.sac.version}</version><type>jar</type></dependency>
   <dependency><groupId>batik</groupId><artifactId>batik-util</artifactId><version>${org.apache.batik-util.version}</version><type>jar</type></dependency>
 	<dependency><groupId>c3p0</groupId><artifactId>c3p0</artifactId><version>${c3p0.version}</version><type>jar</type></dependency><!-- 0.9.1.2-->
-	<dependency><groupId>org.gatein.wci</groupId><artifactId>wci-exo</artifactId><version>${org.gatein.wci.version}</version><type>jar</type></dependency><!-- 2.0.1-GA-->
-	<dependency><groupId>org.gatein.wci</groupId><artifactId>wci-tomcat</artifactId><version>${org.gatein.wci.version}</version><type>jar</type></dependency><!-- 2.0.1-GA-->
+	<dependency><groupId>org.gatein.wci</groupId><artifactId>wci-exo</artifactId><version>${org.gatein.wci.version}</version><type>jar</type></dependency><!-- 2.1.0-GA-->
+	<dependency><groupId>org.gatein.wci</groupId><artifactId>wci-tomcat6</artifactId><version>${org.gatein.wci.version}</version><type>jar</type></dependency><!-- 2.1.0-GA-->
 	<dependency><groupId>net.sourceforge.nekohtml</groupId><artifactId>nekohtml</artifactId><version>${net.sourceforge.nekohtml.version}</version><type>jar</type></dependency><!-- 1.9.9-->
 	<dependency><groupId>net.oauth</groupId><artifactId>core</artifactId><version>${net.oauth.version}</version><type>jar</type></dependency><!-- 20080621-->
 	<dependency><groupId>cglib</groupId><artifactId>cglib</artifactId><version>${cglib.version}</version><type>jar</type></dependency><!-- 2.2-->

--- a/delivery/wkf-wcm/assembly/pom.xml
+++ b/delivery/wkf-wcm/assembly/pom.xml
@@ -115,9 +115,9 @@
 	<dependency><groupId>org.exoplatform.ecms</groupId><artifactId>exo-ecms-packaging-workflow-config</artifactId><version>${project.version}</version><type>jar</type></dependency>
 	<dependency><groupId>org.exoplatform.ecms</groupId><artifactId>exo-ecms-packaging-workflow-webapp</artifactId><version>${project.version}</version><type>war</type></dependency>
     <dependency><groupId>c3p0</groupId><artifactId>c3p0</artifactId><version>${c3p0.version}</version><type>jar</type></dependency><!-- 0.9.1.2-->
-	<dependency><groupId>org.gatein.wci</groupId><artifactId>wci-exo</artifactId><version>${org.gatein.wci.version}</version><type>jar</type></dependency><!-- 2.0.1-GA-->
+	<dependency><groupId>org.gatein.wci</groupId><artifactId>wci-exo</artifactId><version>${org.gatein.wci.version}</version><type>jar</type></dependency><!-- 2.1.0-GA-->
 	<dependency><groupId>org.exoplatform.jcr</groupId><artifactId>exo.jcr.framework.web</artifactId><version>${org.exoplatform.jcr.version}</version><type>jar</type></dependency><!-- 1.12.6-GA-SNAPSHOT-->
-	<dependency><groupId>org.gatein.wci</groupId><artifactId>wci-tomcat</artifactId><version>${org.gatein.wci.version}</version><type>jar</type></dependency><!-- 2.0.1-GA-->
+	<dependency><groupId>org.gatein.wci</groupId><artifactId>wci-tomcat6</artifactId><version>${org.gatein.wci.version}</version><type>jar</type></dependency><!-- 2.1.0-GA-->
 	<dependency><groupId>net.sourceforge.nekohtml</groupId><artifactId>nekohtml</artifactId><version>${net.sourceforge.nekohtml.version}</version><type>jar</type></dependency><!-- 1.9.9-->
 	<dependency><groupId>org.exoplatform.portal</groupId><artifactId>exo.portal.portlet.dashboard</artifactId><version>${org.exoplatform.portal.version}</version><type>war</type></dependency><!-- 3.1.6-PLF-SNAPSHOT-->
 	<dependency><groupId>org.exoplatform.portal</groupId><artifactId>exo.portal.web.portal</artifactId><version>${org.exoplatform.portal.version}</version><type>war</type></dependency><!-- 3.1.6-PLF-SNAPSHOT-->

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <workflowEngine>jbpm</workflowEngine>
     <!-- 3rd parties -->
     <c3p0.version>0.9.1.2</c3p0.version>
-    <org.gatein.wci.version>2.0.2-GA</org.gatein.wci.version>
+    <org.gatein.wci.version>2.1.0-GA</org.gatein.wci.version>
     <javassist.version>3.4.GA</javassist.version>
     <commons-collections.version>3.2.1</commons-collections.version>
     <commons-pool.version>1.2</commons-pool.version>


### PR DESCRIPTION
ECMS-3813 EXOGTN-892: Updated gatein wci version to 2.1.0-GA and use wci-tomcat6 instead of wci-tomcat
