### PR TITLE
ECMS-5046: CLONE-Inability to remove unlinked links when in trash

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -362,6 +362,20 @@ public class Utils {
     }
     return ret;
   }
+  
+  /**
+   * Remove deleted Symlink from Trash
+   * @param node
+   * @throws Exception
+   */
+  private static void removeDeadSymlinksFromTrash(Node node) throws Exception {
+    LinkManager linkManager = WCMCoreUtils.getService(LinkManager.class);
+    List<Node> symlinks = linkManager.getAllLinks(node, EXO_SYMLINK);
+    for (Node symlink : symlinks) {
+      symlink.remove();
+    }
+  }
+  
   /**
    * 
    * @param     : node
@@ -373,6 +387,7 @@ public class Utils {
    */
   public static void removeDeadSymlinks(Node node, boolean keepInTrash) throws Exception {
     if (isInTrash(node)) {
+      removeDeadSymlinksFromTrash(node);
       return;
     }
     LinkManager linkManager = WCMCoreUtils.getService(LinkManager.class);

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/filter/IsAbleToRestoreFilter.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/filter/IsAbleToRestoreFilter.java
@@ -1,6 +1,7 @@
 package org.exoplatform.ecm.webui.component.explorer.control.filter;
 
 import org.exoplatform.ecm.webui.utils.PermissionUtil;
+import org.exoplatform.ecm.webui.utils.Utils;
 import org.exoplatform.services.cms.documents.TrashService;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
@@ -41,6 +42,13 @@ public class IsAbleToRestoreFilter extends UIExtensionAbstractFilter {
             //Is not a deleted node, may be groovy action, hidden node,...
             return false;
         }
+        if(Utils.isInTrash(currentNode) && Utils.isSymLink(currentNode)){
+            //return false if the target is already deleted
+            Node targetNode = Utils.getNodeSymLink(currentNode);
+            if(Utils.isInTrash(targetNode)){
+              return false;
+            }
+          }
         Session session = WCMCoreUtils.getUserSessionProvider().getSession(restoreWorkspace, WCMCoreUtils.getRepository());
         try {
             restoreLocationNode = (Node) session.getItem(restorePath);

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/RestoreFromTrashManageComponent.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/RestoreFromTrashManageComponent.java
@@ -24,6 +24,7 @@ import org.exoplatform.ecm.webui.component.explorer.popup.actions.UISelectRestor
 import org.exoplatform.ecm.webui.utils.JCRExceptionManager;
 import org.exoplatform.ecm.webui.utils.Utils;
 import org.exoplatform.services.cms.documents.TrashService;
+import org.exoplatform.services.cms.link.LinkManager;
 import org.exoplatform.services.cms.link.NodeFinder;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.core.ManageableRepository;
@@ -166,6 +167,11 @@ public class RestoreFromTrashManageComponent extends UIAbstractManagerComponent 
       Node trashHomeNode = (Node) trashSession.getItem(trashHomeNodePath);
       try {
         trashService.restoreFromTrash(srcPath, sessionProvider);
+        LinkManager linkManager = WCMCoreUtils.getService(LinkManager.class);
+        List<Node> symlinks = linkManager.getAllLinks(node, org.exoplatform.services.cms.impl.Utils.EXO_SYMLINK);
+        for (Node symlink : symlinks) {
+          trashService.restoreFromTrash(symlink.getPath(), sessionProvider);
+        }
         uiExplorer.updateAjax(event);
       } catch(PathNotFoundException e) {
         UIPopupContainer uiPopupContainer = uiExplorer.getChild(UIPopupContainer.class);


### PR DESCRIPTION
Fix description:
- delete symlink from trash when delete source node
- filter not to show restore button for symlink when target is deleted at Trash folder
- when restore a source node, restore also symlink node
