### PR TITLE
ECMS-4306: Inability to remove unlinked links when in trash

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -348,9 +348,22 @@ public class Utils {
     return ret;
   }
 
+  /**
+   * Remove deleted Symlink from Trash
+   * @param node
+   * @throws Exception
+   */
+  private static void removeDeadSymlinksFromTrash(Node node) throws Exception {
+    LinkManager linkManager = WCMCoreUtils.getService(LinkManager.class);
+    List<Node> symlinks = linkManager.getAllLinks(node, EXO_SYMLINK);
+    for (Node symlink : symlinks) {
+      symlink.remove();
+    }
+  }
   
   public static void removeDeadSymlinks(Node node) throws Exception {
     if (isInTrash(node)) {
+      removeDeadSymlinksFromTrash(node);
       return; 
     }
     LinkManager linkManager = WCMCoreUtils.getService(LinkManager.class);

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/filter/CanRestoreNodeFilter.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/filter/CanRestoreNodeFilter.java
@@ -1,0 +1,60 @@
+/***************************************************************************
+ * Copyright (C) 2003-2012 eXo Platform SAS.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see<http://www.gnu.org/licenses/>.
+ *
+ **************************************************************************/
+package org.exoplatform.ecm.webui.component.explorer.control.filter;
+
+import java.util.Map;
+
+import javax.jcr.Node;
+
+import org.exoplatform.ecm.webui.utils.Utils;
+import org.exoplatform.webui.ext.filter.UIExtensionAbstractFilter;
+import org.exoplatform.webui.ext.filter.UIExtensionFilterType;
+
+/**
+ * Created by The eXo Platform SARL
+ * Author : Le Hung Cuong
+ *          cuonglh@exoplatform.com
+ * Dec 19, 2012
+ */
+public class CanRestoreNodeFilter  extends UIExtensionAbstractFilter {
+
+  public CanRestoreNodeFilter() {
+    this("UIActionBar.msg.node-checkedin");
+  }
+
+  public CanRestoreNodeFilter(String messageKey) {
+    super(messageKey, UIExtensionFilterType.MANDATORY);
+  }
+
+  public boolean accept(Map<String, Object> context) throws Exception {
+    if (context==null) return true;
+    
+    Node currentNode = (Node) context.get(Node.class.getName());
+    if(Utils.isInTrash(currentNode) && Utils.isSymLink(currentNode)){
+      //return false if the target is already deleted
+      Node targetNode = Utils.getNodeSymLink(currentNode);
+      if(Utils.isInTrash(targetNode)){
+        return false;
+      }
+    }
+    return true;
+  }
+
+  public void onDeny(Map<String, Object> context) throws Exception {
+  }
+}

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/RestoreFromTrashManageComponent.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/RestoreFromTrashManageComponent.java
@@ -34,6 +34,7 @@ import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.ecm.webui.component.explorer.UIJCRExplorer;
 import org.exoplatform.ecm.webui.component.explorer.UIWorkingArea;
+import org.exoplatform.ecm.webui.component.explorer.control.filter.CanRestoreNodeFilter;
 import org.exoplatform.ecm.webui.component.explorer.control.filter.HasRemovePermissionFilter;
 import org.exoplatform.ecm.webui.component.explorer.control.filter.IsCheckedOutFilter;
 import org.exoplatform.ecm.webui.component.explorer.control.filter.IsInTrashFilter;
@@ -44,6 +45,7 @@ import org.exoplatform.ecm.webui.component.explorer.popup.actions.UISelectRestor
 import org.exoplatform.ecm.webui.utils.JCRExceptionManager;
 import org.exoplatform.ecm.webui.utils.Utils;
 import org.exoplatform.services.cms.documents.TrashService;
+import org.exoplatform.services.cms.link.LinkManager;
 import org.exoplatform.services.cms.link.NodeFinder;
 import org.exoplatform.services.cms.taxonomy.TaxonomyService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
@@ -83,6 +85,7 @@ public class RestoreFromTrashManageComponent extends UIAbstractManagerComponent 
                                                    new IsNotLockedFilter(),
                                                    new IsCheckedOutFilter(),
                                                    new HasRemovePermissionFilter(),
+                                                   new CanRestoreNodeFilter(),
                                                    new IsNotTrashHomeNodeFilter() });
 
   private final static Log                     LOG     = ExoLogger.getLogger(RestoreFromTrashManageComponent.class.getName());
@@ -165,6 +168,11 @@ public class RestoreFromTrashManageComponent extends UIAbstractManagerComponent 
       SessionProvider sessionProvider = uiExplorer.getSessionProvider();
       try {
         trashService.restoreFromTrash(srcPath, sessionProvider);
+        LinkManager linkManager = WCMCoreUtils.getService(LinkManager.class);
+        List<Node> symlinks = linkManager.getAllLinks(node, org.exoplatform.services.cms.impl.Utils.EXO_SYMLINK);
+        for (Node symlink : symlinks) {
+          trashService.restoreFromTrash(symlink.getPath(), sessionProvider);
+        }
         uiExplorer.updateAjax(event);
       } catch(PathNotFoundException e) {
         UIPopupContainer uiPopupContainer = uiExplorer.getChild(UIPopupContainer.class);


### PR DESCRIPTION
Fix description:
- delete symlink from trash when delete source node
- filter not to show restore button for symlink at Trash folder
- when restore a source node, restore also symlink node
