### PR TITLE
ECMS-4104: Wrong error message when save action of taxonomy without name

### DIFF
--- a/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_ar.properties
+++ b/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_ar.properties
@@ -1410,4 +1410,3 @@ UISideBar.title.Control=\u0627\u0644\u062A\u062D\u0643\u0645 \u0639\u0644\u0649 
 UIAllItems.label.Hidden=\u0645\u062E\u0641\u064A
 UIRestoreConfirmMessage.label.ReplaceData=\u0627\u0633\u062A\u0628\u062F\u0627\u0644 \u0627\u0644\u0628\u064A\u0627\u0646\u0627\u062A
 UIPermissionInfo.msg.no-permission=You can not remove all permissions of this node. Node should have at least one permission except for the 'system'
-UIActionForm.msg.xss-vulnerability-character=Field '{0}' contains XSS vulnerability characters

--- a/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_ar.xml
+++ b/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_ar.xml
@@ -2886,9 +2886,4 @@
       <no-permission>You can not remove all permissions of this node. Node should have at least one permission except for the 'system'</no-permission>
     </msg>
   </UIPermissionInfo>	  	
-  <UIActionForm>
-    <msg>
-      <xss-vulnerability-character>Field '{0}' contains XSS vulnerability characters</xss-vulnerability-character>
-    </msg>
-  </UIActionForm>
 </bundle>

--- a/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_de.xml
+++ b/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_de.xml
@@ -3345,9 +3345,4 @@
       <no-permission>You can not remove all permissions of this node. Node should have at least one permission except for the 'system'</no-permission>
     </msg>
   </UIPermissionInfo>	  	
-  <UIActionForm>
-    <msg>
-      <xss-vulnerability-character>Field '{0}' contains XSS vulnerability characters</xss-vulnerability-character>
-    </msg>
-  </UIActionForm>
 </bundle>

--- a/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_en.xml
+++ b/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_en.xml
@@ -3328,10 +3328,5 @@
       <no-permission>You can not remove all permissions of this node. Node should have at least one permission except for the 'system'</no-permission>
     </msg>
   </UIPermissionInfo>	  	
-  <UIActionForm>
-    <msg>
-      <xss-vulnerability-character>Field '{0}' contains XSS vulnerability characters</xss-vulnerability-character>
-    </msg>
-  </UIActionForm>
 </bundle>
 

--- a/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_es.properties
+++ b/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_es.properties
@@ -1410,4 +1410,3 @@ UISideBar.title.Control=Controlar la barra lateral
 UIAllItems.label.Hidden=Escondido
 UIRestoreConfirmMessage.label.ReplaceData=Reemplazar data
 UIPermissionInfo.msg.no-permission=You can not remove all permissions of this node. Node should have at least one permission except for the 'system'
-UIActionForm.msg.xss-vulnerability-character=Field '{0}' contains XSS vulnerability characters

--- a/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_fr.xml
+++ b/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_fr.xml
@@ -3361,9 +3361,4 @@
       <no-permission>Vous ne pouvez pas supprimer tous les droits de ce noeud. Chaque noeud doit avoir au moins une permission sauf pour les 'system'</no-permission>
     </msg>
   </UIPermissionInfo>	  	
-  <UIActionForm>
-    <msg>
-      <xss-vulnerability-character>Le champ '{0}' contient des caractères vulnérables aux attaques XSS</xss-vulnerability-character>
-    </msg>
-  </UIActionForm>
 </bundle>

--- a/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_it.properties
+++ b/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_it.properties
@@ -1418,4 +1418,3 @@ UISideBar.title.Control=Controlla sidebar
 UIAllItems.label.Hidden=Nascosto
 UIRestoreConfirmMessage.label.ReplaceData=Sostituisci i dati
 UIPermissionInfo.msg.no-permission=You can not remove all permissions of this node. Node should have at least one permission except for the 'system'
-UIActionForm.msg.xss-vulnerability-character=Field '{0}' contains XSS vulnerability characters

--- a/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_ja.xml
+++ b/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_ja.xml
@@ -3312,10 +3312,5 @@
       <no-permission>You can not remove all permissions of this node. Node should have at least one permission except for the 'system'</no-permission>
     </msg>
   </UIPermissionInfo>	  	
-  <UIActionForm>
-    <msg>
-      <xss-vulnerability-character>Field '{0}' contains XSS vulnerability characters</xss-vulnerability-character>
-    </msg>
-  </UIActionForm>
 </bundle>
 

--- a/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_nl.xml
+++ b/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_nl.xml
@@ -3327,9 +3327,4 @@
       <no-permission>You can not remove all permissions of this node. Node should have at least one permission except for the 'system'</no-permission>
     </msg>
   </UIPermissionInfo>	  	
-  <UIActionForm>
-    <msg>
-      <xss-vulnerability-character>Field '{0}' contains XSS vulnerability characters</xss-vulnerability-character>
-    </msg>
-  </UIActionForm>
 </bundle>

--- a/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_pt_BR.properties
+++ b/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_pt_BR.properties
@@ -1414,4 +1414,3 @@ UISideBar.title.Control=Controle da Barra Lateral
 UIAllItems.label.Hidden=Oculto
 UIRestoreConfirmMessage.label.ReplaceData=Substituir dado
 UIPermissionInfo.msg.no-permission=You can not remove all permissions of this node. Node should have at least one permission except for the 'system'
-UIActionForm.msg.xss-vulnerability-character=Field '{0}' contains XSS vulnerability characters

--- a/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_vi.xml
+++ b/apps/portlet-explorer/src/main/webapp/WEB-INF/classes/locale/portlet/explorer/JCRExplorerPortlet_vi.xml
@@ -3366,9 +3366,4 @@
       <no-permission>Bạn không có thể loại bỏ tất cả quyền truy cập của node này. Node cần có ít nhất một quyền truy cập ngoại trừ 'system'</no-permission>
     </msg>
   </UIPermissionInfo>	  	
-  <UIActionForm>
-    <msg>
-      <xss-vulnerability-character>Trường '{0}' có chứa các ký tự không hợp lệ</xss-vulnerability-character>
-    </msg>
-  </UIActionForm>
 </bundle>

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/classes/locale/wcm/webui_ar.properties
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/classes/locale/wcm/webui_ar.properties
@@ -162,3 +162,4 @@ ContentSelector.title.CollaborationCenter=\u0645\u0631\u0643\u0632 \u0627\u0644\
 UIPermissionManager.action.Clear=\u0648\u0627\u0636\u062D
 UIPermissionManager.action.Save=\u062D\u0641\u0638
 UIPermissionInputSetWithAction.title.SelectMember=\u0627\u062E\u062A\u0631\u00a0\u0639\u0636\u0648\u0627
+UIActionForm.msg.xss-vulnerability-character=Field '{0}' contains XSS vulnerability characters

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/classes/locale/wcm/webui_en.xml
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/classes/locale/wcm/webui_en.xml
@@ -412,5 +412,9 @@
       <access-denied-exception>Access denied. You may not have the privileges on reading or node removed or changed</access-denied-exception>
     </msg>
   </UIDocumentInfo>
-  
+  <UIActionForm>
+    <msg>
+      <xss-vulnerability-character>Field '{0}' contains XSS vulnerability characters</xss-vulnerability-character>
+    </msg>
+  </UIActionForm>  
 </bundle>

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/classes/locale/wcm/webui_es.properties
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/classes/locale/wcm/webui_es.properties
@@ -162,3 +162,4 @@ ContentSelector.title.CollaborationCenter=Centro de Colaboraci\u00f3n
 UIPermissionManager.action.Clear=Claro
 UIPermissionManager.action.Save=Guardar
 UIPermissionInputSetWithAction.title.SelectMember=Seleccionar miembro
+UIActionForm.msg.xss-vulnerability-character=Field '{0}' contains XSS vulnerability characters

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/classes/locale/wcm/webui_fr.xml
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/classes/locale/wcm/webui_fr.xml
@@ -411,5 +411,9 @@
       <access-denied-exception>Accès interdit. Veuillez vérifier vos droits d'accès à ce noeud</access-denied-exception>
     </msg>
   </UIDocumentInfo>
-  
+  <UIActionForm>
+    <msg>
+      <xss-vulnerability-character>Le champ '{0}' contient des caractères vulnérables aux attaques XSS</xss-vulnerability-character>
+      </msg>
+  </UIActionForm>  
 </bundle>

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/classes/locale/wcm/webui_it.properties
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/classes/locale/wcm/webui_it.properties
@@ -163,3 +163,4 @@ ContentSelector.title.CollaborationCenter=Centro collaborazione
 UIPermissionManager.action.Clear=Cancella
 UIPermissionManager.action.Save=Salva
 UIPermissionInputSetWithAction.title.SelectMember=Seleziona membro
+UIActionForm.msg.xss-vulnerability-character=Field '{0}' contains XSS vulnerability characters

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/classes/locale/wcm/webui_ja.xml
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/classes/locale/wcm/webui_ja.xml
@@ -411,5 +411,9 @@
       <access-denied-exception>アクセスが拒否されました。読み出し権がない、もしくはノードが削除、変更されたかもしれません。</access-denied-exception>
     </msg>
   </UIDocumentInfo>
-  
+   <UIActionForm>
+     <msg>
+       <xss-vulnerability-character> フィールド'{0}'はクロスサイトスクリプティングの脆弱性文字が含まれている</xss-vulnerability-character>
+     </msg>
+  </UIActionForm>
 </bundle>

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/classes/locale/wcm/webui_pt_BR.properties
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/classes/locale/wcm/webui_pt_BR.properties
@@ -162,3 +162,4 @@ ContentSelector.title.CollaborationCenter=Centro de Colabora\u00e7\u00e3o
 UIPermissionManager.action.Clear=Limpar
 UIPermissionManager.action.Save=Salvar
 UIPermissionInputSetWithAction.title.SelectMember=Selecionar membro
+UIActionForm.msg.xss-vulnerability-character=Field '{0}' contains XSS vulnerability characters

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/classes/locale/wcm/webui_vi.xml
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/classes/locale/wcm/webui_vi.xml
@@ -413,5 +413,9 @@
       <access-denied-exception>Truy cập bị chặn do bạn không có quyền đọc node, thay đổi node hoặc node đã bị xóa hoặc thay đổi.</access-denied-exception>
     </msg>
   </UIDocumentInfo>
-  
+  <UIActionForm>
+    <msg>
+      <xss-vulnerability-character>Trường '{0}' có chứa các ký tự không hợp lệ</xss-vulnerability-character>
+    </msg>
+  </UIActionForm>
 </bundle>

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/actions/getMail/dialogs/dialog1.gtmpl
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/actions/getMail/dialogs/dialog1.gtmpl
@@ -17,7 +17,7 @@
 	      <td class="FieldLabel"><%=_ctx.appRes("Getmail.dialog.label.name")%></td>
 	      <td class="FieldComponent">
 		      <% 
-		        String[] fieldName = ["jcrPath=/node/exo:name", "validate=XSSValidator"];
+		        String[] fieldName = ["jcrPath=/node/exo:name", "validate=empty,XSSValidator"];
 		        uicomponent.addTextField("actionName", _ctx.appRes("Getmail.dialog.label.name"), fieldName);
 		      %>
 		    </td>

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/actions/rss/dialogs/dialog1.gtmpl
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/actions/rss/dialogs/dialog1.gtmpl
@@ -27,7 +27,7 @@
 	      <td class="FieldLabel"><%=_ctx.appRes("Rss.dialog.label.feed-action-name")%></td>
 	      <td class="FieldComponent">
 		      <%
-		        String[] fieldName = ["jcrPath=/node/exo:name", "validate=XSSValidator"];
+		        String[] fieldName = ["jcrPath=/node/exo:name", "validate=empty,XSSValidator"];
 		        uicomponent.addTextField("actionName", _ctx.appRes("Rss.dialog.label.feed-action-name"), fieldName) ;  
 		      %>
 		    </td>

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/actions/script/addMetadata/dialogs/dialog1.gtmpl
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/actions/script/addMetadata/dialogs/dialog1.gtmpl
@@ -16,7 +16,7 @@
 			  <td class="FieldLabel"><%=_ctx.appRes("AddMetadata.dialog.label.name")%></td>
 			  <td class="FieldComponent">
 				  <% 
-					String[] fieldName = ["jcrPath=/node/exo:name", "validate=XSSValidator"];
+					String[] fieldName = ["jcrPath=/node/exo:name", "validate=empty,XSSValidator"];
 					uicomponent.addTextField("actionName", _ctx.appRes("AddMetadata.dialog.label.name"), fieldName);
 				  %>
 				</td>

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/actions/script/addTaxonomy/dialogs/dialog1.gtmpl
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/actions/script/addTaxonomy/dialogs/dialog1.gtmpl
@@ -21,7 +21,7 @@
 			  <td class="FieldLabel"><%=_ctx.appRes("ScriptAction.dialog.label.name")%></td>
 			  <td class="FieldComponent">
 				  <% 
-						String[] fieldName = ["jcrPath=/node/exo:name", "validate=XSSValidator"];
+						String[] fieldName = ["jcrPath=/node/exo:name", "validate=empty,XSSValidator"];
 						uicomponent.addTextField("actionName", _ctx.appRes("ScriptAction.dialog.label.name"), fieldName);
 				  %>
 				</td>

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/actions/script/reloadBP/dialogs/dialog1.gtmpl
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/actions/script/reloadBP/dialogs/dialog1.gtmpl
@@ -16,7 +16,7 @@
       <td class="FieldLabel"><%=_ctx.appRes("ReloadAction.dialog.label.name")%></td>
       <td class="FieldComponent">
 	      <% 
-	        String[] fieldName = ["jcrPath=/node/exo:name", "validate=XSSValidator"];
+	        String[] fieldName = ["jcrPath=/node/exo:name", "validate=empty,XSSValidator"];
 	        uicomponent.addTextField("actionName", _ctx.appRes("ReloadAction.dialog.label.name"), fieldName);  
 	      %>
 	    </td>

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/actions/script/sendMail/dialogs/dialog1.gtmpl
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/actions/script/sendMail/dialogs/dialog1.gtmpl
@@ -16,7 +16,7 @@
 				  <td class="FieldLabel"><%=_ctx.appRes("SendMail.dialog.label.name")%></td>
 				  <td class="FieldComponent">				  
 				  <% 
-						String[] fieldName = ["jcrPath=/node/exo:name", "validate=XSSValidator"];
+						String[] fieldName = ["jcrPath=/node/exo:name", "validate=empty,XSSValidator"];
 						uicomponent.addTextField("actionName", _ctx.appRes("SendMail.dialog.label.name"), fieldName);
 				  %>
 				  </td>

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/actions/script/transformBinaryToText/dialogs/dialog1.gtmpl
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/actions/script/transformBinaryToText/dialogs/dialog1.gtmpl
@@ -16,7 +16,7 @@
 	      <td class="FieldLabel"><%=_ctx.appRes("Transform.dialog.label.name")%></td>
 	      <td class="FieldComponent">
 		      <% 
-		        String[] fieldName = ["jcrPath=/node/exo:name", "validate=XSSValidator"];
+		        String[] fieldName = ["jcrPath=/node/exo:name", "validate=empty,XSSValidator"];
 		        uicomponent.addTextField("actionName", _ctx.appRes("Transform.dialog.label.name"), fieldName) ;  
 		      %>
 		    </td>

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/actions/versioning/auto-versioning/dialogs/dialog1.gtmpl
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/actions/versioning/auto-versioning/dialogs/dialog1.gtmpl
@@ -16,7 +16,7 @@
 			  <td class="FieldLabel"><%=_ctx.appRes("AutoVersioning.dialog.label.name")%></td>
 			  <td class="FieldComponent">
 				  <% 
-					String[] fieldName = ["jcrPath=/node/exo:name", "validate=XSSValidator"];
+					String[] fieldName = ["jcrPath=/node/exo:name", "validate=empty,XSSValidator"];
 					uicomponent.addTextField("actionName", _ctx.appRes("AutoVersioning.dialog.label.name"), fieldName);
 				  %>
 				</td>

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/actions/versioning/enable-versioning/dialogs/dialog1.gtmpl
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/actions/versioning/enable-versioning/dialogs/dialog1.gtmpl
@@ -16,7 +16,7 @@
 			  <td class="FieldLabel"><%=_ctx.appRes("EnableVersioning.dialog.label.name")%></td>
 			  <td class="FieldComponent">
 				  <% 
-					String[] fieldName = ["jcrPath=/node/exo:name", "validate=XSSValidator"];
+					String[] fieldName = ["jcrPath=/node/exo:name", "validate=empty,XSSValidator"];
 					uicomponent.addTextField("actionName", _ctx.appRes("EnableVersioning.dialog.label.name"), fieldName);
 				  %>
 				</td>


### PR DESCRIPTION
Fix description:
    - Verify that the mandatory field is filled before avoiding XSS attack
        - Move localization value to location where they can be used by both of Content Explorer and ECM Admin
