### PR TITLE
ECMS-4718: Displaying problem with the CLV configuration

### DIFF
--- a/apps/portlet-presentation/src/main/webapp/groovy/ContentListViewer/UICLVConfig.gtmpl
+++ b/apps/portlet-presentation/src/main/webapp/groovy/ContentListViewer/UICLVConfig.gtmpl
@@ -73,6 +73,7 @@
               <td class="FieldLabel">&nbsp;</td>
               <td class="FieldComponent" colspan="4"><% uiform.renderField(uicomponent.ORDER_TYPE_FORM_RADIO_BOX_INPUT) %></td>
             </tr>
+           </table>
             <% 
               List<String> contents = uiform.getItems();
               if (contents != null && !contents.isEmpty()) {
@@ -120,7 +121,6 @@
                 <%
               }
             %>
-          </table>
         </fieldset>   
         <fieldset class="fieldsetPreferences">
           <legend class="StyleLegend"><%= _ctx.appRes("UICLVConfig.label.DisplaySettingBlock") %></legend>


### PR DESCRIPTION
Problem analysis
    - DOM is incorrect in ManualMode of CLV. After back event, the web browser cannot provide error-tolerant

Fix description
    - Fix DOM syntax
