### PR TITLE
ECMS-4963: Restoring a version of an interceptor doesn't take effect

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/scripts/ScriptService.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/scripts/ScriptService.java
@@ -323,4 +323,11 @@ public interface ScriptService {
    * @return
    */
   public Set<String> getAllConfiguredScripts();
+
+  /**
+  * remove Script From Cache
+  * @param scriptPath    String
+  *                      The Path of script
+  */
+  public void removeScriptFromCache(String scriptPath) throws Exception;
 }

--- a/core/services/src/main/java/org/exoplatform/services/cms/scripts/impl/ScriptServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/scripts/impl/ScriptServiceImpl.java
@@ -458,6 +458,15 @@ public class ScriptServiceImpl extends BaseResourceLoaderService implements Scri
   }
 
   /**
+  * remove Script From Cache
+  * @param scriptPath    String
+  *                      The Path of script
+  */
+  public void removeScriptFromCache(String scriptPath) throws Exception {
+    removeFromCache(scriptPath);
+  }
+
+  /**
    * remove From Cache
    * @param scriptName    String
    *                      The name of script

--- a/core/webui-administration/src/main/java/org/exoplatform/ecm/webui/component/admin/script/UIScriptForm.java
+++ b/core/webui-administration/src/main/java/org/exoplatform/ecm/webui/component/admin/script/UIScriptForm.java
@@ -286,7 +286,10 @@ public class UIScriptForm extends UIForm implements UIPopupComponent {
           node.checkout() ;
           node.restore(vesion, true) ;
           uiScriptList.refresh(1) ;
-        }  
+        }
+        ScriptService scriptService = uiForm.getApplicationComponent(ScriptService.class) ;
+        String scriptpath = node.getPath().substring(scriptService.getBaseScriptPath().length()+1,node.getPath().length());
+        scriptService.removeScriptFromCache(scriptpath);
         if(uiForm.getId().equals(UIECMScripts.SCRIPTFORM_NAME))
           uiManager.getChild(UIECMScripts.class).removeChildById(UIScriptList.ECMScript_EDIT);
         event.getRequestContext().addUIComponentToUpdateByAjax(uiManager) ;


### PR DESCRIPTION
Problem analysis:
- Adding a version call the addScript method in ScriptService which call in her side the removeFromCache method. While, restoring a version does not remove the actual version from cache.

Fix description:
- Add this method removeScriptFromCache to call the protected method removeFromCache.
- Call it when restoring a node
