### PR TITLE
ECMS-5795: CLONE - A 2nd time staged document is displayed in CLV portle...

### DIFF
--- a/ext/authoring/services/src/main/java/org/exoplatform/services/wcm/extensions/publication/lifecycle/authoring/AuthoringPublicationPlugin.java
+++ b/ext/authoring/services/src/main/java/org/exoplatform/services/wcm/extensions/publication/lifecycle/authoring/AuthoringPublicationPlugin.java
@@ -192,7 +192,18 @@ public class AuthoringPublicationPlugin extends  WebpagePublicationPlugin {
                                   userId,
                                   new GregorianCalendar(),
                                   AuthoringPublicationConstant.CHANGE_TO_UNPUBLISHED);
-      VersionData versionData = revisionsMap.get(selectedRevision.getUUID());
+      
+      
+      VersionData selectedVersionData = revisionsMap.get(selectedRevision.getUUID());
+      if (selectedVersionData != null) {
+        selectedVersionData.setAuthor(userId);
+        selectedVersionData.setState(PublicationDefaultStates.UNPUBLISHED);
+      } else {
+        selectedVersionData = new VersionData(selectedRevision.getUUID(),
+                                      PublicationDefaultStates.UNPUBLISHED,
+                                      userId);
+      }
+      VersionData versionData = revisionsMap.get(node.getUUID());
       if (versionData != null) {
         versionData.setAuthor(userId);
         versionData.setState(PublicationDefaultStates.UNPUBLISHED);
@@ -201,11 +212,23 @@ public class AuthoringPublicationPlugin extends  WebpagePublicationPlugin {
                                       PublicationDefaultStates.UNPUBLISHED,
                                       userId);
       }
-      revisionsMap.put(selectedRevision.getUUID(), versionData);
+      revisionsMap.put(node.getUUID(), versionData);
+      revisionsMap.put(selectedRevision.getUUID(), selectedVersionData);
+      
       addLog(node, versionLog);
       // change base version to unpublished state
       node.setProperty(AuthoringPublicationConstant.CURRENT_STATE,
                        PublicationDefaultStates.UNPUBLISHED);
+      Value value = valueFactory.createValue(selectedRevision);
+      Value liveRevision = null;
+      if (node.hasProperty(AuthoringPublicationConstant.LIVE_REVISION_PROP)) {
+        liveRevision = node.getProperty(AuthoringPublicationConstant.LIVE_REVISION_PROP)
+                               .getValue();
+      }
+      if (liveRevision != null && value.getString().equals(liveRevision.getString())) {
+        node.setProperty(AuthoringPublicationConstant.LIVE_REVISION_PROP,
+                         valueFactory.createValue(""));
+      }
       addRevisionData(node, revisionsMap.values());
     } else if (PublicationDefaultStates.OBSOLETE.equals(newState)) {
       node.setProperty(AuthoringPublicationConstant.CURRENT_STATE, newState);

--- a/ext/authoring/services/src/main/java/org/exoplatform/services/wcm/extensions/scheduler/impl/ChangeStateCronJobImpl.java
+++ b/ext/authoring/services/src/main/java/org/exoplatform/services/wcm/extensions/scheduler/impl/ChangeStateCronJobImpl.java
@@ -192,6 +192,14 @@ public class ChangeStateCronJobImpl implements Job {
           if (LOG.isInfoEnabled()) LOG.info("'" + toState + "' " + node_.getPath());
           publicationPlugin.changeState(node_, toState, context_);
         }
+        if(START_TIME_PROPERTY.equals(property) && node_.hasProperty(START_TIME_PROPERTY)){
+          node_.getProperty(START_TIME_PROPERTY).remove();
+          node_.save();
+        }
+        if(END_TIME_PROPERTY.equals(property) && node_.hasProperty(END_TIME_PROPERTY)){
+          node_.getProperty(END_TIME_PROPERTY).remove();
+          node_.save();
+        }
       }
     }
     


### PR DESCRIPTION
...t

Problem analysis:
- when we unpublish a document the property exo:liveRevision is still remain

Fix description:
- set the property exo:liveRevision to empty when changing publication status to unpublished
