### PR TITLE
ECMS-5288: Error in CLV link with document containing accent character

### DIFF
--- a/apps/portlet-presentation/src/main/java/org/exoplatform/wcm/webui/clv/UICLVPresentation.java
+++ b/apps/portlet-presentation/src/main/java/org/exoplatform/wcm/webui/clv/UICLVPresentation.java
@@ -440,7 +440,7 @@ public class UICLVPresentation extends UIContainer {
       sb.append(node.getPath());
     }
     String param = sb.toString();
-    param = Text.escape(param, '%', true, " ");
+    param = Text.escapeIllegalJcrChars(param);
     NodeURL nodeURL = Util.getPortalRequestContext().createURL(NodeURL.TYPE);
     NavigationResource resource = new NavigationResource(SiteType.PORTAL,
                                                          Util.getPortalRequestContext()


### PR DESCRIPTION
Fix description:
- Fix the URL path with accent content
