### PR TITLE
ECMS-5597 update symlink only when target is updated

### DIFF
--- a/apps/portlet-presentation/src/main/java/org/exoplatform/wcm/webui/clv/UICLVConfig.java
+++ b/apps/portlet-presentation/src/main/java/org/exoplatform/wcm/webui/clv/UICLVConfig.java
@@ -355,8 +355,9 @@ public class UICLVConfig extends UIFormTabPane  implements UISelectable {
     List<SelectItemOption<String>> orderByOptions = new ArrayList<SelectItemOption<String>>();
     orderByOptions.add(new SelectItemOption<String>(UICLVPortlet.ORDER_BY_TITLE, NodetypeConstant.EXO_TITLE));
     orderByOptions.add(new SelectItemOption<String>(UICLVPortlet.ORDER_BY_DATE_CREATED, NodetypeConstant.EXO_DATE_CREATED));
-    orderByOptions.add(new SelectItemOption<String>(UICLVPortlet.ORDER_BY_DATE_MODIFIED, NodetypeConstant.EXO_DATE_MODIFIED));
-    orderByOptions.add(new SelectItemOption<String>(UICLVPortlet.ORDER_BY_DATE_PUBLISHED, NodetypeConstant.PUBLICATION_LIVE_DATE));
+    orderByOptions.add(new SelectItemOption<String>(UICLVPortlet.ORDER_BY_DATE_MODIFIED, NodetypeConstant.EXO_LAST_MODIFIED_DATE));
+    orderByOptions.add(new SelectItemOption<String>(UICLVPortlet.ORDER_BY_DATE_PUBLISHED, 
+        NodetypeConstant.PUBLICATION_LIVE_DATE));
     orderByOptions.add(new SelectItemOption<String>(UICLVPortlet.ORDER_BY_DATE_START_EVENT, NodetypeConstant.EXO_START_EVENT));
     orderByOptions.add(new SelectItemOption<String>(UICLVPortlet.ORDER_BY_INDEX, NodetypeConstant.EXO_INDEX));
     UIFormSelectBox orderBySelectBox = new UIFormSelectBox(ORDER_BY_FORM_SELECT_BOX, ORDER_BY_FORM_SELECT_BOX, orderByOptions);

--- a/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_ar.xml
+++ b/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_ar.xml
@@ -30,6 +30,7 @@
         <exo:title>عنوان</exo:title>
         <exo:dateCreated>تاريخ الإنشاء</exo:dateCreated>
         <exo:dateModified>تاريخ التغيير</exo:dateModified>
+        <exo:lastModifiedDate>تاريخ التغيير</exo:lastModifiedDate>
         <publication:liveDate>تاريخ النشر</publication:liveDate>
         <exo:startEvent>تاريخ الحدث</exo:startEvent>
         <exo:index>الفهرس</exo:index>

--- a/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_de.xml
+++ b/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_de.xml
@@ -30,6 +30,7 @@
         <exo:title>Titel</exo:title>
         <exo:dateCreated>Erstellungsdatum</exo:dateCreated>
         <exo:dateModified>Bearbeitungsdatum</exo:dateModified>
+        <exo:lastModifiedDate>Bearbeitungsdatum</exo:lastModifiedDate>
         <publication:liveDate>Veröffentlichungsdatum</publication:liveDate>
         <exo:startEvent>Veranstaltungsdatum</exo:startEvent>
         <exo:index>Index</exo:index>

--- a/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_en.xml
+++ b/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_en.xml
@@ -30,6 +30,7 @@
         <exo:title>Title</exo:title>
         <exo:dateCreated>Created Date</exo:dateCreated>
         <exo:dateModified>Modified Date</exo:dateModified>
+        <exo:lastModifiedDate>Modified Date</exo:lastModifiedDate>
         <publication:liveDate>Published Date</publication:liveDate>
         <exo:startEvent>Event Date</exo:startEvent>
         <exo:index>Index</exo:index>

--- a/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_es_ES.xml
+++ b/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_es_ES.xml
@@ -30,6 +30,7 @@
         <exo:title>Título</exo:title>
         <exo:dateCreated>Created Date</exo:dateCreated>
         <exo:dateModified>Modified Date</exo:dateModified>
+        <exo:lastModifiedDate>Modified Date</exo:lastModifiedDate>
         <publication:liveDate>Fecha de Publicación</publication:liveDate>
         <exo:startEvent>Fecha del evento</exo:startEvent>
         <exo:index>Índice</exo:index>

--- a/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_fr.xml
+++ b/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_fr.xml
@@ -30,6 +30,7 @@
         <exo:title>Titre</exo:title>
         <exo:dateCreated>Date de création</exo:dateCreated>
         <exo:dateModified>Date de modification</exo:dateModified>
+        <exo:lastModifiedDate>Date de modification</exo:lastModifiedDate>
         <publication:liveDate>Date de publication</publication:liveDate>
         <exo:startEvent>Date d'événement</exo:startEvent>
         <exo:index>Index</exo:index>

--- a/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_it.xml
+++ b/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_it.xml
@@ -30,6 +30,7 @@
         <exo:title>Titolo</exo:title>
         <exo:dateCreated>Data di Creazione</exo:dateCreated>
         <exo:dateModified>Data di Modifica</exo:dateModified>
+        <exo:lastModifiedDate>Data di Modifica</exo:lastModifiedDate>
         <publication:liveDate>Published Date</publication:liveDate>
         <exo:startEvent>Data Evento</exo:startEvent>
         <exo:index>Indice</exo:index>

--- a/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_ja.xml
+++ b/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_ja.xml
@@ -30,6 +30,7 @@
         <exo:title>タイトル</exo:title>
         <exo:dateCreated>作成日</exo:dateCreated>
         <exo:dateModified>変更日</exo:dateModified>
+        <exo:lastModifiedDate>変更日</exo:lastModifiedDate>
         <publication:liveDate>公開日</publication:liveDate>
         <exo:startEvent>イベント日</exo:startEvent>
         <exo:index>目次</exo:index>

--- a/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_pt_BR.xml
+++ b/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_pt_BR.xml
@@ -30,6 +30,7 @@
         <exo:title>Title</exo:title>
         <exo:dateCreated>Created Date</exo:dateCreated>
         <exo:dateModified>Modified Date</exo:dateModified>
+        <exo:lastModifiedDate>Modified Date</exo:lastModifiedDate>
         <publication:liveDate>Published Date</publication:liveDate>
         <exo:startEvent>Event Date</exo:startEvent>
         <exo:index>Index</exo:index>

--- a/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_sv_SE.xml
+++ b/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_sv_SE.xml
@@ -30,6 +30,7 @@
         <exo:title>Titel</exo:title>
         <exo:dateCreated>Skapad</exo:dateCreated>
         <exo:dateModified>Ändrad</exo:dateModified>
+        <exo:lastModifiedDate>Ändrad</exo:lastModifiedDate>
         <publication:liveDate>Publicerad</publication:liveDate>
         <exo:startEvent>Händelsedatum</exo:startEvent>
         <exo:index>Index</exo:index>

--- a/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_vi.xml
+++ b/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_vi.xml
@@ -30,6 +30,7 @@
         <exo:title>Tiêu đề</exo:title>
         <exo:dateCreated>Ngày Tạo</exo:dateCreated>
         <exo:dateModified>Ngày Sửa</exo:dateModified>
+        <exo:lastModifiedDate>Ngày Sửa</exo:lastModifiedDate>
         <publication:liveDate>Ngày Đăng tải</publication:liveDate>
         <exo:startEvent>Ngày diễn ra Sự kiện</exo:startEvent>
         <exo:index>Chỉ số</exo:index>

--- a/core/services/src/main/java/org/exoplatform/services/cms/link/impl/LinkManagerImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/link/impl/LinkManagerImpl.java
@@ -395,21 +395,25 @@ public class LinkManagerImpl implements LinkManager {
         node.addMixin(NodetypeConstant.EXO_TARGET_DATA);
       }
       Node target = this.getTarget(node, true);
-      String[] propList = {NodetypeConstant.EXO_DATE_CREATED,
-                           NodetypeConstant.EXO_DATE_MODIFIED, NodetypeConstant.PUBLICATION_LIVE_DATE,
-                           NodetypeConstant.EXO_START_EVENT, NodetypeConstant.EXO_INDEX};
-      for (String p : propList) {
-        try {
-          if (target.hasProperty(p)) {
-            node.setProperty(p, target.getProperty(p).getValue());
-            node.save();
-          }
-        } catch (RepositoryException e) {
-          if (LOG.isErrorEnabled()) {
-            LOG.error("Can not update property: " + p + " for node: " + node.getPath(), e);
+      if (!node.hasProperty(NodetypeConstant.EXO_LAST_MODIFIED_DATE) || 
+          node.getProperty(NodetypeConstant.EXO_LAST_MODIFIED_DATE).getDate().compareTo( 
+          target.getProperty(NodetypeConstant.EXO_LAST_MODIFIED_DATE).getDate()) < 0) {
+        String[] propList = {NodetypeConstant.EXO_DATE_CREATED,
+            NodetypeConstant.EXO_LAST_MODIFIED_DATE, NodetypeConstant.PUBLICATION_LIVE_DATE,
+            NodetypeConstant.EXO_START_EVENT, NodetypeConstant.EXO_INDEX};
+        for (String p : propList) {
+          try {
+            if (target.hasProperty(p)) {
+              node.setProperty(p, target.getProperty(p).getValue());
+              node.save();
+            }
+          } catch (RepositoryException e) {
+            if (LOG.isErrorEnabled()) {
+              LOG.error("Can not update property: " + p + " for node: " + node.getPath(), e);
+            }
           }
         }
-      }
+    }
     }
   }
 

--- a/core/services/src/test/java/org/exoplatform/services/ecm/dms/link/TestLinkManager.java
+++ b/core/services/src/test/java/org/exoplatform/services/ecm/dms/link/TestLinkManager.java
@@ -366,12 +366,15 @@ public class TestLinkManager extends BaseWCMTestCase {
     Node nodeB1_1 = rootNode.getNode("TestTreeNode/B1/B1_1");
     Node symlinkNode = linkManager.createLink(nodeA1, nodeB1_1);
     assertNotNull(symlinkNode);
+    symlinkNode.addMixin("exo:modify");
+    symlinkNode.save();
     
     nodeB1_1.setProperty(NodetypeConstant.EXO_TITLE, "titleB1");
     nodeB1_1.setProperty(NodetypeConstant.EXO_DATE_CREATED, new GregorianCalendar());
     Calendar d = new GregorianCalendar();
     d.add(Calendar.DATE, 1);
     nodeB1_1.setProperty(NodetypeConstant.EXO_DATE_MODIFIED, d);
+    nodeB1_1.setProperty(NodetypeConstant.EXO_LAST_MODIFIED_DATE, d);
     d = new GregorianCalendar();
     d.add(Calendar.DATE, 2);
     nodeB1_1.setProperty(NodetypeConstant.PUBLICATION_LIVE_DATE, d);
@@ -382,8 +385,8 @@ public class TestLinkManager extends BaseWCMTestCase {
 
     assertEquals(symlinkNode.getProperty(NodetypeConstant.EXO_DATE_CREATED).getDate(), 
                  nodeB1_1.getProperty(NodetypeConstant.EXO_DATE_CREATED).getDate());
-    assertEquals(symlinkNode.getProperty(NodetypeConstant.EXO_DATE_MODIFIED).getDate(), 
-                 nodeB1_1.getProperty(NodetypeConstant.EXO_DATE_MODIFIED).getDate());
+    assertEquals(symlinkNode.getProperty(NodetypeConstant.EXO_LAST_MODIFIED_DATE).getDate(), 
+                 nodeB1_1.getProperty(NodetypeConstant.EXO_LAST_MODIFIED_DATE).getDate());
     assertEquals(symlinkNode.getProperty(NodetypeConstant.PUBLICATION_LIVE_DATE).getDate(), 
                  nodeB1_1.getProperty(NodetypeConstant.PUBLICATION_LIVE_DATE).getDate());
     assertEquals(symlinkNode.getProperty(NodetypeConstant.EXO_INDEX).getLong(), 


### PR DESCRIPTION
We check the last modified date of symlink and target, and update symlink only when target is updated after symlink. This helps us to avoid redundant setProperty/save operations which are quite expensive.
