### PR TITLE
ECMS-6258 | PDF not shown in the PDFViewer with specific creation date

### DIFF
--- a/core/viewer/src/main/java/org/exoplatform/ecm/webui/viewer/PDFViewer.java
+++ b/core/viewer/src/main/java/org/exoplatform/ecm/webui/viewer/PDFViewer.java
@@ -34,6 +34,8 @@ import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.portal.webui.util.Util;
 import org.exoplatform.portal.webui.workspace.UIPortalApplication;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
 import org.exoplatform.services.pdfviewer.PDFViewerService;
 import org.exoplatform.services.resources.ResourceBundleService;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
@@ -79,7 +81,7 @@ public class PDFViewer extends UIForm {
 
   final static private String PAGE_NUMBER = "pageNumber";
   final static private String SCALE_PAGE = "scalePage";
-  private static final Logger logger = Logger.getLogger(PDFViewer.class.toString());
+  private static final Log logger = ExoLogger.getLogger(PDFViewer.class.toString());
 
   final private String localeFile = "locale.portlet.viewer.PDFViewer";
 
@@ -177,9 +179,10 @@ public class PDFViewer extends UIForm {
       if(documentInfo.getModDate() != null) {
         metadatas.put("modDate", documentInfo.getModDate().toString());
       }
-     }}catch (Exception e){
-        if (logger.isLoggable(Level.WARNING)) {
-            logger.warning("An error occurred while creating the document metadata");
+     }
+   }catch (Exception e){
+        if (logger.isWarnEnabled()) {
+            logger.warn("An error occurred while creating the document metadata");
         }
     }
   }

--- a/core/viewer/src/main/java/org/exoplatform/ecm/webui/viewer/PDFViewer.java
+++ b/core/viewer/src/main/java/org/exoplatform/ecm/webui/viewer/PDFViewer.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
@@ -77,6 +79,7 @@ public class PDFViewer extends UIForm {
 
   final static private String PAGE_NUMBER = "pageNumber";
   final static private String SCALE_PAGE = "scalePage";
+  private static final Logger logger = Logger.getLogger(PDFViewer.class.toString());
 
   final private String localeFile = "locale.portlet.viewer.PDFViewer";
 
@@ -148,7 +151,8 @@ public class PDFViewer extends UIForm {
   }
 
   private void putDocumentInfo(PInfo documentInfo) {
-    if (documentInfo != null) {
+   try{
+     if (documentInfo != null) {
       if(documentInfo.getTitle() != null && documentInfo.getTitle().length() > 0) {
         metadatas.put("title", documentInfo.getTitle());
       }
@@ -173,6 +177,10 @@ public class PDFViewer extends UIForm {
       if(documentInfo.getModDate() != null) {
         metadatas.put("modDate", documentInfo.getModDate().toString());
       }
+     }}catch (Exception e){
+        if (logger.isLoggable(Level.WARNING)) {
+            logger.warning("An error occurred while creating the document metadata");
+        }
     }
   }
 

--- a/core/viewer/src/main/java/org/exoplatform/ecm/webui/viewer/PDFViewer.java
+++ b/core/viewer/src/main/java/org/exoplatform/ecm/webui/viewer/PDFViewer.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;


### PR DESCRIPTION
 **Fix description:**
- Add `try/catch` block inside the `putDocumentInfo()` in order to view (download) PDF files even the tool being used does not respect the standard format for date fields.
