### PR TITLE
ECMS-5570 - [CLV] Weird help tooltips of setting options

### DIFF
--- a/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_en.xml
+++ b/apps/portlet-presentation/src/main/resources/locale/portlet/ContentListViewer/ContentListViewer_en.xml
@@ -77,7 +77,7 @@
       <ParameterHelp>This parameter will be used to access the content if Dynamic Navigation is activated.</ParameterHelp>
       <ShowDetailInPageHelp>Clicking on content redirects the user to a Detail page. You must have a "Content by URL" portlet with Dynamic Navigation enabled on the target page to show the content.</ShowDetailInPageHelp>
       <DetailParameterHelp>This parameter will contain the path to the content in the link to the Detail page. This parameter must match the parameter used in the "Content by URL" portlet of the page.</DetailParameterHelp>
-      <ContentByQueryHelp><![CDATA[You can set a SQL Query to get content dynamically. The following parameters are allowed : ${user}, ${lang} or any get parameter (PARAM) surrounded by ${PARAM}.]]></ContentByQueryHelp>
+      <ContentByQueryHelp>You can set a SQL Query to get content dynamically. The following parameters are allowed : ${user}, ${lang} or any get parameter (PARAM) surrounded by ${PARAM}.</ContentByQueryHelp>
       <ContentsVisibilityHelp>"Restricted by Authentication" will filter the content based on the authentication. If you do not sign in, you see public content only. If you are logged in, you see all the content visible by intranet users (but shared by all). "Restricted by User Roles" means you will see content depending on your rights. In most cases, this option should not be used, as it reduces the overall performance.</ContentsVisibilityHelp>
     </help>
     <action>

--- a/apps/portlet-presentation/src/main/webapp/groovy/ContentListViewer/UICLVConfig.gtmpl
+++ b/apps/portlet-presentation/src/main/webapp/groovy/ContentListViewer/UICLVConfig.gtmpl
@@ -5,6 +5,7 @@
 	import org.exoplatform.ecm.utils.text.Text;
 	import org.apache.commons.lang.StringEscapeUtils;
 	import org.exoplatform.wcm.webui.reader.ContentReader;
+	import org.apache.commons.lang.StringEscapeUtils;
 	
 	
 	def rcontext = _ctx.getRequestContext();
@@ -57,7 +58,7 @@
 												<div class="form-horizontal" >  
 													<div class="control-group">  
 													  <label class="control-label"><%=uicomponent.getLabel(uicomponent.DISPLAY_MODE_FORM_RADIO_BOX_INPUT) %>: </label>
-													  <a class="actionIcon pull-right" title="<%= _ctx.appRes("UICLVConfig.help.ModeSelectionHelp") %>" data-placement="left" rel="tooltip"><i class="uiIconQuestion uiIconLightGray" id="" ></i></a>
+													  <a class="actionIcon pull-right" title="<%= StringEscapeUtils.escapeHtml(_ctx.appRes("UICLVConfig.help.ModeSelectionHelp")) %>" data-placement="left" rel="tooltip"><i class="uiIconQuestion uiIconLightGray" id="" ></i></a>
 													  <div class="controls">
 														<% uiform.renderField(uicomponent.DISPLAY_MODE_FORM_RADIO_BOX_INPUT) %>
 													  </div>
@@ -66,7 +67,7 @@
 													  <label class="control-label" for="<%=uicomponent.ITEM_PATH_FORM_INPUT_SET%>">											  
 													    <%=uicomponent.getLabel(uicomponent.ITEM_PATH_FORM_INPUT_SET) %>: 
 													  </label>
-													  <a class="actionIcon pull-right"  title="<%= _ctx.appRes("UICLVConfig.help.FolderPathHelp") %>" data-placement="left" rel="tooltip"><i class="uiIconQuestion uiIconLightGray" id=""></i></a>
+													  <a class="actionIcon pull-right"  title="<%= StringEscapeUtils.escapeHtml(_ctx.appRes("UICLVConfig.help.FolderPathHelp")) %>" data-placement="left" rel="tooltip"><i class="uiIconQuestion uiIconLightGray" id=""></i></a>
 													  <div class="controls" <% if (uicomponent.getSavedPath() != null) { %>title="<%=uicomponent.getSavedPath()%>" <% }%> >
 													    <% uiform.renderField(uicomponent.ITEM_PATH_FORM_INPUT_SET) %>
 													  </div>
@@ -126,7 +127,7 @@
 											  <div class="form-horizontal" >  
 													<div class="control-group">  
 													  <label class="control-label" for="<%=uicomponent.HEADER_FORM_STRING_INPUT%>"><%=uicomponent.getLabel(uicomponent.HEADER_FORM_STRING_INPUT) %>: </label>
-													  <a class="actionIcon pull-right" title="<%= _ctx.appRes("UICLVConfig.help.HeaderOptionHelp") %>" data-placement="left" rel="tooltip"><i class="uiIconQuestion uiIconLightGray" id="" ></i></a>
+													  <a class="actionIcon pull-right" title="<%= StringEscapeUtils.escapeHtml(_ctx.appRes("UICLVConfig.help.HeaderOptionHelp")) %>" data-placement="left" rel="tooltip"><i class="uiIconQuestion uiIconLightGray" id="" ></i></a>
 													  <div class="controls clearfix">
 														<div class="pull-left"> <% uiform.renderField(uicomponent.HEADER_FORM_STRING_INPUT) %></div>
 														<label class="checkbox pull-left">
@@ -208,8 +209,15 @@
 											  <%
 											  } else if(formInput.getName().equals(uicomponent.ADVANCED_TAB)) {
 											  %>
+    <%
+      def contextualHelp = StringEscapeUtils.escapeHtml(_ctx.appRes("UICLVConfig.help.ContextualHelp"));
+      def parameterHelp = StringEscapeUtils.escapeHtml(_ctx.appRes("UICLVConfig.help.ParameterHelp"));
+      def contentByQueryHelp = StringEscapeUtils.escapeHtml(_ctx.appRes("UICLVConfig.help.ContentByQueryHelp"));
+      def showDetailInPageHelp = StringEscapeUtils.escapeHtml(_ctx.appRes("UICLVConfig.help.ShowDetailInPageHelp")); 
+    %>
+  
 												<div class="form-horizontal" >  
-													<h6 class="clearfix"> <a class="actionIcon pull-right" title="<%= _ctx.appRes("UICLVConfig.help.ContextualHelp") %> <%= _ctx.appRes("UICLVConfig.help.ParameterHelp") %> <%= _ctx.appRes("UICLVConfig.help.ContentByQueryHelp") %> <%= _ctx.appRes("UICLVConfig.help.ShowDetailInPageHelp") %>" data-placement="left" rel="tooltip"><i class="uiIconQuestion uiIconLightGray" id="" ></i></a><%=uicomponent.getLabel(uicomponent.DYNAMIC_NAVIGATION_LABEL) %></h6>
+													<h6 class="clearfix"> <a class="actionIcon pull-right" title="$contextualHelp $parameterHelp $contentByQueryHelp $showDetailInPageHelp" data-placement="left" rel="tooltip"><i class="uiIconQuestion uiIconLightGray" id="" ></i></a><%=uicomponent.getLabel(uicomponent.DYNAMIC_NAVIGATION_LABEL) %></h6>
 													<div class="control-group">  
 													  <label class="control-label"><%=uicomponent.getLabel(uicomponent.CONTEXTUAL_FOLDER_RADIOBOX_INPUT) %>: </label>
 													  <div class="controls">
@@ -253,7 +261,7 @@
 														<% uiform.renderField(uicomponent.SHOW_SCV_WITH_STRING_INPUT) %>
 													  </div>
 													</div>
-													<h6 class="clearfix"> <a class="actionIcon pull-right" title="<%= _ctx.appRes("UICLVConfig.help.ContentsVisibilityHelp") %>" data-placement="left" rel="tooltip"><i class="uiIconQuestion uiIconLightGray" id="" ></i></a><%=uicomponent.getLabel(uicomponent.CACHE_MANAGEMENT_LABEL)%></h6>
+													<h6 class="clearfix"> <a class="actionIcon pull-right" title="<%= StringEscapeUtils.escapeHtml(_ctx.appRes("UICLVConfig.help.ContentsVisibilityHelp")) %>" data-placement="left" rel="tooltip"><i class="uiIconQuestion uiIconLightGray" id="" ></i></a><%=uicomponent.getLabel(uicomponent.CACHE_MANAGEMENT_LABEL)%></h6>
 													<div class="control-group">                  
 													  <% uiform.renderField(uicomponent.CACHE_ENABLE_RADIOBOX_INPUT) %>
 													</div>


### PR DESCRIPTION
Problem analysis
- These tooltips have double quotes which are considered as ending marks in HTML title attribute.

Fix description:
- Escape the double quotes before assigning to HTML title attribute
