### PR TITLE
ECMS-5386: WEBDAV Remove symlink or favorited file also remove original ...

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/webdav/WebDavServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/webdav/WebDavServiceImpl.java
@@ -718,9 +718,7 @@ public class WebDavServiceImpl extends org.exoplatform.services.jcr.webdav.WebDa
   	Item item = null;
     try {
       repoName = repositoryService.getCurrentRepository().getConfiguration().getName();
-      repoPath = convertRepoPath(repoPath, true);
-      
-      
+      repoPath = convertRepoPath(repoPath, false);
       
       Session session = null;
       try {

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/FavouriteManageComponent.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/FavouriteManageComponent.java
@@ -44,6 +44,7 @@ import org.exoplatform.services.cms.documents.FavoriteService;
 import org.exoplatform.services.cms.link.LinkManager;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
+import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.web.application.ApplicationMessage;
 import org.exoplatform.webui.config.annotation.ComponentConfig;
@@ -135,7 +136,7 @@ public class FavouriteManageComponent extends UIAbstractManagerComponent {
         throw new VersionException("node is locked, can't add favourite to node:" + node.getPath());
       if (!PermissionUtil.canSetProperty(node))
         throw new AccessDeniedException("access denied, can't add favourite to node:" + node.getPath());
-      favoriteService.addFavorite(node, session.getUserID());
+      favoriteService.addFavorite(node, ConversationState.getCurrent().getIdentity().getUserId());
       uiExplorer.updateAjax(event);
     } catch (LockException e) {
       if (LOG.isErrorEnabled()) {

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/RemoveFavouriteManageComponent.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/RemoveFavouriteManageComponent.java
@@ -42,6 +42,7 @@ import org.exoplatform.services.cms.documents.FavoriteService;
 import org.exoplatform.services.cms.link.LinkManager;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
+import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.web.application.ApplicationMessage;
 import org.exoplatform.webui.config.annotation.ComponentConfig;
@@ -140,7 +141,7 @@ public class RemoveFavouriteManageComponent extends UIAbstractManagerComponent {
           throw new VersionException("node is locked, can't remove favourite of node :" + node.getPath());
         if (!PermissionUtil.canRemoveNode(node))
           throw new AccessDeniedException("access denied, can't remove favourite of node:" + node.getPath());
-        favoriteService.removeFavorite(node, session.getUserID());
+        favoriteService.removeFavorite(node, ConversationState.getCurrent().getIdentity().getUserId());
         uiExplorer.updateAjax(event);
       } catch (LockException e) {
         if (LOG.isErrorEnabled()) {


### PR DESCRIPTION
...file

Problem analysis:
- when deleting a farovite symlink by webdav, path of target node is returned. Therefore, target node is deleted also.

Solution:
- only return current path of favorite link. Therefore, only symlink is deleted
