### PR TITLE
ECMS-6004: Lack of expand icon with taxonomies nodes

### DIFF
--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/sidebar/UITreeExplorer.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/sidebar/UITreeExplorer.java
@@ -536,7 +536,7 @@ public class UITreeExplorer extends UIContainer {
     if(!node.hasNodes()) return false;
     UIJCRExplorer uiExplorer =  getAncestorOfType(UIJCRExplorer.class);
     Preference preferences = uiExplorer.getPreference();
-    if(!isFolderType(node) && !preferences.isJcrEnable())
+    if(!isFolderType(node) && !preferences.isJcrEnable() && !node.isNodeType(org.exoplatform.ecm.webui.utils.Utils.EXO_TAXONOMY))
       return false;
     NodeIterator iterator = node.getNodes();
     while(iterator.hasNext()) {


### PR DESCRIPTION
Fix Description:
- Taxonomy nodes are excepted as isFolderType and isJcrEnable, to have expand and collapse icons.
