### PR TITLE
ECMS-6521: [PLF41-Migration] UserViewUpgradePlugin, SiteExplorerUpgrade don't work

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/views/impl/ApplicationTemplateManagerServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/views/impl/ApplicationTemplateManagerServiceImpl.java
@@ -102,21 +102,21 @@ public class ApplicationTemplateManagerServiceImpl implements ApplicationTemplat
       category = portletTemplateHome.addNode(config.getCategory(),"nt:unstructured");
       portletTemplateHome.save();
     }
-    if (!category.hasNode(config.getTemplateName())) {
-      templateService.createTemplate(category,
-                                     config.getTitle(),
-                                     config.getTemplateName(),
-                                     new ByteArrayInputStream(config.getTemplateData().getBytes()),
-                                     new String[] { "*" });
+    StringBuilder tBuilder = new StringBuilder();
+    tBuilder.append(config.getCategory()).append(config.getTemplateName());
+    boolean isExistedTemplate = Utils.getAllEditedConfiguredData(this.getClass().getSimpleName(),
+        EDITED_CONFIGURED_TEMPLATES, true).contains(tBuilder.toString());
+    if (!category.hasNode(config.getTemplateName()) && !isExistedTemplate) {
+      templateService.createTemplate(category, config.getTitle(), config.getTemplateName(), new ByteArrayInputStream(
+          config.getTemplateData().getBytes()), new String[] { "*" });
+      Utils.addEditedConfiguredData(tBuilder.toString(), this.getClass().getSimpleName(), EDITED_CONFIGURED_TEMPLATES,
+          true);
     }
     Set<String> templateSet = configuredTemplates_.get(portletTemplateHome.getName());
     if (templateSet == null) {
       templateSet = new HashSet<String>();
     }
     templateSet.add(category.getName() + "/" + config.getTemplateName());
-    StringBuilder tBuilder = new StringBuilder();
-    tBuilder.append(config.getCategory()).append(config.getTemplateName());
-    Utils.addEditedConfiguredData(tBuilder.toString(), this.getClass().getSimpleName(), EDITED_CONFIGURED_TEMPLATES, true);
     configuredTemplates_.put(portletTemplateHome.getName(), templateSet);
   }
 
@@ -234,9 +234,6 @@ public class ApplicationTemplateManagerServiceImpl implements ApplicationTemplat
                           storedTemplateHomeNode.addNode(portletName,"nt:unstructured");
       storedTemplateHomeNode.save();
       for(PortletTemplateConfig config: map.get(portletName)) {
-        StringBuilder tBuilder = new StringBuilder();
-        tBuilder.append(config.getCategory()).append(config.getTemplateName());
-        if(Utils.getAllEditedConfiguredData(this.getClass().getSimpleName(), EDITED_CONFIGURED_TEMPLATES, true).contains(tBuilder.toString())) continue;
         addTemplate(templateNode,config);
       }
     }

--- a/core/services/src/main/java/org/exoplatform/services/cms/views/impl/ManageViewPlugin.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/views/impl/ManageViewPlugin.java
@@ -44,8 +44,8 @@ import java.util.Set;
 public class ManageViewPlugin extends BaseComponentPlugin {
 
   private static String ECM_EXPLORER_TEMPLATE = "ecmExplorerTemplate" ;
-  private static final String EDITED_CONFIGURED_VIEWS = "EditedConfiguredViews";
-  private static final String EDITED_CONFIGURED_VIEWS_TEMPLATES = "EditedConfiguredViewsTemplate";
+  public static final String EDITED_CONFIGURED_VIEWS = "EditedConfiguredViews";
+  public static final String EDITED_CONFIGURED_VIEWS_TEMPLATES = "EditedConfiguredViewsTemplate";
   private InitParams params_ ;
   private RepositoryService repositoryService_ ;
   private NodeHierarchyCreator nodeHierarchyCreator_ ;
@@ -151,12 +151,12 @@ public class ManageViewPlugin extends BaseComponentPlugin {
     String templateHomePath = nodeHierarchyCreator_.getJcrPath(alias) ;
     Node templateHomeNode = (Node)session.getItem(templateHomePath) ;
     String templateName = tempObject.getName() ;
+    configuredTemplate_.add(templateName);
     if(templateHomeNode.hasNode(templateName) || Utils.getAllEditedConfiguredData(
       this.getClass().getSimpleName(), EDITED_CONFIGURED_VIEWS_TEMPLATES, true).contains(templateName)) return;
     String warPath = warViewPath + tempObject.getWarPath() ;
     InputStream in = cservice_.getInputStream(warPath) ;
     templateService.createTemplate(templateHomeNode, templateName, templateName, in, new String[] {"*"});
-    configuredTemplate_.add(templateName);
     Utils.addEditedConfiguredData(templateName, this.getClass().getSimpleName(), EDITED_CONFIGURED_VIEWS_TEMPLATES, true);
   }
   

--- a/upgrade-plugins/src/main/java/org/exoplatform/ecms/upgrade/views/SiteExplorerTemplateUpgradePlugin.java
+++ b/upgrade-plugins/src/main/java/org/exoplatform/ecms/upgrade/views/SiteExplorerTemplateUpgradePlugin.java
@@ -33,7 +33,9 @@ import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.cms.BasePath;
 import org.exoplatform.services.cms.impl.DMSConfiguration;
 import org.exoplatform.services.cms.impl.DMSRepositoryConfiguration;
+import org.exoplatform.services.cms.impl.Utils;
 import org.exoplatform.services.cms.views.ManageViewService;
+import org.exoplatform.services.cms.views.impl.ManageViewPlugin;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
@@ -107,6 +109,10 @@ public class SiteExplorerTemplateUpgradePlugin extends UpgradeProductPlugin {
       //remove the old query nodes
       for (Node removedNode : removedNodes) {
         try {
+          String editedViewTemplates = removedNode.getName();
+          Utils.removeEditedConfiguredData(editedViewTemplates,
+                                           ManageViewPlugin.class.getSimpleName(), 
+                                           ManageViewPlugin.EDITED_CONFIGURED_VIEWS_TEMPLATES, true);
           removedNode.remove();
           ecmExplorerViewNode.save();
         } catch (Exception e) {
@@ -117,6 +123,10 @@ public class SiteExplorerTemplateUpgradePlugin extends UpgradeProductPlugin {
       }
       //re-initialize new views
       manageViewService_.init();
+      
+      if (log.isInfoEnabled()) {
+        log.info("Finish " + this.getClass().getName() + " successfully");
+      }
     } catch (Exception e) {
       if (log.isErrorEnabled()) {
         log.error("An unexpected error occurs when migrating Site Explorer views:", e);        

--- a/upgrade-plugins/src/main/java/org/exoplatform/ecms/upgrade/views/UserViewUpgradePlugin.java
+++ b/upgrade-plugins/src/main/java/org/exoplatform/ecms/upgrade/views/UserViewUpgradePlugin.java
@@ -28,8 +28,10 @@ import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
 import org.exoplatform.commons.utils.PrivilegedSystemHelper;
 import org.exoplatform.commons.version.util.VersionComparator;
 import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.cms.impl.Utils;
 import org.exoplatform.services.cms.views.ManageViewService;
 import org.exoplatform.services.cms.views.ViewConfig;
+import org.exoplatform.services.cms.views.impl.ManageViewPlugin;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -86,6 +88,9 @@ public class UserViewUpgradePlugin extends UpgradeProductPlugin {
       //remove the old query nodes
       for (Node removedNode : removedNodes) {
         try {
+          String editedViews = removedNode.getName();
+          Utils.removeEditedConfiguredData(editedViews, ManageViewPlugin.class.getSimpleName(),
+                                           ManageViewPlugin.EDITED_CONFIGURED_VIEWS, true);
           removedNode.remove();
           parentNode.save();
         } catch (Exception e) {
@@ -96,6 +101,11 @@ public class UserViewUpgradePlugin extends UpgradeProductPlugin {
       }
       //re-initialize new views
       manageViewService_.init();
+      
+      if (log.isInfoEnabled()) {
+        log.info("Finish " + this.getClass().getName() + " successfully");
+      }      
+      
     } catch (Exception e) {
       if (log.isErrorEnabled()) {
         log.error("An unexpected error occurs when migrating Site Explorer views:", e);        


### PR DESCRIPTION

Fix description:
* Always add configured view templates independently from the log.
* UserViewUpgradePlugin, SiteExplorerUpgradePlugin: remove all configured views in the log to allow reinitialization at the end of upgrade.