### PR TITLE
ECMS-6113: [IE8, 9] Weird encoding of file name with accent characters

### DIFF
--- a/apps/portlet-explorer/src/main/webapp/javascript/eXo/ecm/MultiUpload.js
+++ b/apps/portlet-explorer/src/main/webapp/javascript/eXo/ecm/MultiUpload.js
@@ -286,7 +286,7 @@
 				ret += oldName[i];
 			}
 		}
-		return encodeURIComponent(ret);
+		return ret;
 	};
 
 	MultiUpload.prototype.changeStatusValue = function(id, delta) {
@@ -890,7 +890,7 @@
 		  	  //load image thumbnail
 		  	  var nodePath = (eXo.ecm.MultiUpload.drivePath.length <= 1 ? "":"/" + eXo.ecm.MultiUpload.drivePath) + 
 		  	  (eXo.ecm.MultiUpload.pathMap[progressID].length <= 1 ? "" : "/" + eXo.ecm.MultiUpload.pathMap[progressID]) +
-		  	  "/" + cleanName(file.name);
+		  	  "/" + encodeURIComponent(cleanName(file.name));
 				var icon = gj("#icon" + progressID, eXo.ecm.MultiUpload.document)[0];
 		  	  if (icon && eXo.ecm.MultiUpload.fileType[progressID].indexOf("image") != -1) {
 		  		  var iconHTMLForImageLoadFail = gj(icon).html();

--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
@@ -19,6 +19,7 @@ package org.exoplatform.wcm.connector;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.net.URLDecoder;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -332,6 +333,7 @@ public class FileUploadHandler {
     if(parent.isLocked()) {
       parent.getSession().addLockToken(LockUtil.getLockToken(parent));
     }
+    fileName = URLDecoder.decode(fileName,"UTF-8");
     if (parent.hasNode(fileName)) {
 //      Object args[] = { fileName, parent.getPath() };
 //      Document fileExisted = fckMessage.createMessage(FCKMessage.FILE_EXISTED,


### PR DESCRIPTION
Problem analysis:
    - Upload progress processes encoded file name
    - File name is encoded twice before rendering in the upload progress bar
Fix description:
    - Decode file name before staring the upload progress
    - Only encode file name in link to uploaded file
