### PR TITLE
ECMS-4451: Impossible to display RSS feed with article's summary having ...

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/RssConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/RssConnector.java
@@ -264,7 +264,7 @@ public class RssConnector extends BaseConnector implements ResourceContainer {
           String nTitle = node.getProperty(TITLE).getString();
           //encoding
           nTitle = new String(nTitle.getBytes("UTF-8"));
-          entry.setTitle(Text.encodeIllegalXMLCharacters(nTitle));
+          entry.setTitle(Text.encodeIllegalXMLCharacters(nTitle).replaceAll("&quot;", "\"").replaceAll("&apos;", "\'"));
         }
         else entry.setTitle("") ;
 
@@ -272,11 +272,12 @@ public class RssConnector extends BaseConnector implements ResourceContainer {
         SyndContent description = new SyndContentImpl();
         description.setType("text/plain");
 
-        if (node.hasProperty(SUMMARY))
-          description.setValue(Text.encodeIllegalXMLCharacters(node.getProperty(SUMMARY)
-                                                                   .getString())
-                                   .replaceAll("&nbsp;", " "));
-        else
+        if (node.hasProperty(SUMMARY)){
+          String summary=Text.encodeIllegalXMLCharacters(node.getProperty(SUMMARY)
+                                                         .getString())
+                         .replaceAll("&nbsp;", " ").replaceAll("&amp;quot;", "\"").replaceAll("&apos;", "\'");
+          description.setValue(summary);
+        }else
           description.setValue("");
 
         entry.setDescription(description);


### PR DESCRIPTION
...apostrophe and image

Fix description:
- unescape " and ' character in the RSS content because they are valid for the content.
