### PR TITLE
ECMS-6479: Cannot cut and paste a document into a Content Folder

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/clipboard/ClipboardService.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/clipboard/ClipboardService.java
@@ -45,7 +45,8 @@ public interface ClipboardService {
   public ClipboardCommand getLastClipboard(String userId);
 
   /**
-   * Gets the list of clipboard command added by given user 
+   * Gets the list of clipboard command added by given user
+   * check in clipboard. if a node was deleted, remove all clipboardCommands relate to that node in clipboard 
    * @param userId the user who added the commands
    * @param isVirtual if the commands are virtual
    * @return the list of ClipboardCommand

--- a/core/services/src/test/java/org/exoplatform/services/cms/clipboard/TestClipboardService.java
+++ b/core/services/src/test/java/org/exoplatform/services/cms/clipboard/TestClipboardService.java
@@ -39,7 +39,7 @@ public class TestClipboardService extends BaseWCMTestCase {
     super.setUp();
     session.getRootNode().addNode("documents");
     session.getRootNode().addNode("music");
-    session.getRootNode().addNode("public");
+    session.getRootNode().addNode("favorites");
     session.getRootNode().addNode("pictures");
     session.save();
     clipboardService_ = WCMCoreUtils.getService(ClipboardService.class);
@@ -48,7 +48,7 @@ public class TestClipboardService extends BaseWCMTestCase {
     clipboardService_.addClipboardCommand("john", 
       new ClipboardCommand(ClipboardCommand.CUT, "/music", "collaboration"), false);
     clipboardService_.addClipboardCommand("john", 
-      new ClipboardCommand(ClipboardCommand.CUT, "/public", "collaboration"), true);
+      new ClipboardCommand(ClipboardCommand.CUT, "/favorites", "collaboration"), true);
     //duplication
     clipboardService_.addClipboardCommand("john", 
       new ClipboardCommand(ClipboardCommand.CUT, "/documents", "collaboration"), false);
@@ -57,7 +57,10 @@ public class TestClipboardService extends BaseWCMTestCase {
     clipboardService_.addClipboardCommand("john", 
       new ClipboardCommand(ClipboardCommand.COPY, "/documents", "dms-system"), false);
     clipboardService_.addClipboardCommand("mary", 
-      new ClipboardCommand(ClipboardCommand.CUT, "/pictures", "collaboration"), true);
+      new ClipboardCommand(ClipboardCommand.CUT, "/documents", "collaboration"), true);
+    clipboardService_.addClipboardCommand("mary", 
+      new ClipboardCommand(ClipboardCommand.CUT, "/publics", "collaboration"), true);
+    
   }
   
   public void tearDown() throws Exception {
@@ -70,10 +73,13 @@ public class TestClipboardService extends BaseWCMTestCase {
   public void testAddClipboardCommand() throws Exception {
     clipboardService_.addClipboardCommand("john", 
       new ClipboardCommand(ClipboardCommand.CUT, "/pictures", "collaboration"), false);
+    // expect 3 because workspace "dms-system" doesn't exist in test platform
     assertEquals(3, clipboardService_.getClipboardList("john", false).size());
     clipboardService_.addClipboardCommand("john", 
       new ClipboardCommand(ClipboardCommand.CUT, "/public", "collaboration"), true);
+    // expect 2 because public node is not added
     assertEquals(2, clipboardService_.getClipboardList("john", true).size());
+    // expect 1 because publics node is not added
     assertEquals(1, clipboardService_.getClipboardList("mary", true).size());
     assertEquals(0, clipboardService_.getClipboardList("james", false).size());
   }

--- a/core/services/src/test/java/org/exoplatform/services/cms/clipboard/TestClipboardService.java
+++ b/core/services/src/test/java/org/exoplatform/services/cms/clipboard/TestClipboardService.java
@@ -31,16 +31,24 @@ import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 public class TestClipboardService extends BaseWCMTestCase {
   
   ClipboardService clipboardService_ = null;
-  
+  /**
+   * add some nodes for testing because getClipboardList check the existing of node
+   * some nodes will not be found if workspace is not defined
+   */
   public void setUp() throws Exception {
     super.setUp();
+    session.getRootNode().addNode("documents");
+    session.getRootNode().addNode("music");
+    session.getRootNode().addNode("public");
+    session.getRootNode().addNode("pictures");
+    session.save();
     clipboardService_ = WCMCoreUtils.getService(ClipboardService.class);
     clipboardService_.addClipboardCommand("john", 
       new ClipboardCommand(ClipboardCommand.CUT, "/documents", "collaboration"), false);
     clipboardService_.addClipboardCommand("john", 
-      new ClipboardCommand(ClipboardCommand.CUT, "/favorites", "collaboration"), false);
-    clipboardService_.addClipboardCommand("john", 
       new ClipboardCommand(ClipboardCommand.CUT, "/music", "collaboration"), false);
+    clipboardService_.addClipboardCommand("john", 
+      new ClipboardCommand(ClipboardCommand.CUT, "/public", "collaboration"), true);
     //duplication
     clipboardService_.addClipboardCommand("john", 
       new ClipboardCommand(ClipboardCommand.CUT, "/documents", "collaboration"), false);
@@ -49,7 +57,7 @@ public class TestClipboardService extends BaseWCMTestCase {
     clipboardService_.addClipboardCommand("john", 
       new ClipboardCommand(ClipboardCommand.COPY, "/documents", "dms-system"), false);
     clipboardService_.addClipboardCommand("mary", 
-      new ClipboardCommand(ClipboardCommand.CUT, "/documents", "collaboration"), true);
+      new ClipboardCommand(ClipboardCommand.CUT, "/pictures", "collaboration"), true);
   }
   
   public void tearDown() throws Exception {
@@ -62,7 +70,7 @@ public class TestClipboardService extends BaseWCMTestCase {
   public void testAddClipboardCommand() throws Exception {
     clipboardService_.addClipboardCommand("john", 
       new ClipboardCommand(ClipboardCommand.CUT, "/pictures", "collaboration"), false);
-    assertEquals(5, clipboardService_.getClipboardList("john", false).size());
+    assertEquals(3, clipboardService_.getClipboardList("john", false).size());
     clipboardService_.addClipboardCommand("john", 
       new ClipboardCommand(ClipboardCommand.CUT, "/public", "collaboration"), true);
     assertEquals(2, clipboardService_.getClipboardList("john", true).size());
@@ -87,9 +95,9 @@ public class TestClipboardService extends BaseWCMTestCase {
 
   public void testGetClipboardList() {
     Set<ClipboardCommand> commands = clipboardService_.getClipboardList("john", false);
-    assertEquals(4, commands.size());
+    assertEquals(2, commands.size());
     commands = clipboardService_.getClipboardList("john", true);
-    assertEquals(1, commands.size());
+    assertEquals(2, commands.size());
     commands = clipboardService_.getClipboardList("mary", true);
     assertEquals(1, commands.size());
     commands = clipboardService_.getClipboardList("mary", false);


### PR DESCRIPTION
Fix Description:

* Check clipboard when calling getClipboardList. Clean commands in clipboard relate to a node which was deleted