### PR TITLE
ECMS-6000: CLONE - Pagination does not work with permissions

### DIFF
--- a/core/publication/src/main/java/org/exoplatform/services/wcm/publication/PaginatedResultIterator.java
+++ b/core/publication/src/main/java/org/exoplatform/services/wcm/publication/PaginatedResultIterator.java
@@ -120,7 +120,15 @@ public class PaginatedResultIterator extends PageList {
       throw new ExoMessageException("PageList.page-out-of-range", args);
     }
     populateCurrentPage(page);
+    while (currentListPage_ != null && currentListPage_.size() == 0 && page > 1) {
+      page--;
+      result.setNumTotal(page * this.getPageSize());
+      populateCurrentPage(page);
+      availablePage_ = page;
+    }
+
     return currentListPage_;
+    
   }
 
   /**

--- a/core/publication/src/main/java/org/exoplatform/services/wcm/publication/Result.java
+++ b/core/publication/src/main/java/org/exoplatform/services/wcm/publication/Result.java
@@ -71,4 +71,9 @@ public class Result {
   public long getNumTotal() {
     return numTotal;
   }
+  
+  public void setNumTotal(long value) {
+    numTotal = value;
+  }
+
 }


### PR DESCRIPTION
Fix description:
- when the clicked page is empty, return to the previous pages util meet an unempty page
