### PR TITLE
ECMS-6103 Incorrect arrow style in comboboxes (Import Node, Content Search Form)

### DIFF
--- a/apps/portlet-explorer/src/main/webapp/skin/less/ecms-explorer.less
+++ b/apps/portlet-explorer/src/main/webapp/skin/less/ecms-explorer.less
@@ -844,7 +844,7 @@
 	.uiSelectbox {
 		width: 150px;
 		.selectbox {
-			width: 175px;
+			width: 153px;
 		}
 	}
 }

--- a/apps/resources-wcm/src/main/webapp/skin/less/ecms-resources-wcmskin.less
+++ b/apps/resources-wcm/src/main/webapp/skin/less/ecms-resources-wcmskin.less
@@ -116,7 +116,7 @@
 	.uiSelectbox {
 		width: 123px;
 		.selectbox {
-			width: 148px;
+			width: 126px;
 		}
 	}
 }


### PR DESCRIPTION
Fix description:
- Reduce the width to make the correct arrow appear.
