### PR TITLE
ECMS-6474: [Webdav - Windows] NPE and redundant comment when uploading a...

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/webdav/WebDavServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/webdav/WebDavServiceImpl.java
@@ -436,9 +436,7 @@ public class WebDavServiceImpl extends org.exoplatform.services.jcr.webdav.WebDa
         session = item.getSession();
       }
       activityService = WCMCoreUtils.getService(ActivityCommonService.class);
-      try {
-        currentNode = (Node) session.getItem(path(repoPath));
-      } catch (Exception e) {
+      if (!session.itemExists(path(repoPath))) {
         isCreating = true;
       }
     } catch (PathNotFoundException exc) {
@@ -464,8 +462,8 @@ public class WebDavServiceImpl extends org.exoplatform.services.jcr.webdav.WebDa
                              inputStream,
                              uriInfo);
     try {
+      currentNode = (Node) session.getItem(path(repoPath));
       if (isCreating) {
-        currentNode = (Node) session.getItem(path(repoPath));
         // Since ECMS-6474:
         // Windows webdav calls *put* function twice during uploading a file.
         // As the result, this node must be in creating list of nodes during those calls.

--- a/core/services/src/main/java/org/exoplatform/services/cms/webdav/WebDavServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/webdav/WebDavServiceImpl.java
@@ -413,9 +413,11 @@ public class WebDavServiceImpl extends org.exoplatform.services.jcr.webdav.WebDa
                       @HeaderParam(ExtHttpHeaders.USER_AGENT) String userAgent,
                       InputStream inputStream,
                       @Context UriInfo uriInfo) {
-
     Session session = null;
     Item item = null;
+    Node currentNode = null;
+    boolean isCreating = false;
+    ActivityCommonService activityService = null;
     try {
       repoName = repositoryService.getCurrentRepository().getConfiguration().getName();
       try {
@@ -432,6 +434,12 @@ public class WebDavServiceImpl extends org.exoplatform.services.jcr.webdav.WebDa
         repoPath = item.getSession().getWorkspace().getName()
             + LinkUtils.createPath(item.getPath(), Text.escapeIllegalJcrChars(LinkUtils.getItemName(path(repoPath))));
         session = item.getSession();
+      }
+      activityService = WCMCoreUtils.getService(ActivityCommonService.class);
+      try {
+        currentNode = (Node) session.getItem(path(repoPath));
+      } catch (Exception e) {
+        isCreating = true;
       }
     } catch (PathNotFoundException exc) {
       return Response.status(HTTPStatus.NOT_FOUND).entity(exc.getMessage()).build();
@@ -456,10 +464,20 @@ public class WebDavServiceImpl extends org.exoplatform.services.jcr.webdav.WebDa
                              inputStream,
                              uriInfo);
     try {
-      Node currentNode = (Node) session.getItem(path(repoPath));
-      if (currentNode.isCheckedOut())
+      if (isCreating) {
+        currentNode = (Node) session.getItem(path(repoPath));
+        // Since ECMS-6474:
+        // Windows webdav calls *put* function twice during uploading a file.
+        // As the result, this node must be in creating list of nodes during those calls.
+        if (userAgent.contains("Microsoft")) {
+          activityService.setCreating(currentNode, true);
+        }
+      } else {
+        activityService.setCreating(currentNode, false);
+      }
+      if (currentNode.isCheckedOut() && !activityService.isCreating(currentNode))
         listenerService.broadcast(this.POST_UPLOAD_CONTENT_EVENT, this, currentNode);
-      if(currentNode != null) {
+      if(currentNode != null && isCreating) {
         ListenerService listenerService = WCMCoreUtils.getService(ListenerService.class);
         try {
           listenerService.broadcast(ActivityCommonService.FILE_CREATED_ACTIVITY, null, currentNode);
@@ -470,6 +488,7 @@ public class WebDavServiceImpl extends org.exoplatform.services.jcr.webdav.WebDa
           }
         }
       }
+
     } catch (PathNotFoundException npfe) {
       return Response.status(HTTPStatus.NOT_FOUND).entity(npfe.getMessage()).build();
     } catch (RepositoryException re) {


### PR DESCRIPTION
... file via webdav of windows

Problem analysis
- FILE_CREATED_ACTIVITY event is fired when updating node in webdav
- FILE_EDIT_ACTIVITY event is fired when uploading file in windows webdav. This behavior is caused by specification of this type of webdav. The PUT action is called twice to create empty file then update content.

Fix description
- Only fire FILE_CREATED_ACTIVITY event when uploading file.
- Do not fire FILE_EDIT_ACTIVITY event when uploading file by webdav in windows.