### PR TITLE
ECMS-4294: [SECURITY-Access] All folders of collaboration workspace are ...

### DIFF
--- a/core/publication/src/main/java/org/exoplatform/services/wcm/publication/WCMComposerImpl.java
+++ b/core/publication/src/main/java/org/exoplatform/services/wcm/publication/WCMComposerImpl.java
@@ -392,10 +392,11 @@ public class WCMComposerImpl implements WCMComposer, Startable {
       if (primaryType == null) {
         primaryType = "nt:base";
         Node currentFolder = null;
+        Session systemSession = WCMCoreUtils.getSystemSessionProvider().getSession(workspace, manageableRepository);
         if ("/".equals(path)) {
-          currentFolder = session.getRootNode();
-        } else if (session.getRootNode().hasNode(path.substring(1))) {
-          currentFolder = session.getRootNode().getNode(path.substring(1));
+          currentFolder = systemSession.getRootNode();
+        } else if (systemSession.getRootNode().hasNode(path.substring(1))) {
+          currentFolder = systemSession.getRootNode().getNode(path.substring(1));
         } else {
           return null;
         }

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/cms-configuration.xml
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/cms-configuration.xml
@@ -155,7 +155,7 @@
 			                  </value>
 			                  <value>                            
 			                    <object type="org.exoplatform.services.jcr.ext.hierarchy.impl.HierarchyConfig$Permission">             
-			                      <field name="identity"><string>any</string></field>
+			                      <field name="identity"><string>*:/platform/users</string></field>
 			                      <field name="read"><string>true</string></field>                
 			                      <field name="addNode"><string>false</string></field>                
 			                      <field name="setProperty"><string>false</string></field>                
@@ -183,10 +183,10 @@
 			                  </value>
 			                  <value>                            
 			                    <object type="org.exoplatform.services.jcr.ext.hierarchy.impl.HierarchyConfig$Permission">             
-			                      <field name="identity"><string>any</string></field>
+			                      <field name="identity"><string>*:/platform/users</string></field>
 			                      <field name="read"><string>true</string></field>                
 			                      <field name="addNode"><string>false</string></field>                
-			                      <field name="setProperty"><string>true</string></field>                
+			                      <field name="setProperty"><string>false</string></field>                
 			                      <field name="remove"><string>false</string></field>                
 			                    </object>  
 			                  </value>
@@ -240,15 +240,6 @@
 			                      <field name="remove"><string>false</string></field>                
 			                    </object>  
 				                </value>				                
-			                  <value>                            
-			                    <object type="org.exoplatform.services.jcr.ext.hierarchy.impl.HierarchyConfig$Permission">             
-			                      <field name="identity"><string>any</string></field>
-			                      <field name="read"><string>true</string></field>                
-			                      <field name="addNode"><string>false</string></field>                
-			                      <field name="setProperty"><string>true</string></field>                
-			                      <field name="remove"><string>false</string></field>                
-			                    </object>  
-			                  </value>
 			                </collection>
 			              </field>   			               
 	              	</object>
@@ -282,15 +273,6 @@
 			                      <field name="remove"><string>false</string></field>                
 			                    </object>  
 				                </value>			                  
-			                  <value>                            
-			                    <object type="org.exoplatform.services.jcr.ext.hierarchy.impl.HierarchyConfig$Permission">             
-			                      <field name="identity"><string>any</string></field>
-			                      <field name="read"><string>true</string></field>                
-			                      <field name="addNode"><string>false</string></field>                
-			                      <field name="setProperty"><string>true</string></field>                
-			                      <field name="remove"><string>false</string></field>                
-			                    </object>  
-			                  </value>
 			                </collection>
 			              </field>   			               
 	              	</object>
@@ -324,15 +306,6 @@
 			                      <field name="remove"><string>false</string></field>                
 			                    </object>  
 				                </value>			                  
-			                  <value>                            
-			                    <object type="org.exoplatform.services.jcr.ext.hierarchy.impl.HierarchyConfig$Permission">             
-			                      <field name="identity"><string>any</string></field>
-			                      <field name="read"><string>true</string></field>                
-			                      <field name="addNode"><string>false</string></field>                
-			                      <field name="setProperty"><string>true</string></field>                
-			                      <field name="remove"><string>false</string></field>                
-			                    </object>  
-			                  </value>
 			                </collection>
 			              </field>   			               
 	              	</object>
@@ -366,15 +339,6 @@
 			                      <field name="remove"><string>false</string></field>                
 			                    </object>  
 				                </value>			                  
-			                  <value>                            
-			                    <object type="org.exoplatform.services.jcr.ext.hierarchy.impl.HierarchyConfig$Permission">             
-			                      <field name="identity"><string>any</string></field>
-			                      <field name="read"><string>true</string></field>                
-			                      <field name="addNode"><string>false</string></field>                
-			                      <field name="setProperty"><string>true</string></field>                
-			                      <field name="remove"><string>false</string></field>                
-			                    </object>  
-			                  </value>
 			                </collection>
 			              </field>   			               
 	              	</object>
@@ -430,15 +394,6 @@
 			                      <field name="remove"><string>true</string></field>                
 			                    </object>  
 			                  </value>
-			                  <value>                            
-			                    <object type="org.exoplatform.services.jcr.ext.hierarchy.impl.HierarchyConfig$Permission">             
-			                      <field name="identity"><string>any</string></field>
-			                      <field name="read"><string>true</string></field>                
-			                      <field name="addNode"><string>false</string></field>                
-			                      <field name="setProperty"><string>false</string></field>                
-			                      <field name="remove"><string>false</string></field>                
-			                    </object>  
-			                  </value>			                  
 			                </collection>
 			              </field>   			               
 	              	</object>
@@ -467,15 +422,6 @@
 			                      <field name="remove"><string>true</string></field>                
 			                    </object>  
 			                  </value>
-			                  <value>                            
-			                    <object type="org.exoplatform.services.jcr.ext.hierarchy.impl.HierarchyConfig$Permission">             
-			                      <field name="identity"><string>any</string></field>
-			                      <field name="read"><string>true</string></field>                
-			                      <field name="addNode"><string>false</string></field>                
-			                      <field name="setProperty"><string>false</string></field>                
-			                      <field name="remove"><string>false</string></field>                
-			                    </object>  
-			                  </value>			                  
 			                </collection>
 			              </field>   			               
 	              	</object>
@@ -504,15 +450,6 @@
 			                      <field name="remove"><string>true</string></field>                
 			                    </object>  
 			                  </value>
-			                  <value>                            
-			                    <object type="org.exoplatform.services.jcr.ext.hierarchy.impl.HierarchyConfig$Permission">             
-			                      <field name="identity"><string>any</string></field>
-			                      <field name="read"><string>true</string></field>                
-			                      <field name="addNode"><string>false</string></field>                
-			                      <field name="setProperty"><string>false</string></field>                
-			                      <field name="remove"><string>false</string></field>                
-			                    </object>  
-			                  </value>			                  
 			                </collection>
 			              </field>   			               
 	              	</object>
@@ -541,15 +478,6 @@
 			                      <field name="remove"><string>true</string></field>                
 			                    </object>  
 			                  </value>
-			                  <value>                            
-			                    <object type="org.exoplatform.services.jcr.ext.hierarchy.impl.HierarchyConfig$Permission">             
-			                      <field name="identity"><string>any</string></field>
-			                      <field name="read"><string>true</string></field>                
-			                      <field name="addNode"><string>false</string></field>                
-			                      <field name="setProperty"><string>false</string></field>                
-			                      <field name="remove"><string>false</string></field>                
-			                    </object>  
-			                  </value>			                  
 			                </collection>
 			              </field>   			               
 	              	</object>
@@ -577,16 +505,7 @@
                             <field name="setProperty"><string>true</string></field>                
                             <field name="remove"><string>true</string></field>                
                           </object>  
-                        </value>
-                        <value>                            
-                          <object type="org.exoplatform.services.jcr.ext.hierarchy.impl.HierarchyConfig$Permission">             
-                            <field name="identity"><string>any</string></field>
-                            <field name="read"><string>true</string></field>                
-                            <field name="addNode"><string>false</string></field>                
-                            <field name="setProperty"><string>false</string></field>                
-                            <field name="remove"><string>false</string></field>                
-                          </object>  
-                        </value>                        
+                        </value>     
                       </collection>
                     </field>                       
                   </object>
@@ -620,16 +539,7 @@
 			                      <field name="setProperty"><string>false</string></field>                
 			                      <field name="remove"><string>true</string></field>                
 			                    </object>  
-			                  </value>
-			                  <value>                            
-			                    <object type="org.exoplatform.services.jcr.ext.hierarchy.impl.HierarchyConfig$Permission">             
-			                      <field name="identity"><string>any</string></field>
-			                      <field name="read"><string>true</string></field>                
-			                      <field name="addNode"><string>false</string></field>                
-			                      <field name="setProperty"><string>false</string></field>                
-			                      <field name="remove"><string>false</string></field>                
-			                    </object>  
-			                  </value>			                  
+			                  </value>       
 			                </collection>
 			              </field>   			               
 	              	</object>
@@ -681,15 +591,6 @@
 			                      <field name="remove"><string>true</string></field>                
 			                    </object>  
 			                  </value>
-			                  <value>                            
-			                    <object type="org.exoplatform.services.jcr.ext.hierarchy.impl.HierarchyConfig$Permission">             
-			                      <field name="identity"><string>any</string></field>
-			                      <field name="read"><string>true</string></field>                
-			                      <field name="addNode"><string>false</string></field>                
-			                      <field name="setProperty"><string>false</string></field>                
-			                      <field name="remove"><string>false</string></field>                
-			                    </object>  
-			                  </value>			                  
 			                </collection>
 			              </field>   			               
 	              	</object>
@@ -745,16 +646,7 @@
 			                      <field name="setProperty"><string>true</string></field>                
 			                      <field name="remove"><string>true</string></field>                
 			                    </object>  
-			                  </value>
-			                  <value>                            
-			                    <object type="org.exoplatform.services.jcr.ext.hierarchy.impl.HierarchyConfig$Permission">             
-			                      <field name="identity"><string>any</string></field>
-			                      <field name="read"><string>true</string></field>                
-			                      <field name="addNode"><string>false</string></field>                
-			                      <field name="setProperty"><string>false</string></field>                
-			                      <field name="remove"><string>false</string></field>                
-			                    </object>  
-			                  </value>			                  
+			                  </value> 
 			                </collection>
 			              </field>   			               
 	              	</object>
@@ -813,15 +705,6 @@
                             <field name="remove"><string>true</string></field>                
                           </object>  
                         </value>
-                        <value>                            
-                          <object type="org.exoplatform.services.jcr.ext.hierarchy.impl.HierarchyConfig$Permission">             
-                            <field name="identity"><string>any</string></field>
-                            <field name="read"><string>true</string></field>                
-                            <field name="addNode"><string>false</string></field>                
-                            <field name="setProperty"><string>false</string></field>                
-                            <field name="remove"><string>false</string></field>                
-                          </object>  
-                        </value>                        
                       </collection>
                     </field>                       
                   </object>
@@ -851,16 +734,7 @@
                             <field name="setProperty"><string>true</string></field>                
                             <field name="remove"><string>true</string></field>                
                           </object>  
-                        </value>
-                        <value>                            
-                          <object type="org.exoplatform.services.jcr.ext.hierarchy.impl.HierarchyConfig$Permission">             
-                            <field name="identity"><string>any</string></field>
-                            <field name="read"><string>true</string></field>                
-                            <field name="addNode"><string>false</string></field>                
-                            <field name="setProperty"><string>false</string></field>                
-                            <field name="remove"><string>false</string></field>                
-                          </object>  
-                        </value>                        
+                        </value>      
                       </collection>
                     </field>                       
                   </object>

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/jcr/repository-configuration.xml
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/jcr/repository-configuration.xml
@@ -96,7 +96,7 @@
           <initializer class="org.exoplatform.services.jcr.impl.core.ScratchWorkspaceInitializer">
             <properties>
               <property name="root-nodetype" value="nt:unstructured"/>
-              <property name="root-permissions" value="any read;*:/platform/administrators read;*:/platform/administrators add_node;*:/platform/administrators set_property;*:/platform/administrators remove"/>
+              <property name="root-permissions" value="*:/platform/users read;*:/platform/administrators read;*:/platform/administrators add_node;*:/platform/administrators set_property;*:/platform/administrators remove"/>
             </properties>
           </initializer>
           <cache enabled="true" class="org.exoplatform.services.jcr.impl.dataflow.persistent.jbosscache.JBossCacheWorkspaceStorageCache">


### PR DESCRIPTION
...public by default

Problem analysis:
- collaboration workspace and subfolder are config to enable "any" permission

Fix description:
- enable "platform/users" to access collaboration and subfolder and disable "any" permmision
- with this config, non-login user cannot view CLV. Repair WCMComposerImpl for this problem
