### PR TITLE
ECMS-3783: Allow user to customize the enter mode of CKEditor in dialog template and constructor of UIFormRichtextInput

### DIFF
--- a/core/webui/src/main/java/org/exoplatform/ecm/webui/form/field/UIFormRichtextField.java
+++ b/core/webui/src/main/java/org/exoplatform/ecm/webui/form/field/UIFormRichtextField.java
@@ -32,10 +32,12 @@ public class UIFormRichtextField extends DialogFormField {
   private final String TOOLBAR = "toolbar";
   private final String WIDTH = "width";
   private final String HEIGHT = "height";
+  private final String ENTERMODE = "enterMode";
 
   private String toolbar;
   private String width;
   private String height;
+  private String enterMode;
 
   public UIFormRichtextField(String name, String label, String[] arguments) {
     super(name, label, arguments);
@@ -48,6 +50,7 @@ public class UIFormRichtextField extends DialogFormField {
     richtext.setToolbar(toolbar);
     richtext.setWidth(width);
     richtext.setHeight(height);
+    richtext.setEnterMode(enterMode);
     if(validateType != null) {
       DialogFormUtil.addValidators(richtext, validateType);
     }
@@ -64,6 +67,8 @@ public class UIFormRichtextField extends DialogFormField {
         width = entry[1];
       } else if(HEIGHT.equals(entry[0])) {
         height = entry[1];
+      } else if(ENTERMODE.equals(entry[0])) {
+      	enterMode = entry[1];
       }
     }
   }

--- a/core/webui/src/main/java/org/exoplatform/wcm/webui/form/UIFormRichtextInput.java
+++ b/core/webui/src/main/java/org/exoplatform/wcm/webui/form/UIFormRichtextInput.java
@@ -36,18 +36,30 @@ public class UIFormRichtextInput extends UIFormInputBase<String> {
   public static final String FULL_TOOLBAR = "Full";
 
   public static final String BASIC_TOOLBAR = "Basic";
+  
+  public static final String ENTER_P = "1";
+  public static final String ENTER_BR = "2";
+  public static final String ENTER_DIV = "3";
 
   private String width;
 
   private String height;
 
   private String toolbar;
+  
+  private String enterMode;
 
   public UIFormRichtextInput(String name, String bindingField, String value) {
     super(name, bindingField, String.class);
     this.value_ = value;
  }
 
+  public UIFormRichtextInput(String name, String bindingField, String value, String enterMode) {
+    super(name, bindingField, String.class);
+    this.value_ = value;
+    this.enterMode = enterMode;
+ }
+  
   public String getWidth() {
     return width;
   }
@@ -67,9 +79,17 @@ public class UIFormRichtextInput extends UIFormInputBase<String> {
   public String getToolbar() {
     return toolbar;
   }
+  
+  public String getEnterMode() {
+  	return enterMode;
+  }
 
   public void setToolbar(String toolbar) {
     this.toolbar = toolbar;
+  }
+  
+  public void setEnterMode(String enterMode) {
+  	this.enterMode = enterMode;
   }
 
   public void processRender(WebuiRequestContext context) throws Exception {
@@ -77,6 +97,7 @@ public class UIFormRichtextInput extends UIFormInputBase<String> {
     if (toolbar == null) toolbar = BASIC_TOOLBAR;
     if (width == null) width = "'100%'";
     if (height == null) height = "200";
+    if (enterMode == null) enterMode = "1";
     StringBuffer contentsCss = new StringBuffer();
     contentsCss.append("[");
     SkinService skinService = WCMCoreUtils.getService(SkinService.class);
@@ -107,7 +128,7 @@ public class UIFormRichtextInput extends UIFormInputBase<String> {
     buffer.append("  //<![CDATA[\n");
     buffer.append("    var instances = CKEDITOR.instances['" + name + "']; if (instances) instances.destroy(true);\n");
     buffer.append("    CKEDITOR.replace('" + name + "', {toolbar:'" + toolbar + "', height:"
-        + height + ", contentsCss:" + contentsCss + "});\n");
+        + height + ", contentsCss:" + contentsCss + ", enterMode:" + enterMode + ", shiftEnterMode:" + enterMode + "});\n");
     buffer.append("  //]]>\n");
     buffer.append("</script>\n");
     buffer.append("</span>");


### PR DESCRIPTION
- Fix description: Allow user to customize the enter mode of CKEditor in dialog template and constructor of UIFormRichtextInput
- Issue link: https://jira.exoplatform.org/browse/ECMS-3783
