### PR TITLE
ECMS-5749: The layout of Site Explorer will be broken when contains a crash file

### DIFF
--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/filter/IsNotMandatoryChildNode.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/filter/IsNotMandatoryChildNode.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2003-2013 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.ecm.webui.component.explorer.control.filter;
+
+import java.util.Map;
+
+import javax.jcr.Node;
+import javax.jcr.nodetype.NodeDefinition;
+
+import org.exoplatform.webui.ext.filter.UIExtensionAbstractFilter;
+import org.exoplatform.webui.ext.filter.UIExtensionFilterType;
+
+/**
+ * Created by The eXo Platform SAS
+ * Author : eXoPlatform
+ *          tanhq@exoplatform.com
+ * Oct 18, 2013  
+ */
+public class IsNotMandatoryChildNode extends UIExtensionAbstractFilter {
+ 
+  public IsNotMandatoryChildNode() {
+    this(null);
+  }
+  public IsNotMandatoryChildNode(String messageKey) {
+    super(messageKey, UIExtensionFilterType.MANDATORY);
+  }
+  
+  public boolean accept(Map<String, Object> context) throws Exception {
+    if (context == null) return true;
+    Node currentNode = (Node) context.get(Node.class.getName());
+    Node parentNode = currentNode.getParent();
+    String deletedNodeType = currentNode.getDefinition().getDeclaringNodeType().getName();
+    NodeDefinition[] nodeDefinitions = parentNode.getPrimaryNodeType().getDeclaredChildNodeDefinitions();
+    for (NodeDefinition nodeDefinition : nodeDefinitions) {
+      String childNodeType = nodeDefinition.getDeclaringNodeType().getName();
+      if(deletedNodeType.equals(childNodeType) && nodeDefinition.getName().equals(currentNode.getName()) && 
+        nodeDefinition.isMandatory()) {
+        return false;
+      }
+    }   
+    return true;
+  }
+
+  public void onDeny(Map<String, Object> context) throws Exception {}
+  
+}

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/DeleteManageComponent.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/DeleteManageComponent.java
@@ -26,6 +26,7 @@ import org.exoplatform.ecm.webui.component.explorer.UIWorkingArea;
 import org.exoplatform.ecm.webui.component.explorer.control.filter.CanDeleteNodeFilter;
 import org.exoplatform.ecm.webui.component.explorer.control.filter.IsNotEditingDocumentFilter;
 import org.exoplatform.ecm.webui.component.explorer.control.filter.IsNotLockedFilter;
+import org.exoplatform.ecm.webui.component.explorer.control.filter.IsNotMandatoryChildNode;
 import org.exoplatform.ecm.webui.component.explorer.control.filter.IsNotTrashHomeNodeFilter;
 import org.exoplatform.ecm.webui.component.explorer.control.listener.UIWorkingAreaActionListener;
 import org.exoplatform.ecm.webui.utils.JCRExceptionManager;
@@ -38,7 +39,6 @@ import org.exoplatform.services.cms.folksonomy.NewFolksonomyService;
 import org.exoplatform.services.cms.jcrext.activity.ActivityCommonService;
 import org.exoplatform.services.cms.link.LinkManager;
 import org.exoplatform.services.cms.link.LinkUtils;
-import org.exoplatform.services.cms.link.impl.LinkManagerImpl;
 import org.exoplatform.services.cms.relations.RelationsService;
 import org.exoplatform.services.cms.taxonomy.TaxonomyService;
 import org.exoplatform.services.cms.templates.TemplateService;
@@ -115,7 +115,8 @@ public class DeleteManageComponent extends UIAbstractManagerComponent {
       = Arrays.asList(new UIExtensionFilter[]{new IsNotLockedFilter(),
                                               new CanDeleteNodeFilter(),
                                               new IsNotTrashHomeNodeFilter(),
-                                              new IsNotEditingDocumentFilter()});
+                                              new IsNotEditingDocumentFilter(),
+                                              new IsNotMandatoryChildNode()});
 
   @UIExtensionFilters
   public List<UIExtensionFilter> getFilters() {


### PR DESCRIPTION
Link issue: https://jira.exoplatform.org/browse/ECMS-5749
Fix description: Not allow to display "Delete" button if current node is mandatory of parent node.
