### PR TITLE
ECMS-5458: CLONE-impossible to create subcontent with same type as curre...

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/templates/impl/TemplateServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/templates/impl/TemplateServiceImpl.java
@@ -240,9 +240,7 @@ public class TemplateServiceImpl implements TemplateService, Startable {
     List<String> result = new ArrayList<String>();
     for (String contentType : testContentTypes) {
       if (isChildNodePrimaryTypeAllowed(node, contentType)) {
-        if (!folderType.equals(contentType)) // When content type is not parent
-                                             // node's content type
-          result.add(contentType);
+        result.add(contentType);
       }
     }
     return result;


### PR DESCRIPTION
...nt node

Fix description:
- remove wrong condition in ManageTemplate. A node can add subcontent with the same type.
