### PR TITLE
ECMS-5082 The resize pointer doesn't disappear in IE8 and it doesn't resize the column

### DIFF
--- a/apps/portlet-explorer/src/main/webapp/javascript/eXo/ecm/UIListView.js
+++ b/apps/portlet-explorer/src/main/webapp/javascript/eXo/ecm/UIListView.js
@@ -1017,7 +1017,7 @@
       var event = event || window.event;
       event.cancelBubble = true;
       var columnClass = Self.objResizingHeader.className;
-      columnClass = columnClass.replace(" column", "").trim();
+      columnClass = gj.trim(columnClass.replace(" column", ""));
       var resizeValue = event.clientX - eXo.ecm.UIListView.currentMouseX;
       var newWidth    = Self.objResizeValue + resizeValue + "px";
       var div2Resize  = gj(Self.listGrid).find("div." + columnClass);


### PR DESCRIPTION
Fix description: IE8 not support string.trim(), instead use jQuery.trim()
