### PR TITLE
ECMS-5447 File Explorer crashes when I open a web-content in List View

### DIFF
--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIDocumentInfo.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIDocumentInfo.java
@@ -1030,7 +1030,7 @@ public class UIDocumentInfo extends UIBaseNodePresentation {
     return driveData;
   }
 
-  private List<Node> filterNodeList(List<Node> sourceNodeList) throws Exception {
+  public List<Node> filterNodeList(List<Node> sourceNodeList) throws Exception {
     List<Node> ret = new ArrayList<Node>();
 
     if (!this.hasFilters()) {


### PR DESCRIPTION
Problem analysis:
- For tag view, Current behavior of UIDocumentInfo.getPageList always returns tagged node(s).
  This causes recursion forever when clicking to expand a document
  Solution:
- Using new method getPageList specified for file view to get childlist of selected document
