### PR TITLE
ECMS-4753: Changing the fromState of the ChangeStateCronJobImpl job does...

### DIFF
--- a/ext/authoring/services/src/main/java/org/exoplatform/services/wcm/extensions/scheduler/impl/ChangeStateCronJobImpl.java
+++ b/ext/authoring/services/src/main/java/org/exoplatform/services/wcm/extensions/scheduler/impl/ChangeStateCronJobImpl.java
@@ -80,9 +80,9 @@ public class ChangeStateCronJobImpl implements Job {
         sessionProvider = SessionProvider.createSystemProvider();
         
         String property = null;
-        if ("staged".equals(fromState) && "published".equals(toState)) {
+        if (!"published".equals(fromState) && "published".equals(toState)) {
           property = START_TIME_PROPERTY;
-        } else if ("published".equals(fromState) && "unpublished".equals(toState)) {
+        } else if (!"unpublished".equals(fromState) && "unpublished".equals(toState)) {
           property = END_TIME_PROPERTY;
         }
 


### PR DESCRIPTION
... not work

Problem analysis
    - CronTab jobs are only allowed to change from 2 specificed type: stages -> published, pubished -> unpublished

Fix description
    - Only verify toState to realise the type of each job.
