### PR TITLE
Fix/4.0.x/ecms 5682

### DIFF
--- a/core/publication/src/main/java/org/exoplatform/services/wcm/publication/PaginatedResultIterator.java
+++ b/core/publication/src/main/java/org/exoplatform/services/wcm/publication/PaginatedResultIterator.java
@@ -120,7 +120,15 @@ public class PaginatedResultIterator extends PageList {
       throw new ExoMessageException("PageList.page-out-of-range", args);
     }
     populateCurrentPage(page);
+    while (currentListPage_ != null && currentListPage_.size() == 0 && page > 1) {
+      page--;
+      result.setNumTotal(page * this.getPageSize());
+      populateCurrentPage(page);
+      availablePage_ = page;
+    }
+
     return currentListPage_;
+    
   }
 
   /**

--- a/core/publication/src/main/java/org/exoplatform/services/wcm/publication/Result.java
+++ b/core/publication/src/main/java/org/exoplatform/services/wcm/publication/Result.java
@@ -71,4 +71,9 @@ public class Result {
   public long getNumTotal() {
     return numTotal;
   }
+  
+  public void setNumTotal(long value) {
+    numTotal = value;
+  }
+
 }


### PR DESCRIPTION
```
Problem analysis:
  - the function nodeIterator.getSize() does not take the permission into account

Fix description:
  - navigate throw the iterator to get the real number of items
```
