### PR TITLE
ECMS-4003: Warning "You don't have permission to access any template" wh...

### DIFF
--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/popup/actions/UIDocumentFormController.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/popup/actions/UIDocumentFormController.java
@@ -117,8 +117,8 @@ public class UIDocumentFormController extends UIContainer implements UIPopupComp
           templates.put(label, contentType);
         }
       } catch (AccessControlException e) {
-        if (LOG.isWarnEnabled()) {
-          LOG.warn(e.getMessage());
+        if (LOG.isDebugEnabled()) {
+          LOG.warn(userName + " do not have sufficient permission to access " + contentType + " template.");
         }
       } catch (Exception e) {
         if (LOG.isWarnEnabled()) {


### PR DESCRIPTION
...en adding New Content by user not in /platform/administrators group

Problem analysis
    - Several templates are restricted to several groups. If user do not have sufficient permission to access them, the warning annoyes the console

Fix description
    - Only raise this type of log in debug mode
