### PR TITLE
ECMS-6005: Edit symlink node change context in sites management

### DIFF
--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/action/EditDocumentActionComponent.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/action/EditDocumentActionComponent.java
@@ -254,7 +254,6 @@ public class EditDocumentActionComponent extends UIAbstractManagerComponent {
         }
       }
       if (selectedNode == null)  selectedNode = uiExplorer.getCurrentNode();
-      uiExplorer.setCurrentPath(selectedNode.getPath());
       UIApplication uiApp = uicomp.getAncestorOfType(UIApplication.class);
       editDocument(event, null, uicomp, uiExplorer, selectedNode, uiApp);
     }

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/popup/actions/UIDocumentForm.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/popup/actions/UIDocumentForm.java
@@ -475,9 +475,15 @@ public class UIDocumentForm extends UIDialogForm implements UIPopupComponent, UI
           if (newNode.hasProperty("exo:category")) newNode.setProperty("exo:category", vals.toArray(new Value[vals.size()]));
           newNode.save();
         }
-        uiExplorer.setCurrentPath(newNode.getPath());
-        uiExplorer.setWorkspaceName(newNode.getSession().getWorkspace().getName());
-        uiExplorer.refreshExplorer(newNode, true);
+		Node selectedNode = newNode;
+        if (documentForm.isAddNew()) {
+        	if (homeNode.isNodeType("exo:taxonomy")) {
+        		selectedNode = (Node) homeNode.getSession().getItem(homeNode.getPath() + "/" + newNode.getName());
+        	}
+	        uiExplorer.setCurrentPath(selectedNode.getPath());
+	        uiExplorer.setWorkspaceName(selectedNode.getSession().getWorkspace().getName());
+	        uiExplorer.refreshExplorer(selectedNode, true);
+        }   
         uiExplorer.updateAjax(event);
         return newNode;
       } catch(Exception e) {

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/popup/actions/UIDocumentForm.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/popup/actions/UIDocumentForm.java
@@ -475,14 +475,14 @@ public class UIDocumentForm extends UIDialogForm implements UIPopupComponent, UI
           if (newNode.hasProperty("exo:category")) newNode.setProperty("exo:category", vals.toArray(new Value[vals.size()]));
           newNode.save();
         }
-		Node selectedNode = newNode;
+	Node selectedNode = newNode;
         if (documentForm.isAddNew()) {
-        	if (homeNode.isNodeType("exo:taxonomy")) {
-        		selectedNode = (Node) homeNode.getSession().getItem(homeNode.getPath() + "/" + newNode.getName());
-        	}
-	        uiExplorer.setCurrentPath(selectedNode.getPath());
-	        uiExplorer.setWorkspaceName(selectedNode.getSession().getWorkspace().getName());
-	        uiExplorer.refreshExplorer(selectedNode, true);
+          if (homeNode.isNodeType("exo:taxonomy")) {
+            selectedNode = (Node) homeNode.getSession().getItem(homeNode.getPath() + "/" + newNode.getName());
+          }
+	  uiExplorer.setCurrentPath(selectedNode.getPath());
+	  uiExplorer.setWorkspaceName(selectedNode.getSession().getWorkspace().getName());
+	  uiExplorer.refreshExplorer(selectedNode, true);
         }   
         uiExplorer.updateAjax(event);
         return newNode;


### PR DESCRIPTION
Fix description: Keep the taxonomy context when the user edit or create the content in "taxonomies context"
