### PR TITLE
Fix/2.3.x/ecms 3930

### DIFF
--- a/core/webui-seo/src/main/java/org/exoplatform/wcm/webui/seo/UISEOForm.java
+++ b/core/webui-seo/src/main/java/org/exoplatform/wcm/webui/seo/UISEOForm.java
@@ -142,8 +142,8 @@ public class UISEOForm extends UIForm{
       if(pageModel.getPriority() >= 0)
         priority = String.valueOf(pageModel.getPriority());
       if(pageModel.getRobotsContent() != null && pageModel.getRobotsContent().length() > 0) {
-        index = pageModel.getRobotsContent().split(",")[0];
-        follow = pageModel.getRobotsContent().split(",")[1];
+        index = pageModel.getRobotsContent().split(",")[0].trim();
+        follow = pageModel.getRobotsContent().split(",")[1].trim();
       }
       sitemap = pageModel.getSitemap();
     }


### PR DESCRIPTION
Fix the ECMS-3930 by using trim before parameters. The string has a space before due to the necessary configuration inside the meta of the page.
