### PR TITLE
ECMS-6063 | Binary content with no *dc:title* property are not inserted ...

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -325,7 +325,7 @@ public class Utils {
         }
       }
     }
-    if ((title==null) || ((title!=null) && (title.trim().length()==0))) {
+    if (StringUtils.isBlank(title)) {
       if (node.isNodeType("nt:frozenNode")) {
         String uuid = node.getProperty("jcr:frozenUuid").getString();
         Node originalNode = node.getSession().getNodeByUUID(uuid);
@@ -333,7 +333,6 @@ public class Utils {
       } else {
         title = node.getName();
       }
-
     }
     return StringEscapeUtils.escapeHtml(Text.unescapeIllegalJcrChars(title));
   }


### PR DESCRIPTION
...when uploaded and selected with WCM Content Selector

Fix description:
- If the "title" of the node is an empty String then return the node name in org.exoplatform.services.cms.impl.Utils$getTitle(Node node) 
