### PR TITLE
Fix/2.1.x/ecms 3827

### DIFF
--- a/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/UIJCRExplorerContainer.gtmpl
+++ b/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/UIJCRExplorerContainer.gtmpl
@@ -16,11 +16,11 @@
 <script type="text/javascript" src="/ecmexplorer/javascript/eXo/ecm/ZeroClipboard.js"></script>
 <div class="$uicomponent.id" id="$uicomponent.id" >
 	<div style="height: 0px;">
-		<div style="width: 880px;" >
+		<div style="width: 920px;" >
 			<span style="display: none;"></span>
 		</div>
 	</div>
-	<div style="!width: expression(this.previousSibling.offsetWidth - 2 + 'px'); margin: auto; !border: 1px solid white; min-width: 880px;">
+	<div style="!width: expression(this.previousSibling.offsetWidth - 2 + 'px'); margin: auto; !border: 1px solid white; min-width: 920px;">
  		<%  uicomponent.renderChildren(); %>
   </div>
 </div>

--- a/apps/portlet-explorer/src/main/webapp/skin/webui/component/explorer/DefaultStylesheet.css
+++ b/apps/portlet-explorer/src/main/webapp/skin/webui/component/explorer/DefaultStylesheet.css
@@ -26,6 +26,8 @@
 	border: 1px solid #b7b7b7;
 	/* margin: 5px; */
 	overflow: hidden; /* orientation=rt */
+	overflow-x: auto;
+	overflow-y: hidden;
 	background: white;
 }
 


### PR DESCRIPTION
Allow the horizontal scrollbar appear when the width of Content Explorer portlet is smaller than total of the width of components inside it.
