### PR TITLE
ECMS-4316: Impossible to create nodetype with child node name *

### DIFF
--- a/core/webui-administration/src/main/java/org/exoplatform/ecm/webui/component/admin/nodetype/UIChildNodeDefinitionForm.java
+++ b/core/webui-administration/src/main/java/org/exoplatform/ecm/webui/component/admin/nodetype/UIChildNodeDefinitionForm.java
@@ -261,7 +261,7 @@ public class UIChildNodeDefinitionForm extends UIFormInputSetWithAction {
       for(int i = 0; i < nodeName.length(); i ++){
         char c = nodeName.charAt(i);
         if(Character.isLetter(c) || Character.isDigit(c) || Character.isSpaceChar(c) || c=='_'
-          || c=='-' || c=='.' || c==':' || c=='@' || c=='^' || c=='[' || c==']' || c==',') {
+          || c=='-' || c=='.' || c==':' || c=='@' || c=='^' || c=='[' || c==']' || c==',' || nodeName.equals("*")) {
           continue ;
         }
         uiApp.addMessage(new ApplicationMessage(
@@ -301,7 +301,7 @@ public class UIChildNodeDefinitionForm extends UIFormInputSetWithAction {
       for(int i = 0; i < childNodeName.length(); i ++){
         char c = childNodeName.charAt(i);
         if(Character.isLetter(c) || Character.isDigit(c) || Character.isSpaceChar(c) || c=='_'
-          || c=='-' || c=='.' || c==':' || c=='@' || c=='^' || c=='[' || c==']' || c==',') {
+          || c=='-' || c=='.' || c==':' || c=='@' || c=='^' || c=='[' || c==']' || c==',' || childNodeName.equals("*")) {
           continue ;
         }
         uiApp.addMessage(new ApplicationMessage("UIChildNodeDefinitionForm.msg.child-invalid",
@@ -381,7 +381,7 @@ public class UIChildNodeDefinitionForm extends UIFormInputSetWithAction {
       for(int i = 0; i < childNodeName.length(); i ++){
         char c = childNodeName.charAt(i);
         if(Character.isLetter(c) || Character.isDigit(c) || Character.isSpaceChar(c) || c=='_'
-          || c=='-' || c=='.' || c==':' || c=='@' || c=='^' || c=='[' || c==']' || c==',') {
+          || c=='-' || c=='.' || c==':' || c=='@' || c=='^' || c=='[' || c==']' || c==',' || childNodeName.equals("*")) {
           continue ;
         }
         uiApp.addMessage(new ApplicationMessage(


### PR DESCRIPTION
Fix description: add the charactor \* in the filter when adding childNode name
