### PR TITLE
ECMS-4079: Allow input (') character when creating/editing the name of c...

### DIFF
--- a/core/webui/src/main/java/org/exoplatform/ecm/webui/form/validator/ECMNameValidator.java
+++ b/core/webui/src/main/java/org/exoplatform/ecm/webui/form/validator/ECMNameValidator.java
@@ -51,7 +51,7 @@ public class ECMNameValidator implements Validator {
     for(int i = 0; i < s.length(); i ++){
       char c = s.charAt(i);
       if(Character.isLetter(c) || Character.isDigit(c) || Character.isSpaceChar(c) || c=='_'
-        || c=='-' || c=='.' || c==':' || c=='@' || c=='^' || c=='[' || c==']' || c==',' || c=='%') {
+        || c=='-' || c=='.' || c==':' || c=='@' || c=='^' || c=='[' || c==']' || c==',' || c=='%' || c=='\'') {
         continue ;
       }
       Object[] args = { label };


### PR DESCRIPTION
Fix description: Allow input (') character when creating/editing the name of content
Link issue: https://jira.exoplatform.org/browse/ECMS-4079
