### PR TITLE
ECMS-6474: [Webdav - Windows] NPE and redundant comment when uploading a...

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/webdav/WebDavServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/webdav/WebDavServiceImpl.java
@@ -439,7 +439,7 @@ public class WebDavServiceImpl extends org.exoplatform.services.jcr.webdav.WebDa
       try {
         currentNode = (Node) session.getItem(path(repoPath));
       } catch (Exception e) {
-    	isCreating = true;
+        isCreating = true;
       }
     } catch (PathNotFoundException exc) {
       return Response.status(HTTPStatus.NOT_FOUND).entity(exc.getMessage()).build();
@@ -465,10 +465,13 @@ public class WebDavServiceImpl extends org.exoplatform.services.jcr.webdav.WebDa
                              uriInfo);
     try {
       if (isCreating) {
-    	currentNode = (Node) session.getItem(path(repoPath));
-    	if (userAgent.contains("Microsoft")) {
-    	  activityService.setCreating(currentNode, true);
-    	}
+        currentNode = (Node) session.getItem(path(repoPath));
+        # Since ECMS-6474:
+        # Windows webdav calls *put* function twice during uploading a file.
+        # As the result, this node must be in creating list of nodes during those calls.
+        if (userAgent.contains("Microsoft")) {
+          activityService.setCreating(currentNode, true);
+        }
       } else {
         activityService.setCreating(currentNode, false);
       }


### PR DESCRIPTION
... file via webdav of windows

Problem analysis
- FILE_CREATED_ACTIVITY event is fired when updating node in webdav
- FILE_EDIT_ACTIVITY event is fired when uploading file in windows webdav. This behavior is caused by specification of this type of webdav. The PUT action is called twice to create empty file then update content.

Fix description
- Only fire FILE_CREATED_ACTIVITY event when uploading file.
- Do not fire FILE_EDIT_ACTIVITY event when uploading file by webdav in windows.
