### PR TITLE
ECMS-6407: NPE and redundant comment after adding 1 webcontent in CLV

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/jcrext/activity/ActivityCommonService.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/jcrext/activity/ActivityCommonService.java
@@ -94,7 +94,6 @@ public class ActivityCommonService {
   public Map<String, Object> getPreProperties() { return properties; }
   
   public void setPreProperties(Map<String, Object> preProperties) { properties = preProperties; }
-  public LinkManager linkManager = null;
   
   public ActivityCommonService(InitParams initParams) {
     this.acceptedNodeTypes = initParams.getValueParam("acceptedNodeTypes").getValue();
@@ -103,7 +102,6 @@ public class ActivityCommonService {
     if (acceptedNodeTypes==null) acceptedNodeTypes = "";
     if (acceptedProperties==null) acceptedProperties =""; 
     if (acceptedFileProperties==null) acceptedFileProperties ="";
-    linkManager = WCMCoreUtils.getService(LinkManager.class);
   }
   
   /**
@@ -149,21 +147,24 @@ public class ActivityCommonService {
    *   true if the node is creating
    */
   public boolean isCreating(Node node){
+    LinkManager linkManager = WCMCoreUtils.getService(LinkManager.class);
     Node realNode = node;
     try {
-      if (linkManager.isLink(node)) {
+      if (linkManager != null && linkManager.isLink(node)) {
         realNode = linkManager.getTarget(node);
       }
       NodeLocation nodeLocation = NodeLocation.getNodeLocationByNode(realNode);
       if (creatingNodes.contains(nodeLocation.hashCode())) {
         return true;
-      } 
-      List<Node> allLinks = linkManager.getAllLinks(realNode, "exo:symlink");
-      for (Node link : allLinks) {
-        nodeLocation = NodeLocation.getNodeLocationByNode(link);
-        nodeLocation.setUUID(realNode.getUUID());
-        if (creatingNodes.contains(nodeLocation.hashCode())){
-          return true;
+      }
+      if (linkManager != null) {
+        List<Node> allLinks = linkManager.getAllLinks(realNode, "exo:symlink");
+        for (Node link : allLinks) {
+          nodeLocation = NodeLocation.getNodeLocationByNode(link);
+          nodeLocation.setUUID(realNode.getUUID());
+          if (creatingNodes.contains(nodeLocation.hashCode())){
+            return true;
+          }
         }
       }
       return false;

--- a/core/services/src/main/java/org/exoplatform/services/cms/jcrext/activity/ActivityCommonService.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/jcrext/activity/ActivityCommonService.java
@@ -150,21 +150,19 @@ public class ActivityCommonService {
     LinkManager linkManager = WCMCoreUtils.getService(LinkManager.class);
     Node realNode = node;
     try {
-      if (linkManager != null && linkManager.isLink(node)) {
+      if (linkManager.isLink(node)) {
         realNode = linkManager.getTarget(node);
       }
       NodeLocation nodeLocation = NodeLocation.getNodeLocationByNode(realNode);
       if (creatingNodes.contains(nodeLocation.hashCode())) {
         return true;
       }
-      if (linkManager != null) {
-        List<Node> allLinks = linkManager.getAllLinks(realNode, "exo:symlink");
-        for (Node link : allLinks) {
-          nodeLocation = NodeLocation.getNodeLocationByNode(link);
-          nodeLocation.setUUID(realNode.getUUID());
-          if (creatingNodes.contains(nodeLocation.hashCode())){
-            return true;
-          }
+      List<Node> allLinks = linkManager.getAllLinks(realNode, "exo:symlink");
+      for (Node link : allLinks) {
+        nodeLocation = NodeLocation.getNodeLocationByNode(link);
+        nodeLocation.setUUID(realNode.getUUID());
+        if (creatingNodes.contains(nodeLocation.hashCode())){
+          return true;
         }
       }
       return false;


### PR DESCRIPTION
Problem analysis
- When a file is created in taxonomy folder, it is moved to web content and a symlink targeting to this node in taxonomy folder.
- During the progress above, when the moved file's property is changed, the event "update content" is triggered because the only new file in taxonomy folder is marked as creating.

Fix description
- Mark original file as creating if at least one of its symlink is in the creating list
