### PR TITLE
Fix/2.3.x/ecms 4758

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/portletcache/PortletCacheFilter.java
+++ b/core/services/src/main/java/org/exoplatform/services/portletcache/PortletCacheFilter.java
@@ -107,6 +107,7 @@ public class PortletCacheFilter implements PortletFilter, ActionFilter, RenderFi
       if(referer != null){
         query.put("REFERER", new String[] {referer} );
       }
+      query.put("PATH", new String[] {ctx.getRequestURI()} );
       //
       Locale locale = ctx.getLocale();
       //


### PR DESCRIPTION
Fix description: 
- Include the URI path in the cache key to separate between different cache item
