### PR TITLE
Fix/2.1.x/ecms 3839

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/fckeditor/DriverConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/fckeditor/DriverConnector.java
@@ -610,13 +610,13 @@ public class DriverConnector extends BaseConnector implements ResourceContainer 
 
 	  		checkNode = sourceNode != null ? sourceNode : child;
 
-	  		if (isFolder(checkNode)) {	  			
+	  		if (isFolder(checkNode, repositoryName)) {
 	  			Element folder = createFolderElement(
 	  					document, checkNode, checkNode.getPrimaryNodeType().getName(), child.getName(), nodeDriveName);
 	  			folders.appendChild(folder);
 	  		}
 
-	  		if (FILE_TYPE_ALL.equals(filterBy) && (checkNode.isNodeType(NodetypeConstant.EXO_WEBCONTENT) || checkNode.isNodeType(NodetypeConstant.EXO_ARTICLE) || !isFolder(checkNode))) {
+	  		if (FILE_TYPE_ALL.equals(filterBy) && (checkNode.isNodeType(NodetypeConstant.EXO_WEBCONTENT) || checkNode.isNodeType(NodetypeConstant.EXO_ARTICLE) || !isFolder(checkNode, repositoryName))) {
 	  		  fileType = FILE_TYPE_ALL;
 	  		}
 	  		
@@ -653,11 +653,21 @@ public class DriverConnector extends BaseConnector implements ResourceContainer 
 	 * 
 	 * @throws RepositoryException the repository exception
 	 */
-	private boolean isFolder(Node checkNode) throws RepositoryException {
-	  return 
-	  		checkNode.isNodeType(FCKUtils.NT_UNSTRUCTURED)
-	  		|| checkNode.isNodeType(FCKUtils.NT_FOLDER)
-	  		|| checkNode.isNodeType(NodetypeConstant.EXO_TAXONOMY);
+  private boolean isFolder(Node checkNode, String repositoryName) throws RepositoryException {
+    try {
+      if (isDMSDocument(checkNode, repositoryName)) {
+        return false;
+      }
+    } catch (Exception e) {
+      if (log.isWarnEnabled()) {
+        log.warn(e.getMessage());
+      }
+    }
+    
+    return 
+      checkNode.isNodeType(FCKUtils.NT_UNSTRUCTURED)
+        || checkNode.isNodeType(FCKUtils.NT_FOLDER)
+        || checkNode.isNodeType(NodetypeConstant.EXO_TAXONOMY);
   }
   
   /**


### PR DESCRIPTION
ECMS-3839 exo:link still considered as a folder when add CLV page
Fix description: In DriverConnector.isFolder, add check if input node is document then the node is not folder
