### PR TITLE
ECMS-6334: CLV template are not ok when element is unpublished

### DIFF
--- a/core/publication/src/main/java/org/exoplatform/services/wcm/publication/WCMComposerImpl.java
+++ b/core/publication/src/main/java/org/exoplatform/services/wcm/publication/WCMComposerImpl.java
@@ -350,7 +350,7 @@ public class WCMComposerImpl implements WCMComposer, Startable {
       }
       // If clv view mode is live, only get nodes which has published version
       if (MODE_LIVE.equals(mode) && !"exo:taxonomyLink".equals(primaryType))
-        statement.append(" AND (publication:currentState IS NULL OR publication:currentState = 'published' " +
+        statement.append(" AND NOT publication:currentState = 'unpublished' AND (publication:currentState IS NULL OR publication:currentState = 'published' " +
         		"OR exo:titlePublished IS NOT NULL)");
       if (filterTemplates) statement.append(" AND " + getTemplatesSQLFilter());
       if (queryFilter!=null) {

--- a/ext/authoring/services/src/main/java/org/exoplatform/services/wcm/extensions/publication/lifecycle/authoring/AuthoringPublicationPlugin.java
+++ b/ext/authoring/services/src/main/java/org/exoplatform/services/wcm/extensions/publication/lifecycle/authoring/AuthoringPublicationPlugin.java
@@ -91,6 +91,12 @@ public class AuthoringPublicationPlugin extends  WebpagePublicationPlugin {
       node.addMixin(Utils.MIX_VERSIONABLE);
       node.save();
     }
+    if (node.hasProperty(AuthoringPublicationConstant.CURRENT_STATE) && node.getProperty(AuthoringPublicationConstant.CURRENT_STATE)
+    		.getString().equals(PublicationDefaultStates.UNPUBLISHED) && node.hasProperty("exo:titlePublished")) {
+      node.setProperty("exo:titlePublished",(Value)null);
+      
+    }
+
     
     String versionName = context.get(AuthoringPublicationConstant.CURRENT_REVISION_NAME);
     String logItemName = versionName;
@@ -213,6 +219,9 @@ public class AuthoringPublicationPlugin extends  WebpagePublicationPlugin {
       
       addLog(node, versionLog);
       // change base version to unpublished state
+      if (node.hasProperty("exo:titlePublished")) {
+        node.setProperty("exo:titlePublished",(Value)null);
+      }
       node.setProperty(AuthoringPublicationConstant.CURRENT_STATE,
                        PublicationDefaultStates.UNPUBLISHED);
       Value value = valueFactory.createValue(selectedRevision);


### PR DESCRIPTION
Fix description:
- Do not query unpublished documents in all cases
- Remove exo:titlePublish when unpublish a document
- Remove exo:titlePublish if the document changes from unpublish content
