### PR TITLE
ECMS-6210 Wrong information of Public symlink folder

### DIFF
--- a/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/UIDocumentNodeList.gtmpl
+++ b/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/UIDocumentNodeList.gtmpl
@@ -108,8 +108,14 @@ public void writeNodes(level, i, data, uiWorkingArea, linkManager, restContextNa
   def versionNum  = uicomponent.getVersionNumber(data);
   def author = uicomponent.getAuthorName(data);
   def fileSize = uicomponent.getFileSize(data);
-  
-  String actionLink = uiDocumentInfo.event("ChangeNode",Utils.formatNodeName(data.path), new Parameter("workspaceName", preferenceWS)) ;
+
+	def _realPath = Utils.formatNodeName(data.getPath());
+
+	if(data.getRealNode() != null ){
+		_realPath = Utils.formatNodeName(data.getRealNode().getPath());
+	}
+	Parameter[] _params = [new Parameter("workspaceName", preferenceWS), new Parameter("findDrive", "true")];
+	String actionLink = uiDocumentInfo.event("ChangeNode", _realPath, _params) ;
 
   //Begin permlink
   def permLinkComponent =  uiWorkingArea.getPermlink(data);

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIDocumentInfo.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIDocumentInfo.java
@@ -1191,7 +1191,7 @@ public class UIDocumentInfo extends UIBaseNodePresentation {
       UITreeExplorer uiTreeExplorer = uiExplorer.findFirstComponentOfType(UITreeExplorer.class);
       String uri = event.getRequestContext().getRequestParameter(OBJECTID);
       String workspaceName = event.getRequestContext().getRequestParameter("workspaceName");
-      boolean findDrive = Boolean.getBoolean(event.getRequestContext().getRequestParameter("findDrive"));
+      boolean findDrive = Boolean.parseBoolean(event.getRequestContext().getRequestParameter("findDrive"));
       UIApplication uiApp = uicomp.getAncestorOfType(UIApplication.class);
       try {
         // Manage ../ and ./


### PR DESCRIPTION
Cause: When symlink folder, we don't get realPath of node.
Solution: Get realPath Node & enable find drive
