### PR TITLE
CGVALDOISE-130

### DIFF
--- a/apps/portlet-explorer/src/main/webapp/javascript/eXo/ecm/MultiUpload.js
+++ b/apps/portlet-explorer/src/main/webapp/javascript/eXo/ecm/MultiUpload.js
@@ -279,7 +279,7 @@
 				ret += oldName[i];
 			}
 		}
-		return encodeURIComponent(ret);
+		return ret;
 	};
 
 	MultiUpload.prototype.changeStatusValue = function(id, delta) {


### PR DESCRIPTION
Fix problem on IE : if you upload a document with accentued character, the char is not correctly saved.
