### PR TITLE
ECMS-4185: Cannot clear the Description field of podcast in edit mode

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/InlineEditingService.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/InlineEditingService.java
@@ -211,7 +211,7 @@ public class InlineEditingService implements ResourceContainer{
         node = (Node)session.getItem(node.getPath());
         if(canSetProperty(node)) {
           if (!sameValue(newValue, node, propertyName)) {
-            if (newValue.length() > 0) {
+            if (newValue.length() >= 0) {
               newValue = Text.unescapeIllegalJcrChars(newValue.trim());
               PortalContainerInfo containerInfo =
                 (PortalContainerInfo)container.getComponentInstanceOfType(PortalContainerInfo.class);


### PR DESCRIPTION
Fix description: change the condition to accept empty value for property>
