### PR TITLE
ECMS-6272: [Simple Search] Duplicate results when keyword matches file c...

### DIFF
--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/UIAddressBar.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/UIAddressBar.java
@@ -101,10 +101,10 @@ public class UIAddressBar extends UIForm {
   private final static String MESSAGE_NOT_SUPPORT_KEYWORD = "UIAddressBar.msg.keyword-not-support";
   final static private String FIELD_SIMPLE_SEARCH      = "simpleSearch";
 
-  final static private  String ROOT_SQL_QUERY  = "select * from nt:base where " +
+  final static private  String ROOT_SQL_QUERY  = "select * from nt:base where (not jcr:primaryType like 'nt:resource') AND " +
                                "(jcr:primaryType like 'exo:symlink' or jcr:primaryType like 'exo:taxonomyLink')" +
                                " OR ( contains(*, '$1') or lower(exo:name) like '%$2%' or lower(exo:commentContent) like '%$3%') order by exo:title ASC";
-  final static private String SQL_QUERY = "select * from nt:base where jcr:path like '$0/%' AND " +
+  final static private String SQL_QUERY = "select * from nt:base where (not jcr:primaryType like 'nt:resource') AND jcr:path like '$0/%' AND " +
                                "( (jcr:primaryType like 'exo:symlink' or jcr:primaryType like 'exo:taxonomyLink')" +
                                " OR ( contains(*, '$1') or lower(exo:name) like '%$2%' or lower(exo:commentContent) like '%$3%') ) order by exo:title ASC";
 

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/search/UISimpleSearch.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/search/UISimpleSearch.java
@@ -100,6 +100,8 @@ public class UISimpleSearch extends UIForm {
   private static final String XPATH_QUERY      = "/jcr:root$0//*";
 
   private static final String ROOT_SQL_QUERY   = "SELECT * FROM nt:base WHERE jcr:path LIKE '/%' ";
+  
+  private static final String NT_RESOURCE_EXCLUDE = "AND ( not jcr:primaryType like 'nt:resource') ";
 
   private static final String LINK_REQUIREMENT = "AND ( (jcr:primaryType like 'exo:symlink' or " +
                                                         "jcr:primaryType like 'exo:taxonomyLink') ";
@@ -215,6 +217,7 @@ public class UISimpleSearch extends UIForm {
       } else {
         statement.append(StringUtils.replace(SQL_QUERY, "$0", currentNode.getPath()));
       }
+      statement.append(NT_RESOURCE_EXCLUDE);
       statement.append(LINK_REQUIREMENT).append(" OR ( CONTAINS(*,'").
                 append(escapedText).append("') ) )");
     } else if(constraints_.size() > 0) {//constraint != null
@@ -237,6 +240,7 @@ public class UISimpleSearch extends UIForm {
         } else {
           statement.append(StringUtils.replace(SQL_QUERY, "$0", currentNode.getPath()));
         }
+        statement.append(NT_RESOURCE_EXCLUDE);
         if (constraintsStatement.length() > 0)
           statement.append(constraintsStatement);
       } else {
@@ -245,6 +249,7 @@ public class UISimpleSearch extends UIForm {
         } else {
           statement.append(StringUtils.replace(SQL_QUERY, "$0", currentNode.getPath()));
         }
+        statement.append(NT_RESOURCE_EXCLUDE);
         statement.append(LINK_REQUIREMENT).append("OR ( CONTAINS(*,'").
                   append(escapedText.replaceAll("'", "''")).append("') ");
         if (constraintsStatement.length() > 0)


### PR DESCRIPTION
...ontent

Problem analysis
- With ECMS-5758, the nt:resource file is indexed. Each nt:file has a nt:resource as a child to store content. Moreover nt:resource nodetype is one of instance of nt:base. As the result, in the search result, user can see both of nt:file and its nt:resource.

Fix description:
- Exclude nt:resource from search results
