### PR TITLE
ECMS-4802 : Wrong PDF file name with "Save to pdf" button in SCV

### DIFF
--- a/core/viewer/src/main/java/org/exoplatform/ecm/webui/viewer/PDFViewer.java
+++ b/core/viewer/src/main/java/org/exoplatform/ecm/webui/viewer/PDFViewer.java
@@ -281,7 +281,7 @@ public class PDFViewer extends UIForm {
       String repository = (String) pdfViewer.getMethod(uiParent, "getRepository").invoke(uiParent, (Object[]) null);
       PDFViewerRESTService pdfViewerService = pdfViewer.getApplicationComponent(PDFViewerRESTService.class);
       File file = pdfViewerService.getPDFDocumentFile(node, repository);
-      String fileName = node.getName();
+      String fileName = node.getProperty("exo:name").getString();
       String mimeType = node.getNode("jcr:content").getProperty("jcr:mimeType").getString();
       String extension = DMSMimeTypeResolver.getInstance().getExtension(mimeType);
       fileName = fileName.replace(extension, "pdf");


### PR DESCRIPTION
ECMS-4802 : Wrong PDF file name with "Save to pdf" button in SCV
