### PR TITLE
ECMS-6009 [IE8] "The target block ID to update is not found:UISideBar" when opening Admin VIew

### DIFF
--- a/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/UIDocumentNodeList.gtmpl
+++ b/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/UIDocumentNodeList.gtmpl
@@ -237,8 +237,8 @@ public void writeNodes(level, i, data, uiWorkingArea, linkManager, restContextNa
 			<span class="uiCheckbox"><input type="checkbox" name="checkbox" class="checkbox"><span></span></span>
 		</div>
     <div class="columnText" data-placement="bottom" rel="tooltip" title="$lockedLabel">
-			<a href="javascript void(0)" onmousedown="$actionLink" onmouseup="eXo.ecm.UIFileView.cancelEvent(event);">
-					<span class="nodeName"><%=fileName%><span>
+			<a href="javascript:void(0);" onmousedown="$actionLink" onmouseup="eXo.ecm.UIFileView.cancelEvent(event);">
+					<span class="nodeName"><%=fileName%></span>
 			</a>
 			<span class="nodeLabel fileExtension"><%=fileExtension%></span>
 


### PR DESCRIPTION
Problem Analysis: wrong closing html tag span causes javascript function can not parse html markups properly
Fix description: Change to correct tag
