### PR TITLE
Fix/4.0.x/ecms 6231

### DIFF
--- a/core/services/src/main/java/org/exoplatform/ecm/utils/comparator/PropertyValueComparator.java
+++ b/core/services/src/main/java/org/exoplatform/ecm/utils/comparator/PropertyValueComparator.java
@@ -63,9 +63,9 @@ public class PropertyValueComparator implements Comparator<Node> {
       case PropertyType.STRING:
         return compareString(node0, node1);
       case PropertyType.LONG:
-        return compareString(node0, node1);
+        return compareLong(node0, node1);
       case PropertyType.DOUBLE:
-        return compareString(node0, node1);
+        return compareLong(node0, node1);
       case PropertyType.DATE:
         return compareDate(node0, node1);
       case PropertyType.REFERENCE:
@@ -74,6 +74,37 @@ public class PropertyValueComparator implements Comparator<Node> {
         throw new RepositoryException("Unknown type " + requireType);
       }
     } catch (Exception e) {
+      if (LOG.isErrorEnabled()) {
+        LOG.error("Unexpected error", e);
+      }
+      return 0;
+    }
+  }
+  
+  private int compareLong(Node node0, Node node1) {
+    try {
+      Long propertyValue0 = node0.getProperty(propertyName) == null ? -1 : node0.getProperty(propertyName)
+              .getLong();
+      Long propertyValue1 = node1.getProperty(propertyName) == null ? -1 : node1.getProperty(propertyName)
+              .getLong();
+      if (ASCENDING_ORDER.equals(orderType)) {
+        if (propertyValue0 < propertyValue1) {
+          return -1;
+        } else if (propertyValue0 == propertyValue1) {
+          return 0;
+        } else {
+          return 1;
+        }
+      } else {
+        if (propertyValue0 < propertyValue1) {
+          return 1;
+        } else if (propertyValue0 == propertyValue1) {
+          return 0;
+        } else {
+          return -1;
+        }
+      }
+    } catch (RepositoryException e) {
       if (LOG.isErrorEnabled()) {
         LOG.error("Unexpected error", e);
       }

--- a/core/webui/src/main/java/org/exoplatform/ecm/webui/comparator/PropertyValueComparator.java
+++ b/core/webui/src/main/java/org/exoplatform/ecm/webui/comparator/PropertyValueComparator.java
@@ -66,9 +66,9 @@ public class PropertyValueComparator implements Comparator<Node> {
       case PropertyType.STRING:
         return compareString(node0, node1);
       case PropertyType.LONG:
-        return compareString(node0, node1);
+        return compareLong(node0, node1);
       case PropertyType.DOUBLE:
-        return compareString(node0, node1);
+        return compareLong(node0, node1);
       case PropertyType.DATE:
         return compareDate(node0, node1);
       case PropertyType.REFERENCE:
@@ -79,6 +79,37 @@ public class PropertyValueComparator implements Comparator<Node> {
     } catch (Exception e) {
       if (LOG.isWarnEnabled()) {
         LOG.warn("Unexpected error", e);
+      }
+      return 0;
+    }
+  }
+  
+  private int compareLong(Node node0, Node node1) {
+    try {
+      Long propertyValue0 = node0.getProperty(propertyName) == null ? -1 : node0.getProperty(propertyName)
+              .getLong();
+      Long propertyValue1 = node1.getProperty(propertyName) == null ? -1 : node1.getProperty(propertyName)
+              .getLong();
+      if (ASCENDING_ORDER.equals(orderType)) {
+        if (propertyValue0 < propertyValue1) {
+          return -1;
+        } else if (propertyValue0 == propertyValue1) {
+          return 0;
+        } else {
+          return 1;
+        }
+      } else {
+        if (propertyValue0 < propertyValue1) {
+          return 1;
+        } else if (propertyValue0 == propertyValue1) {
+          return 0;
+        } else {
+          return -1;
+        }
+      }
+    } catch (RepositoryException e) {
+      if (LOG.isErrorEnabled()) {
+        LOG.error("Unexpected error", e);
       }
       return 0;
     }


### PR DESCRIPTION
Fix description: use new method compareLong to compare as a number, instead of a string, when property type is kind of Long or Double.
