### PR TITLE
ECMS-6509 : first modification : keep form.submit for IE8 or lower, but ...

### DIFF
--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/wcm/backoffice/private/CloseEvents.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/wcm/backoffice/private/CloseEvents.js
@@ -104,9 +104,26 @@
 	  form.elements['formOp'].value = action ;
 	  
 
-	 if (navigator.appName == 'Microsoft Internet Explorer')
-	 {
+	 if (document.all && !document.addEventListener)
+	 {//IE and IE8 or lower
 	   if ((action.toLowerCase() == "save" || action.toLowerCase() == "saveandclose" || action.toLowerCase() == "close") && window.popup_opened == true) {
+	     //with IE8, we have to do a submit instead of a ajaxPost
+	     //to keep memory of backTo parameter, we get it from query
+	     //and recopy it as parameter of the form action
+	     //then, on the next page, after the submit, the backto parameter will still exists
+	     var backto = "";
+	     var query = window.location.search.substring(1);
+	     var vars = query.split("&");
+	     for (var i=0;i<vars.length;i++) {
+	         var pair = vars[i].split("=");
+	         if(pair[0] == "backto") {
+	             backto=pair[1];
+	             break;
+		}
+	     }
+	     if (!backto=="") {
+		form.action=form.action+("&backto="+backto);
+	     }
 	     window.onbeforeunload = null;
 	     useAjax=false;
 	     window.popup_opened = false;
@@ -168,9 +185,26 @@
 	  b_changed = false;
 	  this.ajaxPost(form) ;
 	  
-	  if (navigator.appName == 'Microsoft Internet Explorer')
-	  {
+	  if (document.all && !document.addEventListener)
+	  {//IE and IE8 or lower
 	    if (action.toLowerCase() == "changetab" && window.popup_opened == true) {
+	      //with IE8, we have to do a submit instead of a ajaxPost
+	      //to keep memory of backTo parameter, we get it from query
+	      //and recopy it as parameter of the form action
+	      //then, on the next page, after the submit, the backto parameter will still exists
+	      var backto = "";
+	      var query = window.location.search.substring(1);
+	      var vars = query.split("&");
+	      for (var i=0;i<vars.length;i++) {
+	         var pair = vars[i].split("=");
+	         if(pair[0] == "backto") {
+	             backto=pair[1];
+	             break;
+		}
+	      }
+	      if (!backto=="") {
+	         form.action=form.action+("&backto="+backto);
+	      }
 	      window.popup_opened = false;
 	      form.submit();
 	    }


### PR DESCRIPTION
...use ajaxPost for IE > 8 or not IE. Second modification : if IE8 or lower, get backto parameter for request, and put it as parameter of the form action. Then after the submit, the backto parameter will be stil usable


To know if we use IE8 and lower,  I found informations here : http://tanalin.com/en/articles/ie-version-js/