### PR TITLE
ECMS-6170 | Dear null is shown in notification mail when watching a docu...

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/watch/impl/EmailNotifyListener.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/watch/impl/EmailNotifyListener.java
@@ -123,7 +123,7 @@ public class EmailNotifyListener implements EventListener {
     binding.put("user_name", WCMCoreUtils.getService(OrganizationService.class)
                                          .getUserHandler()
                                          .findUsersByQuery(query)
-                                         .load(0, 1)[0].getDisplayName());
+                                         .load(0, 1)[0].getFullName());
 
     Node node = NodeLocation.getNodeByLocation(observedNode_);
     binding.put("doc_title", org.exoplatform.services.cms.impl.Utils.getTitle(node));


### PR DESCRIPTION
...ment
* Problem Analysis:
When using the ```getDisplayName()``` it may return the ```displayName``` whithout checking its nullity when it is delegated to ```org.exoplatform.services.organization.idm.UserImpl```.
* Fix Description:
The current version of ```EmailNotifyListener``` must use the method ```getFullName()``` method even if it is deprecated until the changes in GTNPORTAL-3482 are applied.