### PR TITLE
Fix/2.1.x/ecms 4093

### DIFF
--- a/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/popup/info/UIPropertyTab.gtmpl
+++ b/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/popup/info/UIPropertyTab.gtmpl
@@ -33,7 +33,7 @@ import org.exoplatform.wcm.webui.reader.ContentReader;
 			    multiValue = bean.getDefinition().isMultiple() ;
 		    } catch(Exception e) {
 		    }
-		    ContentReader.getXSSCompatibilityContent(uicomponent.getPropertyValue(bean));
+		    value = ContentReader.getXSSCompatibilityContent(uicomponent.getPropertyValue(bean));
 	      if(even) rowClass = "EvenRow" ;
 	      else rowClass =  "OddRow" ;
 	      even = !even ; %>


### PR DESCRIPTION
Cause: undefined "value" in UIPropertyTab.gtmpl (committed in ECMS-3897)
-                   value = uicomponent.getPropertyValue(bean) ;
-                   ContentReader.getXSSCompatibilityContent(uicomponent.getPropertyValue(bean));

Fix description: add value variable
