### PR TITLE
ECMS-6168: Download function doesn't preserve the original file name in ...

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/DownloadConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/DownloadConnector.java
@@ -83,7 +83,7 @@ public class DownloadConnector implements ResourceContainer{
       mimeType = node.getNode("jcr:content").getProperty("jcr:mimeType").getString();
     }
     return Response.ok(is, mimeType)
-          .header("Content-Disposition","attachment; filename=\"" + fileName+"\"")
+          .header("Content-Disposition","attachment; filename=\"" + fileName + "\"; filename*=UTF-8''" + fileName)
             .build();
   }
 }


### PR DESCRIPTION
...Chinese

Fix description:
- Get the file title instead of filename
- encode the file title
