### PR TITLE
ECMS-4502: Lose acme navigation when open a content

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/wcm/navigation/NavigationUtils.java
+++ b/core/services/src/main/java/org/exoplatform/services/wcm/navigation/NavigationUtils.java
@@ -53,7 +53,7 @@ import org.exoplatform.webui.application.WebuiRequestContext;
 public class NavigationUtils {
 
   public static final Scope ECMS_NAVIGATION_SCOPE = Scope.CHILDREN;
-  
+ 
   private static ThreadLocal<Map<String, String>> gotNavigationKeeper = 
     new ThreadLocal<Map<String, String>>();
   
@@ -88,6 +88,17 @@ public class NavigationUtils {
       return null;
     } else {
       return userNavigationCtor.newInstance(userPortal, portalNav, false);
+    }
+  }
+  
+  public static void removeNavigationAsJson (String portalName, String username) throws Exception
+  {
+    String key = portalName + " " + username;
+    Map<String, String> navigations = gotNavigationKeeper.get();
+    if (navigations != null)
+    {
+       navigations.remove(key);
+       gotNavigationKeeper.set(navigations);
     }
   }
   

--- a/packaging/wcm/webapp/src/main/webapp/groovy/portal/webui/workspace/UIWorkingWorkspace.gtmpl
+++ b/packaging/wcm/webapp/src/main/webapp/groovy/portal/webui/workspace/UIWorkingWorkspace.gtmpl
@@ -2,14 +2,18 @@
   import org.exoplatform.container.PortalContainer;
   import org.exoplatform.web.application.JavascriptManager;
   import org.exoplatform.portal.webui.util.Util;
+  import org.exoplatform.services.wcm.navigation.NavigationUtils;
   import javax.servlet.http.HttpSession;
 
   def rcontext = _ctx.getRequestContext() ;
   def userName = rcontext.getRemoteUser();
+  def portalName = Util.getPortalRequestContext().getPortalOwner();
   
   def selectedNodeUri = Util.getUIPortal().getSelectedUserNode().getURI();
   def session = _ctx.getRequestContext().getRequest().getSession();
   def previousURI = session.getAttribute("previousURI");
+  
+  NavigationUtils.removeNavigationAsJson(portalName, userName);
   
   session.setAttribute("previousURI", selectedNodeUri);
   if (userName==null && session.getMaxInactiveInterval()>60) {


### PR DESCRIPTION
Problem analysis
- On rendering new page, navigation JSON data is marked as initiated although it isn't initiated

Fix description
- On rendering new page, re-initiated navigation JSON data
