### PR TITLE
ECMS-6209: Incorrect description of Pending status

### DIFF
--- a/ext/authoring/services/src/main/java/org/exoplatform/services/wcm/extensions/publication/lifecycle/authoring/AuthoringPublicationPlugin.java
+++ b/ext/authoring/services/src/main/java/org/exoplatform/services/wcm/extensions/publication/lifecycle/authoring/AuthoringPublicationPlugin.java
@@ -125,7 +125,7 @@ public class AuthoringPublicationPlugin extends  WebpagePublicationPlugin {
                                   newState,
                                   userId,
                                   GregorianCalendar.getInstance(),
-                                  AuthoringPublicationConstant.CHANGE_TO_DRAFT);
+                                  AuthoringPublicationConstant.CHANGE_TO_PENDING);
       addLog(node, versionLog);
       VersionData versionData = revisionsMap.get(node.getUUID());
       if (versionData != null) {


### PR DESCRIPTION
Problem analysis:
- In publication history property, each status has a constant of publication status description.
  This constant will be used to render i18n label.

Fix description:
- Update the constant of Pending status description.
