### PR TITLE
ECMS-6029: [acme][IE8] Missing illustration images of built-in contents

### DIFF
--- a/apps/resources-wcm/src/main/webapp/skin/less/ecms-resources-wcmskin.less
+++ b/apps/resources-wcm/src/main/webapp/skin/less/ecms-resources-wcmskin.less
@@ -414,6 +414,17 @@
 	margin-left: 250px;
 }
 
+.ie8 {
+  .UICLVPortlet {
+    .CLV {
+      .Contents {
+        .Image img{
+          padding-right: 51px;
+        }
+      }
+    }
+  }
+}
 
 .UIWCMSearchPortlet{
 	.result{


### PR DESCRIPTION
Fix description:
    - Add image padding for IE 8
