### PR TITLE
ECMS-6095: Comments are not displayed on SCV in live mode

### DIFF
--- a/core/webui/src/main/java/org/exoplatform/ecm/webui/presentation/UIBaseNodePresentation.java
+++ b/core/webui/src/main/java/org/exoplatform/ecm/webui/presentation/UIBaseNodePresentation.java
@@ -120,7 +120,7 @@ public abstract class UIBaseNodePresentation extends UIContainer implements Node
    * @see org.exoplatform.ecm.webui.presentation.NodePresentation#getComments()
    */
   public List<Node> getComments() throws Exception {
-    return getApplicationComponent(CommentsService.class).getComments(getNode(), getLanguage()) ;
+    return getApplicationComponent(CommentsService.class).getComments(getOriginalNode(), getLanguage()) ;
   }
 
   /* (non-Javadoc)


### PR DESCRIPTION
Fix description:
- Display all comments of original node instead of frozen node
