### PR TITLE
Fix/2.1.x/ecms 3863

### DIFF
--- a/core/viewer/src/main/java/org/exoplatform/ecm/REST/viewer/PDFViewerRESTService.java
+++ b/core/viewer/src/main/java/org/exoplatform/ecm/REST/viewer/PDFViewerRESTService.java
@@ -36,6 +36,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
 
+import org.apache.commons.lang.StringUtils;
 import org.artofsolving.jodconverter.office.OfficeException;
 import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.ExoContainerContext;
@@ -115,7 +116,8 @@ public class PDFViewerRESTService implements ResourceContainer {
 	  	}
       // capture the page image to file
 			String lastModified = (String) pdfCache.get(new ObjectKey(bd1.append(bd.toString()).append("/jcr:lastModified").toString()));
-      InputStream is = pushToCache(new File((String) pdfCache.get(new ObjectKey(bd.toString()))), repoName, wsName, uuid, pageNumber, strRotation, strScale);
+      InputStream is = pushToCache(new File((String) pdfCache.get(new ObjectKey(bd.toString()))), repoName, wsName, uuid, 
+                                   pageNumber, strRotation, strScale, lastModified);
       return Response.ok(is, "image").header(LASTMODIFIED, lastModified).build();
     } catch (Exception e) {
       LOG.error(e);
@@ -134,15 +136,18 @@ public class PDFViewerRESTService implements ResourceContainer {
   }  
   
   private InputStream pushToCache(File content, String repoName, String wsName, String uuid, 
-      String pageNumber, String strRotation, String strScale) throws FileNotFoundException {
+      String pageNumber, String strRotation, String strScale, String lastModified) throws FileNotFoundException {
   	StringBuilder bd = new StringBuilder();
 		bd.append(repoName).append("/").append(wsName).append("/").append(uuid).append("/").append(
 				pageNumber).append("/").append(strRotation).append("/").append(strScale);
+		StringBuilder bd1 = new StringBuilder().append(bd).append("/jcr:lastModified");
 		String filePath = (String) pdfCache.get(new ObjectKey(bd.toString()));
-		if (filePath == null || !(new File(filePath).exists())) {
+		String fileModifiedTime = (String) pdfCache.get(new ObjectKey(bd1.toString()));
+		if (filePath == null || !(new File(filePath).exists()) || !StringUtils.equals(lastModified, fileModifiedTime)) {
 	    File file = buildFileImage(content, uuid, pageNumber, strRotation, strScale);
 	    filePath = file.getPath();
 			pdfCache.put(new ObjectKey(bd.toString()), filePath);
+			pdfCache.put(new ObjectKey(bd1.toString()), lastModified);
 		}
 		return new BufferedInputStream(new FileInputStream(new File(filePath)));
   }
@@ -221,11 +226,14 @@ public class PDFViewerRESTService implements ResourceContainer {
   	StringBuilder bd = new StringBuilder();
   	StringBuilder bd1 = new StringBuilder();
   	bd.append(repoName).append("/").append(wsName).append("/").append(uuid);
+  	bd1.append(bd).append("/jcr:lastModified");
   	String path = (String) pdfCache.get(new ObjectKey(bd.toString()));
+  	String lastModifiedTime = (String)pdfCache.get(new ObjectKey(bd1.toString()));
   	File content = null;
   	String name = currentNode.getName();
-  	if (path == null || !(content = new File(path)).exists()) {
-  		Node contentNode = currentNode.getNode("jcr:content");
+    Node contentNode = currentNode.getNode("jcr:content");
+    String lastModified = contentNode.getProperty("jcr:lastModified").getString();
+  	if (path == null || !(content = new File(path)).exists() || !lastModified.equals(lastModifiedTime)) {
   		String mimeType = contentNode.getProperty("jcr:mimeType").getString();
   		InputStream input = new BufferedInputStream(contentNode.getProperty("jcr:data").getStream()); 
   		// Create temp file to store data of nt:file node 
@@ -258,9 +266,8 @@ public class PDFViewerRESTService implements ResourceContainer {
   		}
   		if (content.exists()) {
           if (contentNode.hasProperty("jcr:lastModified")) {
-            String lastModified = contentNode.getProperty("jcr:lastModified").getString();
             pdfCache.put(new ObjectKey(bd.toString()), content.getPath());
-            pdfCache.put(new ObjectKey(bd1.append(bd.toString()).append("/jcr:lastModified").toString()), lastModified);
+            pdfCache.put(new ObjectKey(bd1.toString()), lastModified);
           }   
   		}
   	}
@@ -313,7 +320,7 @@ public class PDFViewerRESTService implements ResourceContainer {
 		
 		@Override
 		public int hashCode() {
-			return key == null ? -1 : key.length();
+			return key == null ? -1 : key.hashCode();
 		}
 		
 		@Override

--- a/core/viewer/src/main/java/resources/templates/PDFViewer.gtmpl
+++ b/core/viewer/src/main/java/resources/templates/PDFViewer.gtmpl
@@ -236,7 +236,10 @@
 	<div class="PDFViewerContent">
   	<div class="ImageView" style="overflow:auto;" id ="pdf_viewer_image" name="pdf_viewer_image">
 		<%
-			  String pdfPageImage = "/" + uiParent.getPortalName() + "/" + Utils.getRestContextName(uiParent.getPortalName()) + "/pdfviewer/" + uiParent.getRepository() + "/" + uiParent.getWorkspaceName() + "/${currentPage}/${currentRotation}/${currentScale}/" + currentNode.getUUID() + "/";
+			  String pdfPageImage = "/" + uiParent.getPortalName() + "/" + Utils.getRestContextName(uiParent.getPortalName()) + 
+			                        "/pdfviewer/" + uiParent.getRepository() + "/" + uiParent.getWorkspaceName() + 
+			                        "/${currentPage}/${currentRotation}/${currentScale}/" + currentNode.getUUID() + "?" +
+			                        currentNode.getProperty("jcr:content/jcr:lastModified").getString();
 		%>
 			  <a href="$pdfPageImage" style="display:inline-block" title="<%=uicomponent.getResourceBundle("PDFViewer.label.viewFullPage")%>"><img src="$pdfPageImage" /></a>
 		</div>


### PR DESCRIPTION
```
1.Add jcr:lastModified value to the preview URL so when the document is changed, the URL is changed, leading to the reloading of preview image
2.In PDFViewerRESTService, update cache when document is modified.
```
