### PR TITLE
ECMS-4789: Incorrect UI of Properties Management

### DIFF
--- a/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/popup/info/UIPropertyTab.gtmpl
+++ b/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/popup/info/UIPropertyTab.gtmpl
@@ -10,7 +10,7 @@
 import org.exoplatform.wcm.webui.reader.ContentReader;
  
 %>
-<div class="uiPropertyTab">
+<div class="uiPropertyTab" id="$uicomponent.id">
 	<div class="resizable">
 		<table class="uiGrid table table-hover table-striped" >
 			<thead>

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/popup/admin/UIPropertyForm.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/popup/admin/UIPropertyForm.java
@@ -567,9 +567,7 @@ public class UIPropertyForm extends UIForm {
           }
         }
       }
-      UIPropertiesManager uiPropertiesManager = uiForm.getAncestorOfType(UIPropertiesManager.class);
-      uiPropertiesManager.setRenderedChild(UIPropertyForm.class);
-      event.getRequestContext().addUIComponentToUpdateByAjax(uiForm.getParent());
+      event.getRequestContext().addUIComponentToUpdateByAjax(uiForm);
     }
   }
 
@@ -709,11 +707,9 @@ public class UIPropertyForm extends UIForm {
   static public class ResetActionListener extends EventListener<UIPropertyForm> {
     public void execute(Event<UIPropertyForm> event) throws Exception {
       UIPropertyForm uiForm = event.getSource();
-      UIPropertiesManager uiPropertiesManager = uiForm.getAncestorOfType(UIPropertiesManager.class);
       uiForm.refresh();
       uiForm.isAddNew_ = true;
-      uiPropertiesManager.setRenderedChild(UIPropertyForm.class);
-      event.getRequestContext().addUIComponentToUpdateByAjax(uiForm.getParent());
+      event.getRequestContext().addUIComponentToUpdateByAjax(uiForm);
     }
   }
 
@@ -731,9 +727,7 @@ public class UIPropertyForm extends UIForm {
   static public class AddActionListener extends EventListener<UIPropertyForm> {
     public void execute(Event<UIPropertyForm> event) throws Exception {
       UIPropertyForm uiForm = event.getSource();
-      UIPropertiesManager uiPropertiesManager = uiForm.getAncestorOfType(UIPropertiesManager.class);
-      uiPropertiesManager.setRenderedChild(UIPropertyForm.class);
-      event.getRequestContext().addUIComponentToUpdateByAjax(uiForm.getParent());
+      event.getRequestContext().addUIComponentToUpdateByAjax(uiForm);
     }
   }
 
@@ -749,10 +743,7 @@ public class UIPropertyForm extends UIForm {
           uiInput.setName(FIELD_VALUE + String.valueOf(i));
         }
       }
-      UIPropertiesManager uiPropertiesManager = uiForm.getAncestorOfType(UIPropertiesManager.class);
-
-      uiPropertiesManager.setRenderedChild(UIPropertyForm.class);
-      event.getRequestContext().addUIComponentToUpdateByAjax(uiForm.getParent());
+      event.getRequestContext().addUIComponentToUpdateByAjax(uiForm);
     }
   }
 

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/popup/admin/UIPropertyTab.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/popup/admin/UIPropertyTab.java
@@ -219,7 +219,10 @@ public class UIPropertyTab extends UIContainer {
       try {
         if(currentNode.hasProperty(propertyName)) currentNode.getProperty(propertyName).remove();
         currentNode.save();
-        event.getRequestContext().addUIComponentToUpdateByAjax(uiPropertyTab.getParent());
+        
+        UIPropertiesManager uiManager = uiPropertyTab.getParent();
+        uiManager.setRenderedChild(UIPropertyTab.class);
+        event.getRequestContext().addUIComponentToUpdateByAjax(uiPropertyTab);
         return;
       } catch(AccessDeniedException ace) {
         uiApp.addMessage(new ApplicationMessage("UIActionBar.msg.access-denied", null,


### PR DESCRIPTION
- To fix error relating to Properties Management Pop-up height is changed after :
  open Properties Management Pop-up > Add New Property tab -> select value from select box > go back Properties tab or click Reset button. 
- To update logical UI Component in the popup, ex: if click Reset button, Ui Components are loaded just for current tab of the popup but not loaded for whole popup.
