### PR TITLE
ECMS-4497: [Firefox] Only show the 1st word when download a file with na...

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/DownloadConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/DownloadConnector.java
@@ -86,7 +86,7 @@ public class DownloadConnector implements ResourceContainer{
       mimeType = node.getNode("jcr:content").getProperty("jcr:mimeType").getString();
     }
     return Response.ok(is, mimeType)
-          .header("Content-Disposition","attachment; filename=" + fileName)
+          .header("Content-Disposition","attachment; filename=\"" + fileName+"\"")
             .build();
   }
 }


### PR DESCRIPTION
...me containing space

Fix description:
- wrap the filename in double quote in download link
