### PR TITLE
ECMS-4724: MyDraftContent: unexpected behavior when clicking on a conten...

### DIFF
--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIJCRExplorerPortlet.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIJCRExplorerPortlet.java
@@ -326,7 +326,7 @@ public class UIJCRExplorerPortlet extends UIPortletApplication {
   private void showDocument(WebuiRequestContext context, HashMap<String, String> map) throws Exception {
     String repositoryName = String.valueOf(map.get("repository"));
     String driveName = String.valueOf(map.get("drive"));
-    String path = String.valueOf(map.get("path"));
+    String path = Text.unescapeIllegalJcrChars(String.valueOf(map.get("path")));
     if (path.indexOf("&") > 0) {
       path = path.substring(0, path.indexOf("&"));
     }


### PR DESCRIPTION
...t in this list.

Fix description:
- the space in the path was escaped as %20. We need to unescape the space in the path
