### PR TITLE
ECMS-5902 "Show Drives" button and some menu did not work after selecting the folders

### DIFF
--- a/packaging/wcm/webapp/src/main/webapp/javascript/eXo/ecm/ZeroClipboard.js
+++ b/packaging/wcm/webapp/src/main/webapp/javascript/eXo/ecm/ZeroClipboard.js
@@ -240,8 +240,12 @@
                     break;
             
                 case 'mouseover':
-                  var item = document.getElementById(this.domElement.id);
-                  item.className = 'menuItemSelected';
+                  if(gj("#ECMContextMenu .uiIconEcmsCopyUrlToClipboard").is(":visible")) {
+                    var item = document.getElementById(this.domElement.id);
+                    item.className = 'menuItemSelected';
+                  } else {
+                    this.destroy();
+                  }
                   break;
             
                 case 'mouseout':


### PR DESCRIPTION
Problem analysys: ZeroClipboard flash is not destroyed when item [Copy URL To ClipBoard] disappears
Fix solution: Destroy ZeroClipboard flash when item [Copy URL To ClipBoard] disappears
