### PR TITLE
Fix/2.3.x/ecms 4506

### DIFF
--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/wcm/frontoffice/private/ContentSelector.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/wcm/frontoffice/private/ContentSelector.js
@@ -858,28 +858,32 @@ EcmContentSelector.prototype.insertContent = function(objNode) {
 				window.close();
 				editor.OnAfterSetHTML = window.close();				
 			}
-		} else {      						
-			var newImg = new Image();
-			newImg.src = url;
-      newImg.onload = function() {
-				var height = newImg.height;
-				var width = newImg.width;  
+		} else {
+      var newImg = new Image();
+      url = decodeURIComponent(url);
+      function loadInfoImage () {
+        var height = newImg.height;
+        var width = newImg.width;  
         var parent = window.opener.document;
         parent.getElementById(eXo.ecm.ECS.components).src=url;
-				parent.getElementById(eXo.ecm.ECS.components).style.display="block";
-				parent.getElementById(editor.name+"_txtWidth").value=width;	
-				parent.getElementById(editor.name+"_txtHeight").value=height;        
-        var elements = parent.getElementsByTagName('*');
-       	for(var i=0;i<elements.length;i++)	{        
-					if(elements[i].type && elements[i].type=="text") {          
-						if(elements[i].id && elements[i].id==editor.name+"_txtUrl") elements[i].value = url;
-					}
-				}       
-				window.close();
-				editor.OnAfterSetHTML = window.close();				
-			}
-		}		
-	}
+        parent.getElementById(eXo.ecm.ECS.components).style.display="block";
+        parent.getElementById(editor.name+"_txtWidth").value=width;	
+        parent.getElementById(editor.name+"_txtHeight").value=height;
+        var element = parent.getElementById(editor.name+"_txtUrl");
+        if(element.type && element.type=="text") {
+          element.value = url;
+        }
+        window.close();
+        editor.OnAfterSetHTML = window.close();	
+      }
+    }
+    newImg.onload = loadInfoImage;
+    newImg.src = url;
+    if (newImg.complete)
+    {
+      loadInfoImage();
+    }
+  }
 };
 
 EcmContentSelector.prototype.insertMultiContent = function(operation, currentpath) {


### PR DESCRIPTION
Problem analysis
    - The url isn't decoded so that the js error is raised by debugger in IE although this url can be processed by server
    - There are a loop of all elements to find the url field. It causes performance degradation in IE.
    - In case Image is cached, Content Selector cannot work

Fix description:
    - Decode url before processing
    - Avoid traversing all elements of dialog by finding exactly this element
    - Only changing parameter if image is loaded (from cache and/or loading process)
