### PR TITLE
ECMS-5524:  [CKEditor] Problem to access a content with a "%" in the tit...

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/fckeditor/DriverConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/fckeditor/DriverConnector.java
@@ -912,8 +912,8 @@ public class DriverConnector extends BaseConnector implements ResourceContainer 
                                       String childName,
                                       String nodeDriveName) throws Exception {
       Element folder = document.createElement("Folder");
-      folder.setAttribute("name", childName);
-      folder.setAttribute("title", Utils.getTitle(child));
+      folder.setAttribute("name", childName.replaceAll("%", "%25"));
+      folder.setAttribute("title", Utils.getTitle(child).replaceAll("%", "%25"));
       folder.setAttribute("url", FCKUtils.createWebdavURL(child));
       folder.setAttribute("folderType", folderType);
       folder.setAttribute("path", child.getPath());


### PR DESCRIPTION
...le, via the Image-FCKplugin

Problem analysis:
       - In ContentSelector.js, the name and title is decoded by using decodeURIComponent. This function return error if % character is not escaped

```
Fix description:
   - Escape % character to %25
```
