### PR TITLE
ECMS-6036: Issue with file/content activity

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/TrashServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/TrashServiceImpl.java
@@ -195,8 +195,12 @@ public class TrashServiceImpl implements TrashService {
       }
 
       trashSession.save();
-
-      Node nodeInTrash =  trashSession.getRootNode().getNode(actualTrashPath.substring(1));
+      Node nodeInTrash = null;
+      if(nodeUUID != null) {
+    	nodeInTrash = trashSession.getRootNode().getSession().getNodeByUUID(nodeUUID);
+      }else{
+    	nodeInTrash =  trashSession.getRootNode().getNode(actualTrashPath.substring(1));
+      }
       nodeInTrash.addMixin(EXO_RESTORE_LOCATION);
       nodeInTrash.setProperty(RESTORE_PATH, fixRestorePath(restorePath));
       nodeInTrash.setProperty(RESTORE_WORKSPACE, nodeWorkspaceName);

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/DeleteManageComponent.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/DeleteManageComponent.java
@@ -204,7 +204,11 @@ public class DeleteManageComponent extends UIAbstractManagerComponent {
         ActivityCommonService activityService = WCMCoreUtils.getService(ActivityCommonService.class);
         TrashService trashService = WCMCoreUtils.getService(TrashService.class);
         Node parent = trashService.getTrashHomeNode();
-        node = parent.getNode(nodeName);
+        if(nodeUUID != null){
+          node = parent.getSession().getNodeByUUID(nodeUUID);
+        }else{
+          node = parent.getNode(nodeName);
+        }
         if (node.getPrimaryNodeType().getName().equals(NodetypeConstant.NT_FILE)) {        
           if (activityService.isBroadcastNTFileEvents(node)) {
             listenerService.broadcast(ActivityCommonService.FILE_REMOVE_ACTIVITY, parent, node);


### PR DESCRIPTION
Problem analysis:
- after moving a file to Trash, if there are many files with the same name, there will be an index after the name. \
- However, when we get value, we do not use the index

Fix description:
- Use node uuid to avoid getting the wrong node
