### PR TITLE
ECMS-5815: Show Draft [current revision] after publish a document

### DIFF
--- a/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/popup/action/UIPublicationPanel.gtmpl
+++ b/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/popup/action/UIPublicationPanel.gtmpl
@@ -107,6 +107,9 @@
 	<tbody>
     <%
       List<Node> revisions = uicomponent.getRevisions();
+      if (isCurrentRevision("published", currentRevision)) {
+    	  revisions.remove(0);
+      }
       if (revisions.isEmpty()) {
         %>
           <tr>


### PR DESCRIPTION
Fix description:
- when a node is published, the current state is stage, so we need to remove the first state
