### PR TITLE
ECMS-6521: [PLF41-Migration] WCMTemplateUpgradePlugin failed due to NPE

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -623,6 +623,24 @@ public class Utils {
     }
   }
 
+  public static void removeAllEditedConfiguredData(String className, String id, boolean skipActivities) throws Exception {
+    SessionProvider systemProvider = SessionProvider.createSystemProvider();
+    try {
+      DocumentContext.getCurrent().getAttributes().put(DocumentContext.IS_SKIP_RAISE_ACT, skipActivities);
+      Node serviceLogContentNode = getServiceLogContentNode(systemProvider, className, id);
+      if (serviceLogContentNode == null)
+        return;
+      String logData = serviceLogContentNode.getProperty(NodetypeConstant.JCR_DATA).getString();
+      if (StringUtils.isNotBlank(logData)) {
+        logData = StringUtils.EMPTY;
+        serviceLogContentNode.setProperty(NodetypeConstant.JCR_DATA, logData);
+        serviceLogContentNode.getSession().save();
+      }
+    } finally {
+      systemProvider.close();
+    }
+  }
+
   public static String getObjectId(String nodePath) throws UnsupportedEncodingException {
     return URLEncoder.encode(nodePath.replaceAll("'", "\\\\'"), "utf-8");
   }

--- a/core/services/src/main/java/org/exoplatform/services/cms/views/impl/ManageViewPlugin.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/views/impl/ManageViewPlugin.java
@@ -44,8 +44,8 @@ import java.util.Set;
 public class ManageViewPlugin extends BaseComponentPlugin {
 
   private static String ECM_EXPLORER_TEMPLATE = "ecmExplorerTemplate" ;
-  private static final String EDITED_CONFIGURED_VIEWS = "EditedConfiguredViews";
-  private static final String EDITED_CONFIGURED_VIEWS_TEMPLATES = "EditedConfiguredViewsTemplate";
+  public static final String EDITED_CONFIGURED_VIEWS = "EditedConfiguredViews";
+  public static final String EDITED_CONFIGURED_VIEWS_TEMPLATES = "EditedConfiguredViewsTemplate";
   private InitParams params_ ;
   private RepositoryService repositoryService_ ;
   private NodeHierarchyCreator nodeHierarchyCreator_ ;

--- a/upgrade-plugins/src/main/java/org/exoplatform/ecms/upgrade/templates/WCMTemplateUpgradePlugin.java
+++ b/upgrade-plugins/src/main/java/org/exoplatform/ecms/upgrade/templates/WCMTemplateUpgradePlugin.java
@@ -68,17 +68,27 @@ public class WCMTemplateUpgradePlugin extends UpgradeProductPlugin {
     if (log.isInfoEnabled()) {
       log.info("Start " + this.getClass().getName() + ".............");
     }
+    try {
+      // Remove cache application templates
+      Utils.removeAllEditedConfiguredData(ApplicationTemplateManagerServiceImpl.class.getSimpleName(),
+          ApplicationTemplateManagerServiceImpl.EDITED_CONFIGURED_TEMPLATES, true);
+      // re-initialize new scripts
+      ((ApplicationTemplateManagerServiceImpl) appTemplateService_).start();
+    } catch (Exception e) {
+      if (log.isErrorEnabled()) {
+        log.error("An unexpected error occurs when migrating templates for portlet CLV and WCMSearch: ", e);
+      }
+    }
     String unchangedClvTemplates = PrivilegedSystemHelper.getProperty("unchanged-clv-templates");
     String unchangedSearchTemplates = PrivilegedSystemHelper.getProperty("unchanged-wcm-search-templates");
     upgrade(unchangedClvTemplates, "content-list-viewer");
     upgrade(unchangedSearchTemplates, "search");
-    
     try {
       // re-initialize new scripts
-      ((ApplicationTemplateManagerServiceImpl)appTemplateService_).start();
+      ((ApplicationTemplateManagerServiceImpl) appTemplateService_).start();
     } catch (Exception e) {
       if (log.isErrorEnabled()) {
-        log.error("An unexpected error occurs when migrating templates for portlet CLV and WCMSearch: ", e);        
+        log.error("An unexpected error occurs when migrating templates for portlet CLV and WCMSearch: ", e);
       }
     }
   }

--- a/upgrade-plugins/src/main/java/org/exoplatform/ecms/upgrade/views/UserViewUpgradePlugin.java
+++ b/upgrade-plugins/src/main/java/org/exoplatform/ecms/upgrade/views/UserViewUpgradePlugin.java
@@ -28,8 +28,10 @@ import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
 import org.exoplatform.commons.utils.PrivilegedSystemHelper;
 import org.exoplatform.commons.version.util.VersionComparator;
 import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.cms.impl.Utils;
 import org.exoplatform.services.cms.views.ManageViewService;
 import org.exoplatform.services.cms.views.ViewConfig;
+import org.exoplatform.services.cms.views.impl.ManageViewPlugin;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -55,11 +57,21 @@ public class UserViewUpgradePlugin extends UpgradeProductPlugin {
   public UserViewUpgradePlugin(ManageViewService manageViewService, InitParams initParams) {
     super(initParams);
     this.manageViewService_  = manageViewService;
+
   }
   
   public void processUpgrade(String oldVersion, String newVersion) {
     if (log.isInfoEnabled()) {
       log.info("Start " + this.getClass().getName() + ".............");
+    }
+    try {
+      // Remove cached user view
+      Utils.removeAllEditedConfiguredData(ManageViewPlugin.class.getSimpleName(), ManageViewPlugin.EDITED_CONFIGURED_VIEWS, true);
+      Utils.removeAllEditedConfiguredData(ManageViewPlugin.class.getSimpleName(), ManageViewPlugin.EDITED_CONFIGURED_VIEWS_TEMPLATES, true);
+    } catch (Exception e) {
+      if (log.isErrorEnabled()) {
+        log.error("An unexpected error occurs when migrating Site Explorer views:", e);
+      }
     }
     String unchangedViews = PrivilegedSystemHelper.getProperty("unchanged-site-explorer-views");
     SessionProvider sessionProvider = null;
@@ -73,6 +85,7 @@ public class UserViewUpgradePlugin extends UpgradeProductPlugin {
       for (String unchangedView : unchangedViews.split(",")) {
         unchangedViewSet.add(unchangedView.trim());
       }
+
       //get all old query nodes that need to be removed.
       sessionProvider = SessionProvider.createSystemProvider();
       Node parentNode = null;


### PR DESCRIPTION
Problem analysis
- During upgrade time, the predefined templates and views are not loaded because they are marked as edited in log node.

Fix description:
- Remove nodes storing marked edited templates when WCMTemplateUpgradePlugin and UserViewUpgradePlugin start
