### PR TITLE
ECMS-5514: Problem with content with accented character in the name

### DIFF
--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/UIActionBar.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/UIActionBar.java
@@ -155,9 +155,7 @@ public class UIActionBar extends UIForm {
   }
   public String getBackLink() {
     String newLink = getAncestorOfType(UIJCRExplorerPortlet.class).getBacktoValue();
-    if (newLink != null && newLink.length()>0)
-      backLink = URLDecoder.decode(newLink);
-    return backLink;
+    return newLink;
   }
   public String getTemplateName() { return templateName_;  }
 


### PR DESCRIPTION
Fix description:
- remove the section to decode URL because the URL does not need to decode
