### PR TITLE
ECMS-5266: Error in CacheableLockManagerImpl properties' values

### DIFF
--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/jcr/repository-configuration.xml
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/jcr/repository-configuration.xml
@@ -208,7 +208,7 @@
               <property name="jgroups-multiplexer-stack" value="false" />
               <property name="jbosscache-cluster-name" value="jcrlock${container.name.suffix}" />
               <property name="jbosscache-shareable" value="true" />
-              <property name="jbosscache-cl-cache.jdbc.table.name" value="jcrlocks" />
+              <property name="jbosscache-cl-cache.jdbc.table.name" value="jcrlock" />
               <property name="jbosscache-cl-cache.jdbc.table.create" value="true" />
               <property name="jbosscache-cl-cache.jdbc.table.drop" value="false" />
               <property name="jbosscache-cl-cache.jdbc.table.primarykey" value="pk" />


### PR DESCRIPTION
LInk issue: https://github.com/exodev/ecms/pull/new/fix/4.0.x/ECMS-5266
Description: Change jbosscache-cl-cache.jdbc.table.name to jcrlock
