### PR TITLE
ECMS-6521: [PLF41-Migration] WCMTemplateUpgradePlugin failed due to NPE

### DIFF
--- a/core/services/pom.xml
+++ b/core/services/pom.xml
@@ -71,6 +71,10 @@
     </dependency>
     <dependency>
       <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-component-product</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.commons</groupId>
       <artifactId>commons-webui-ext</artifactId>
     </dependency>
     <dependency>

--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -19,6 +19,7 @@ package org.exoplatform.services.cms.impl;
 import com.ibm.icu.text.Transliterator;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
+import org.exoplatform.commons.info.ProductInformations;
 import org.exoplatform.container.component.ComponentPlugin;
 import org.exoplatform.services.cms.BasePath;
 import org.exoplatform.services.cms.documents.TrashService;
@@ -907,6 +908,24 @@ public class Utils {
   public static boolean isFolder(Node node) throws RepositoryException  {
     return node.isNodeType(NodetypeConstant.NT_FOLDER)
         || node.isNodeType(NodetypeConstant.NT_UNSTRUCTURED);
- }
+  }
+  
+  /** Check if upgrade service will run
+   * @return upgrade service will run or not
+   * 
+   */
+  public static boolean isActivatedUpgradeService() {
+    ProductInformations productInformations = (ProductInformations)WCMCoreUtils.getService(ProductInformations.class);
+    try {
+      String currentVersion = productInformations.getVersion();
+      String previousVersion = productInformations.getPreviousVersion();
+      if (!previousVersion.equals(currentVersion)) {
+        return true;
+      }
+      return false;
+    } catch (Exception e) {
+      return false;
+    }
+  }
 
 }

--- a/core/services/src/main/java/org/exoplatform/services/cms/views/impl/ApplicationTemplateManagerServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/views/impl/ApplicationTemplateManagerServiceImpl.java
@@ -236,7 +236,7 @@ public class ApplicationTemplateManagerServiceImpl implements ApplicationTemplat
       for(PortletTemplateConfig config: map.get(portletName)) {
         StringBuilder tBuilder = new StringBuilder();
         tBuilder.append(config.getCategory()).append(config.getTemplateName());
-        if(Utils.getAllEditedConfiguredData(this.getClass().getSimpleName(), EDITED_CONFIGURED_TEMPLATES, true).contains(tBuilder.toString())) continue;
+        if(Utils.getAllEditedConfiguredData(this.getClass().getSimpleName(), EDITED_CONFIGURED_TEMPLATES, true).contains(tBuilder.toString()) && !Utils.isActivatedUpgradeService()) continue;
         addTemplate(templateNode,config);
       }
     }

--- a/core/services/src/main/java/org/exoplatform/services/cms/views/impl/ManageViewPlugin.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/views/impl/ManageViewPlugin.java
@@ -102,8 +102,8 @@ public class ManageViewPlugin extends BaseComponentPlugin {
         viewObject = (ViewConfig)object ;
         String viewNodeName = viewObject.getName();
         configuredViews_.add(viewNodeName);
-        if(viewHomeNode.hasNode(viewNodeName) || Utils.getAllEditedConfiguredData(
-          this.getClass().getSimpleName(), EDITED_CONFIGURED_VIEWS, true).contains(viewNodeName)) continue ;
+        if(viewHomeNode.hasNode(viewNodeName) || (Utils.getAllEditedConfiguredData(
+          this.getClass().getSimpleName(), EDITED_CONFIGURED_VIEWS, true).contains(viewNodeName) && !Utils.isActivatedUpgradeService())) continue ;
         Node viewNode = addView(viewHomeNode,viewNodeName,viewObject.getPermissions(),
                                 viewObject.isHideExplorerPanel(), viewObject.getTemplate()) ;
         Utils.addEditedConfiguredData(viewNodeName, this.getClass().getSimpleName(), EDITED_CONFIGURED_VIEWS, true);


### PR DESCRIPTION
Problem analysis
- During upgrade time, the predefined templates and views are not loaded because they are marked as edited in log node.

Fix description
- Force loading predefined templates and views during upgrade time
