### PR TITLE
ECMS-5271 Cannot Rename child node while parent node is being locked by not locker

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/RenameConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/RenameConnector.java
@@ -39,6 +39,7 @@ import javax.jcr.NodeIterator;
 import javax.jcr.Property;
 import javax.jcr.PropertyIterator;
 import javax.jcr.Session;
+import javax.jcr.lock.LockException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
@@ -222,12 +223,18 @@ public class RenameConnector implements ResourceContainer {
       }
 
       return Response.ok(uuid).build();
-    } catch (Exception e) {
-      if (LOG.isInfoEnabled()) {
-        LOG.info("Rename is not successful!");
+    } catch (LockException e) {
+      if (LOG.isWarnEnabled()) {
+        LOG.warn("The node or parent node is locked. Rename is not successful!");
       }
-      return Response.status(HTTPStatus.BAD_REQUEST).build();
+    } catch (Exception e) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Rename is not successful!", e);
+      } else if (LOG.isWarnEnabled()) {
+        LOG.warn("Rename is not successful!");
+      }
     }
+    return Response.status(HTTPStatus.BAD_REQUEST).build();
   }
 
   /**

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/filter/IsNotParentLockedWhenRenameFilter.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/filter/IsNotParentLockedWhenRenameFilter.java
@@ -1,0 +1,33 @@
+package org.exoplatform.ecm.webui.component.explorer.control.filter;
+
+import org.exoplatform.services.cms.lock.LockService;
+import org.exoplatform.services.wcm.utils.WCMCoreUtils;
+import org.exoplatform.webui.ext.filter.UIExtensionAbstractFilter;
+import org.exoplatform.webui.ext.filter.UIExtensionFilterType;
+
+import javax.jcr.Node;
+import java.util.Map;
+
+/**
+ * Filter a node can be renamed if its parent is locked.
+ * It means that only to accept a node of which parent is not locked or (is locked and able to get lock token)
+ */
+public class IsNotParentLockedWhenRenameFilter extends UIExtensionAbstractFilter {
+
+  @Override
+  public UIExtensionFilterType getType() {
+    return UIExtensionFilterType.MANDATORY;
+  }
+  
+  @Override
+  public boolean accept(Map<String, Object> context) throws Exception {
+    if (context == null) return true;
+    Node parentNode = ((Node) context.get(Node.class.getName())).getParent();
+    LockService lockService = WCMCoreUtils.getService(LockService.class);
+    return !(parentNode.isLocked() && lockService.getLockToken(parentNode) == null);
+  }
+
+  @Override
+  public void onDeny(Map<String, Object> context) throws Exception {
+  }
+}

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/RenameManageComponent.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/RenameManageComponent.java
@@ -25,6 +25,7 @@ import org.exoplatform.ecm.webui.component.explorer.control.filter.IsCheckedOutF
 import org.exoplatform.ecm.webui.component.explorer.control.filter.IsNotEditingDocumentFilter;
 import org.exoplatform.ecm.webui.component.explorer.control.filter.IsNotInTrashFilter;
 import org.exoplatform.ecm.webui.component.explorer.control.filter.IsNotLockedFilter;
+import org.exoplatform.ecm.webui.component.explorer.control.filter.IsNotParentLockedWhenRenameFilter;
 import org.exoplatform.ecm.webui.component.explorer.control.filter.IsNotTrashHomeNodeFilter;
 import org.exoplatform.webui.config.annotation.ComponentConfig;
 import org.exoplatform.webui.ext.filter.UIExtensionFilter;
@@ -43,7 +44,7 @@ public class RenameManageComponent extends UIAbstractManagerComponent {
 
  private static final List<UIExtensionFilter> FILTERS
          = Arrays.asList(new UIExtensionFilter[]{new IsNotInTrashFilter(),
-                                                 new IsNotInTrashFilter(),
+                                                 new IsNotParentLockedWhenRenameFilter(),
                                                  new CanSetPropertyFilter(),
                                                  new IsNotLockedFilter(),
                                                  new IsCheckedOutFilter(),


### PR DESCRIPTION
Fix description: 
If parent node is locked and user has no permission in Lock Management, he will not able to rename child node
Otherwise, the node can be renamed
