### PR TITLE
ECMS-6115: Permission parameter not taken into account for Group drives

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/drives/impl/ManageDriveServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/drives/impl/ManageDriveServiceImpl.java
@@ -512,6 +512,9 @@ public class ManageDriveServiceImpl implements ManageDriveService, Startable {
       return new ArrayList<DriveData>((List<DriveData>) drives);
     List<DriveData> groupDrives = new ArrayList<DriveData>();
     DriveData groupDrive = getDriveByName("Groups");
+    if(groupDrive == null){
+      return groupDrives;
+    }
     String[] allPermission = groupDrive.getAllPermissions();
     boolean flag = false;
     for (String role : userRoles) {


### PR DESCRIPTION
Fix description
- Check the permission to view Group Drive
