### PR TITLE
ECMS-5788: A 2nd time staged document is displayed in CLV portlet

### DIFF
--- a/ext/authoring/services/src/main/java/org/exoplatform/services/wcm/extensions/scheduler/impl/ChangeStateCronJobImpl.java
+++ b/ext/authoring/services/src/main/java/org/exoplatform/services/wcm/extensions/scheduler/impl/ChangeStateCronJobImpl.java
@@ -197,6 +197,14 @@ public class ChangeStateCronJobImpl implements Job {
             if (LOG.isInfoEnabled()) LOG.info("'" + toState + "' " + node_.getPath());
             publicationPlugin.changeState(node_, toState, context_);
           }
+          if(START_TIME_PROPERTY.equals(property) && node_.hasProperty(START_TIME_PROPERTY)){
+            node_.getProperty(START_TIME_PROPERTY).remove();
+            node_.save();
+          }
+          if(END_TIME_PROPERTY.equals(property) && node_.hasProperty(END_TIME_PROPERTY)){
+            node_.getProperty(END_TIME_PROPERTY).remove();
+            node_.save();
+          }
         }
       }catch( Exception e ) {
         if (LOG.isErrorEnabled()) LOG.error("Exception while changing '" + toState + "' " + path + " (" + property + "="


### PR DESCRIPTION
Problem analysis:
- when we unpublish a document the property exo:titlePublished is still remain
- a document is visible when status is not unpublished and having exo:titlePublished

Fix description:
- remove the property exo:titlePublished when changing publication status to unpublished or obsolete
