### PR TITLE
ECMS-4209 Can not go to a node by Enter Node Path into Address Bar

### DIFF
--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/UIAddressBar.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/UIAddressBar.java
@@ -189,9 +189,8 @@ public class UIAddressBar extends UIForm {
   static public class ChangeNodeActionListener extends EventListener<UIAddressBar> {
     public void execute(Event<UIAddressBar> event) throws Exception {
       UIAddressBar uiAddress = event.getSource() ;
-      String path = null;
-      if(uiAddress.getUIInput(FIELD_ADDRESS_HIDDEN).getValue() != null)
-        path = uiAddress.getUIInput(FIELD_ADDRESS_HIDDEN).getValue().toString();
+      String path = Text.escapeIllegalJcrChars(uiAddress.getUIStringInput(FIELD_ADDRESS).getValue());
+      ((UIFormHiddenInput)uiAddress.getChildById(FIELD_ADDRESS_HIDDEN)).setValue(path);
       if (path == null || path.trim().length() == 0) path = "/";
       UIJCRExplorer uiExplorer = uiAddress.getAncestorOfType(UIJCRExplorer.class) ;
       uiExplorer.setIsViewTag(false) ;


### PR DESCRIPTION
Fix description: When clicking enter to change  node in address bar, get lastest input value and synchronize with hidden value
