### PR TITLE
ECMS-6348: Can't restore file when undo delete file in Collaboration dri...

### DIFF
--- a/core/webui/src/main/java/org/exoplatform/ecm/webui/utils/Utils.java
+++ b/core/webui/src/main/java/org/exoplatform/ecm/webui/utils/Utils.java
@@ -317,9 +317,13 @@ public class Utils {
     }
     Session session = WCMCoreUtils.getUserSessionProvider().getSession(restoreWorkspace, WCMCoreUtils.getRepository());
     try {
+      if (restorePath == null || restorePath.length() == 0 ) {
+        restoreLocationNode = session.getRootNode();
+      } else {
         restoreLocationNode = (Node) session.getItem(restorePath);
+      }
     } catch(Exception e) {
-        return false;
+      return false;
     }
     return PermissionUtil.canAddNode(restoreLocationNode);
   }


### PR DESCRIPTION
...ve

Problem analysis
- When restoring a node which is direct children of root node, the restore path is empty string. However, it is impossible to get node by path if absolute path is empty.

Fix description
- if restore path is empty string, get root node instead of getting item by path