### PR TITLE
ECMS-6053: After being added symlink, published document is changed to d...

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/link/impl/LinkManagerImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/link/impl/LinkManagerImpl.java
@@ -106,9 +106,11 @@ public class LinkManagerImpl implements LinkManager {
   public Node createLink(Node parent, String linkType, Node target, String linkName, String linkTitle)
       throws RepositoryException {
     if (!target.isNodeType(SYMLINK)) {
+      boolean targetEdited = false;
       if (target.canAddMixin("mix:referenceable")) {
         target.addMixin("mix:referenceable");
         target.getSession().save();
+        targetEdited = true;
       }
       if (linkType == null || linkType.trim().length() == 0)
         linkType = SYMLINK;
@@ -135,7 +137,7 @@ public class LinkManagerImpl implements LinkManager {
       try {
         String remoteUser = WCMCoreUtils.getRemoteUser();
         if (remoteUser != null) {
-          if (Utils.isDocument(target)) {
+          if (Utils.isDocument(target) && targetEdited) {
             listenerService.broadcast(CmsService.POST_EDIT_CONTENT_EVENT, null, target);
           }
         }


### PR DESCRIPTION
...raft

Problem analysis:
- After adding a symlink, we trigger the event POST_EDIT_CONTENT_EVENT for the target node even when it is not modified

Fix description:
- we trigger this event only when there is a change in the target node
