### PR TITLE
Fix/4.0.x/ecms 5572

### DIFF
--- a/core/webui-administration/src/main/java/org/exoplatform/ecm/webui/component/admin/unlock/UILockHolderList.java
+++ b/core/webui-administration/src/main/java/org/exoplatform/ecm/webui/component/admin/unlock/UILockHolderList.java
@@ -16,12 +16,15 @@
  */
 package org.exoplatform.ecm.webui.component.admin.unlock;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
 import org.exoplatform.commons.utils.LazyPageList;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.commons.utils.ListAccessImpl;
 import org.exoplatform.ecm.webui.core.UIPagingGridDecorator;
+import org.exoplatform.ecm.webui.utils.LockUtil;
 import org.exoplatform.services.cms.lock.LockService;
 import org.exoplatform.web.application.ApplicationMessage;
 import org.exoplatform.webui.config.annotation.ComponentConfig;
@@ -80,16 +83,30 @@ public class UILockHolderList extends UIPagingGridDecorator {
     public void execute(Event<UILockHolderList> event) throws Exception {
       UILockHolderList uiLockHolderList = event.getSource();
       UILockHolderContainer uiLockHolderContainer = uiLockHolderList.getAncestorOfType(UILockHolderContainer.class);
-      String settingLock = event.getRequestContext().getRequestParameter(OBJECTID);
+      String removedLockSetting = event.getRequestContext().getRequestParameter(OBJECTID);
       LockService lockService = uiLockHolderContainer.getApplicationComponent(LockService.class);
-      if (!lockService.getPreSettingLockList().contains(settingLock)) {
-        lockService.removeGroupsOrUsersForLock(settingLock);
+      if (!lockService.getPreSettingLockList().contains(removedLockSetting)) {
+        lockService.removeGroupsOrUsersForLock(removedLockSetting);
+
+        // Update lock cache
+        List<String> ignoredList = new ArrayList<String>();
+        if (removedLockSetting.startsWith("*")) {
+          String groupOfRemovedLockSetting = StringUtils.substringAfter(removedLockSetting, ":");
+          List<String> allLockSettings = lockService.getAllGroupsOrUsersForLock();
+          for (String lockSetting : allLockSettings) {
+            if (groupOfRemovedLockSetting.equals(StringUtils.substringAfter(lockSetting, ":"))) {
+              ignoredList.add(lockSetting);
+            }
+          }
+        }
+        LockUtil.removeLockCache(removedLockSetting, ignoredList);
+
       } else {
-        Object[] args = {settingLock};
+        Object[] args = {removedLockSetting};
         UIApplication uiApp = uiLockHolderList.getAncestorOfType(UIApplication.class);
         uiApp.addMessage(new ApplicationMessage("UILockHolderList.msg.can-not-delete-lock-holder", args,
             ApplicationMessage.WARNING));
-        
+
         event.getRequestContext().addUIComponentToUpdateByAjax(uiLockHolderContainer.getParent());
       }
       UILockHolderList uiHolderList = uiLockHolderContainer.getChild(UILockHolderList.class);

--- a/core/webui/src/main/java/org/exoplatform/ecm/webui/utils/LockUtil.java
+++ b/core/webui/src/main/java/org/exoplatform/ecm/webui/utils/LockUtil.java
@@ -28,8 +28,6 @@ import javax.jcr.query.Query;
 import javax.jcr.query.QueryManager;
 import javax.jcr.query.QueryResult;
 
-import org.exoplatform.container.ExoContainer;
-import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.portal.webui.util.Util;
 import org.exoplatform.services.cms.lock.LockService;
 import org.exoplatform.services.jcr.core.ManageableRepository;
@@ -160,6 +158,35 @@ public class LockUtil {
               LockUtil.keepLock(itemNode.getLock(), lockTokenString, lockToken);
             }
           }
+        }
+      }
+    }
+  }
+
+  /**
+   * Remove a membership from lock cache.
+   * If membership type is *, remove all memberships of specified group except ignored list
+   *
+   * @param removedMembership
+   * @param ignoredMemberships
+   * @throws Exception
+   */
+  @SuppressWarnings("unchecked")
+  public static void removeLockCache(String removedMembership, List<String> ignoredMemberships) throws Exception {
+    OrganizationService organizationService = WCMCoreUtils.getService(OrganizationService.class);
+    List<MembershipType> availMembershipTypes =
+        (List<MembershipType>) organizationService.getMembershipTypeHandler().findMembershipTypes();
+    HashMap<String, Map<String, String>> lockHolding = WCMCoreUtils.getService(LockService.class).getLockHolding();
+
+    // Remove lock cache for specific membership
+    lockHolding.remove(removedMembership);
+
+    // If membership type is *, remove all types except ignored list
+    if (removedMembership.startsWith("*")) {
+      for (MembershipType membershipType : availMembershipTypes) {
+        String membership = removedMembership.replace("*", membershipType.getName());
+        if (!ignoredMemberships.contains(membership)) {
+          lockHolding.remove(membership);
         }
       }
     }


### PR DESCRIPTION
Problem analysis:
- when selecting new membership in Manage Lock screen, the lockcache is updated with lasest tokens of all locked nodes for new membership
- But when removing a membership, the lockcache is not updated to remove cache item(s) of removed membership

Solution:
- After removing a membership, the lockcache should be updated coresponding to lastest lock settings of Manage Lock screen
- when unlocking a node, if membership type of a lock setting is '*', all membership types of specific group have permission to unlock
