### PR TITLE
ECMS-5410 Drag&Drop UI looks not beautiful

### DIFF
--- a/apps/portlet-explorer/src/main/webapp/javascript/eXo/ecm/UIListView.js
+++ b/apps/portlet-explorer/src/main/webapp/javascript/eXo/ecm/UIListView.js
@@ -15,6 +15,7 @@
     ListView.prototype.enableDragDrop = null;
 
     ListView.prototype.colorSelected = "#e8e8e8";
+    ListView.prototype.colorHover = "#eeeeee";
 
     ListView.prototype.t1 = 0;
     ListView.prototype.t2 = 0;
@@ -232,6 +233,7 @@
       var event = event || window.event;
       var element = this;
       if (!element.selected) {
+        element.style.background = Self.colorHover;
         element.temporary = true;
         //eXo.core.Browser.setOpacity(element, 100);
       }
@@ -241,10 +243,10 @@
       var event = event || window.event;
       var element = this;
       element.temporary = false;
-      //if (!element.selected) {
-      //  element.style.background = "none";
+      if (!element.selected) {
+        element.style.background = "none";
       //  eXo.core.Browser.setOpacity(element, 85);
-      //}
+      }
     };
 
     ListView.prototype.mouseDownItem = function(evt) {

--- a/apps/portlet-explorer/src/main/webapp/javascript/eXo/ecm/UISimpleView.js
+++ b/apps/portlet-explorer/src/main/webapp/javascript/eXo/ecm/UISimpleView.js
@@ -13,7 +13,7 @@
     SimpleView.prototype.enableDragDrop = null;
 
     SimpleView.prototype.colorSelected = "#e7f3ff";
-    SimpleView.prototype.colorHover = "#f2f8ff";
+    SimpleView.prototype.colorHover = "#eeeeee";
     SimpleView.prototype.selectedItemClass = "selectedBox";
 
     SimpleView.prototype.t1 = 0;
@@ -253,7 +253,7 @@
       var event = event || window.event;
       var element = this;
       if (!element.selected) {
-        //element.style.background = Self.colorHover;
+        element.style.background = Self.colorHover;
         element.temporary = true;
         //eXo.core.Browser.setOpacity(element, 100);
       }
@@ -263,10 +263,10 @@
       var event = event || window.event;
       var element = this;
       element.temporary = false;
-    //if (!element.selected) {
-      //element.style.background = "none";
+      if (!element.selected) {
+        element.style.background = "none";
       //eXo.core.Browser.setOpacity(element, 85);
-    //}
+      }
     };
 
     SimpleView.prototype.mouseDownItem = function(evt) {

--- a/apps/portlet-explorer/src/main/webapp/skin/less/UIFileView/Style.less
+++ b/apps/portlet-explorer/src/main/webapp/skin/less/UIFileView/Style.less
@@ -270,3 +270,7 @@
 		}
 	}
 }
+
+.MoveItem {
+	padding: 0px;
+}

--- a/apps/portlet-explorer/src/main/webapp/skin/less/ecms-explorer.less
+++ b/apps/portlet-explorer/src/main/webapp/skin/less/ecms-explorer.less
@@ -6,7 +6,7 @@
 @import "UIFileView/Style.less";
 
 .UIJCRExplorerPortlet {
-	padding: 25px !important;
+	padding: 25px;
 	background: none !important;
 	
 	.uiActionBarAlone {

--- a/apps/portlet-explorer/src/main/webapp/skin/webui/component/explorer/DefaultStylesheet.css
+++ b/apps/portlet-explorer/src/main/webapp/skin/webui/component/explorer/DefaultStylesheet.css
@@ -19,7 +19,6 @@
 .UIJCRExplorerPortlet {
 	overflow: hidden; /* orientation=rt */
 	background: white;
-  padding: 9px;
 }
 
 .UIJCRExplorerPortlet .NoShow {	


### PR DESCRIPTION
Problem analysis:
  In Content Explorer, while user drags and drops nodes, there are some bugs:
1. In Webview and Iconview, target node is not highlighted
2. In container of moved node, all icons are in vertical line
3. The container of moved node is too big.
   Solution:
   1 ->  Highlight the target node
   2 ->  Icons should be in horizontal line
   3 ->  Reduce the size of this container
