### PR TITLE
ECMS-5489: [Cloud migration] SanitizationUpgradePlugin doesn't work in e...

### DIFF
--- a/upgrade-plugins/src/main/java/org/exoplatform/ecms/upgrade/sanitization/SanitizationUpgradePlugin.java
+++ b/upgrade-plugins/src/main/java/org/exoplatform/ecms/upgrade/sanitization/SanitizationUpgradePlugin.java
@@ -118,9 +118,8 @@ public class SanitizationUpgradePlugin extends UpgradeProductPlugin {
       if (LOG.isInfoEnabled()) {
         LOG.info("=====Start migrate data for all user views=====");
       }
-      String statement = "SELECT * FROM exo:view ORDER BY exo:name DESC";
-      QueryResult result = session.getWorkspace().getQueryManager().createQuery(statement, Query.SQL).execute();
-      NodeIterator nodeIter = result.getNodes();
+      Node views = (Node)session.getItem("/exo:ecm/views/userviews");
+      NodeIterator nodeIter = views.getNodes();
       while(nodeIter.hasNext()) {
         Node viewNode = nodeIter.nextNode();
         String template = viewNode.getProperty("exo:template").getString();
@@ -210,9 +209,8 @@ public class SanitizationUpgradePlugin extends UpgradeProductPlugin {
     try {
       Session session = WCMCoreUtils.getSystemSessionProvider().getSession(dmsConfiguration_.getConfig().getSystemWorkspace(),
                                                                                   repoService_.getCurrentRepository());
-      String statement = "SELECT * FROM exo:drive ORDER BY exo:name DESC";
-      QueryResult result = session.getWorkspace().getQueryManager().createQuery(statement, Query.SQL).execute();
-      NodeIterator nodeIter = result.getNodes();
+      Node drives = (Node)session.getItem("/exo:ecm/exo:drives");
+      NodeIterator nodeIter = drives.getNodes();
       while(nodeIter.hasNext()) {
         Node drive = nodeIter.nextNode();
         if (LOG.isInfoEnabled()) {


### PR DESCRIPTION
Problem to fix:
- Drives of tenants cannot be migrated.
- Views of tenants cannot be migrated.

How to solve it:
- Instead of using query to collect all drives/views in each tenants we go directly to the drives/views storage and get exact numbers of drives/views to do the migration.
