### PR TITLE
ECMS-6521: [PLF41-Migration] Some upgrade plugins don't work

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/BaseResourceLoaderService.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/BaseResourceLoaderService.java
@@ -143,7 +143,6 @@ public abstract class BaseResourceLoaderService implements Startable{
         if(Utils.getAllEditedConfiguredData(this.getClass().getSimpleName(), EDITED_CONFIGURED_SCRIPTS, true).contains(name)) {
           continue;
         }
-        Utils.addEditedConfiguredData(name, this.getClass().getSimpleName(), EDITED_CONFIGURED_SCRIPTS, true);
         String description = resource.getDescription();
         String path = warPath + "/" + name;
         InputStream in = cservice_.getInputStream(path);

--- a/core/services/src/main/java/org/exoplatform/services/cms/views/impl/ApplicationTemplateManagerServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/views/impl/ApplicationTemplateManagerServiceImpl.java
@@ -114,9 +114,6 @@ public class ApplicationTemplateManagerServiceImpl implements ApplicationTemplat
       templateSet = new HashSet<String>();
     }
     templateSet.add(category.getName() + "/" + config.getTemplateName());
-    StringBuilder tBuilder = new StringBuilder();
-    tBuilder.append(config.getCategory()).append(config.getTemplateName());
-    Utils.addEditedConfiguredData(tBuilder.toString(), this.getClass().getSimpleName(), EDITED_CONFIGURED_TEMPLATES, true);
     configuredTemplates_.put(portletTemplateHome.getName(), templateSet);
   }
 
@@ -235,7 +232,7 @@ public class ApplicationTemplateManagerServiceImpl implements ApplicationTemplat
       storedTemplateHomeNode.save();
       for(PortletTemplateConfig config: map.get(portletName)) {
         StringBuilder tBuilder = new StringBuilder();
-        tBuilder.append(config.getCategory()).append(config.getTemplateName());
+        tBuilder.append(config.getCategory()).append("/").append(config.getTemplateName());
         if(Utils.getAllEditedConfiguredData(this.getClass().getSimpleName(), EDITED_CONFIGURED_TEMPLATES, true).contains(tBuilder.toString())) continue;
         addTemplate(templateNode,config);
       }

--- a/core/services/src/main/java/org/exoplatform/services/cms/views/impl/ManageViewPlugin.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/views/impl/ManageViewPlugin.java
@@ -44,8 +44,8 @@ import java.util.Set;
 public class ManageViewPlugin extends BaseComponentPlugin {
 
   private static String ECM_EXPLORER_TEMPLATE = "ecmExplorerTemplate" ;
-  private static final String EDITED_CONFIGURED_VIEWS = "EditedConfiguredViews";
-  private static final String EDITED_CONFIGURED_VIEWS_TEMPLATES = "EditedConfiguredViewsTemplate";
+  public static final String EDITED_CONFIGURED_VIEWS = "EditedConfiguredViews";
+  public static final String EDITED_CONFIGURED_VIEWS_TEMPLATES = "EditedConfiguredViewsTemplate";
   private InitParams params_ ;
   private RepositoryService repositoryService_ ;
   private NodeHierarchyCreator nodeHierarchyCreator_ ;
@@ -106,13 +106,13 @@ public class ManageViewPlugin extends BaseComponentPlugin {
           this.getClass().getSimpleName(), EDITED_CONFIGURED_VIEWS, true).contains(viewNodeName)) continue ;
         Node viewNode = addView(viewHomeNode,viewNodeName,viewObject.getPermissions(),
                                 viewObject.isHideExplorerPanel(), viewObject.getTemplate()) ;
-        Utils.addEditedConfiguredData(viewNodeName, this.getClass().getSimpleName(), EDITED_CONFIGURED_VIEWS, true);
         for(Tab tab:viewObject.getTabList()) {
           addTab(viewNode,tab.getTabName(),tab.getButtons()) ;
         }
       }else if(object instanceof TemplateConfig) {
         templateObject = (TemplateConfig) object;
-        addTemplate(templateObject,session,warViewPath) ;
+        addTemplate(templateObject,session,warViewPath);
+        configuredTemplate_.add(templateObject.getName());
       }
     }
     session.save();
@@ -156,8 +156,6 @@ public class ManageViewPlugin extends BaseComponentPlugin {
     String warPath = warViewPath + tempObject.getWarPath() ;
     InputStream in = cservice_.getInputStream(warPath) ;
     templateService.createTemplate(templateHomeNode, templateName, templateName, in, new String[] {"*"});
-    configuredTemplate_.add(templateName);
-    Utils.addEditedConfiguredData(templateName, this.getClass().getSimpleName(), EDITED_CONFIGURED_VIEWS_TEMPLATES, true);
   }
   
   public Set<String> getConfiguredTemplates() {

--- a/core/webui-administration/src/main/java/org/exoplatform/ecm/webui/component/admin/script/UIScriptList.java
+++ b/core/webui-administration/src/main/java/org/exoplatform/ecm/webui/component/admin/script/UIScriptList.java
@@ -19,7 +19,6 @@ package org.exoplatform.ecm.webui.component.admin.script;
 import org.exoplatform.commons.utils.LazyPageList;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.commons.utils.ListAccessImpl;
-import org.exoplatform.services.cms.impl.BaseResourceLoaderService;
 import org.exoplatform.services.cms.impl.Utils;
 import org.exoplatform.services.cms.scripts.ScriptService;
 import org.exoplatform.services.wcm.core.NodetypeConstant;
@@ -187,7 +186,7 @@ public class UIScriptList extends UIComponentDecorator {
       String namePrefix = uiScriptList.getScriptCategory();
       try {
         scriptService.removeScript(namePrefix + "/" + scriptName, WCMCoreUtils.getUserSessionProvider());
-        Utils.addEditedConfiguredData(namePrefix + "/" + scriptName, BaseResourceLoaderService.class.getSimpleName(), EDITED_CONFIGURED_SCRIPTS, true);
+        Utils.addEditedConfiguredData(namePrefix + "/" + scriptName, "ScriptServiceImpl", EDITED_CONFIGURED_SCRIPTS, true);
       } catch(AccessDeniedException ace) {
         throw new MessageException(new ApplicationMessage("UIECMAdminControlPanel.msg.access-denied",
                                                           null, ApplicationMessage.WARNING));

--- a/core/webui-administration/src/main/java/org/exoplatform/ecm/webui/component/admin/script/UIScriptList.java
+++ b/core/webui-administration/src/main/java/org/exoplatform/ecm/webui/component/admin/script/UIScriptList.java
@@ -19,6 +19,8 @@ package org.exoplatform.ecm.webui.component.admin.script;
 import org.exoplatform.commons.utils.LazyPageList;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.commons.utils.ListAccessImpl;
+import org.exoplatform.services.cms.impl.BaseResourceLoaderService;
+import org.exoplatform.services.cms.impl.Utils;
 import org.exoplatform.services.cms.scripts.ScriptService;
 import org.exoplatform.services.wcm.core.NodetypeConstant;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
@@ -61,6 +63,8 @@ public class UIScriptList extends UIComponentDecorator {
   public static final String ACTION_SCRIPT_TYPE = "action";
   public static final String INTERCEPTOR_SCRIPT_TYPE = "interceptor";
   public static final String WIDGET_SCRIPT_TYPE = "widget";
+  
+  private static final String EDITED_CONFIGURED_SCRIPTS = "EditedConfiguredScripts";
 
   private String filter = ACTION_SCRIPT_TYPE;
 
@@ -183,6 +187,7 @@ public class UIScriptList extends UIComponentDecorator {
       String namePrefix = uiScriptList.getScriptCategory();
       try {
         scriptService.removeScript(namePrefix + "/" + scriptName, WCMCoreUtils.getUserSessionProvider());
+        Utils.addEditedConfiguredData(namePrefix + "/" + scriptName, BaseResourceLoaderService.class.getSimpleName(), EDITED_CONFIGURED_SCRIPTS, true);
       } catch(AccessDeniedException ace) {
         throw new MessageException(new ApplicationMessage("UIECMAdminControlPanel.msg.access-denied",
                                                           null, ApplicationMessage.WARNING));

--- a/core/webui-administration/src/main/java/org/exoplatform/ecm/webui/component/admin/templates/clv/UICLVTemplateList.java
+++ b/core/webui-administration/src/main/java/org/exoplatform/ecm/webui/component/admin/templates/clv/UICLVTemplateList.java
@@ -32,6 +32,7 @@ import org.exoplatform.commons.utils.ListAccessImpl;
 import org.exoplatform.ecm.webui.core.UIPagingGrid;
 import org.exoplatform.ecm.webui.utils.Utils;
 import org.exoplatform.services.cms.views.ApplicationTemplateManagerService;
+import org.exoplatform.services.cms.views.impl.ApplicationTemplateManagerServiceImpl;
 import org.exoplatform.services.wcm.core.NodetypeConstant;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.web.application.ApplicationMessage;
@@ -184,6 +185,11 @@ public class UICLVTemplateList extends UIPagingGrid {
                 clvTemplateList.getCategoryFromFilter(), 
                 template, 
                 WCMCoreUtils.getUserSessionProvider());
+        StringBuilder tBuilder = new StringBuilder();
+        tBuilder.append(clvTemplateList.getCategoryFromFilter()).append("/").append(template);
+        org.exoplatform.services.cms.impl.Utils.addEditedConfiguredData(tBuilder.toString(),
+            ApplicationTemplateManagerServiceImpl.class.getSimpleName(),
+            ApplicationTemplateManagerServiceImpl.EDITED_CONFIGURED_TEMPLATES, true);
       } catch (PathNotFoundException ex) {
         UIApplication uiApp = event.getSource().getAncestorOfType(UIApplication.class) ;
         uiApp.addMessage(new ApplicationMessage("UITCLVemplateList.msg.template-not-exist", null, ApplicationMessage.WARNING)) ;

--- a/core/webui-administration/src/main/java/org/exoplatform/ecm/webui/component/admin/views/UIECMTemplateList.java
+++ b/core/webui-administration/src/main/java/org/exoplatform/ecm/webui/component/admin/views/UIECMTemplateList.java
@@ -30,7 +30,9 @@ import org.exoplatform.commons.utils.ListAccessImpl;
 import org.exoplatform.ecm.webui.core.UIPagingGrid;
 import org.exoplatform.services.cms.BasePath;
 import org.exoplatform.services.cms.drives.ManageDriveService;
+import org.exoplatform.services.cms.impl.Utils;
 import org.exoplatform.services.cms.views.ManageViewService;
+import org.exoplatform.services.cms.views.impl.ManageViewPlugin;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.web.application.ApplicationMessage;
@@ -135,6 +137,7 @@ public class UIECMTemplateList extends UIPagingGrid {
       }
       try {
         vservice.removeTemplate(templatePath, WCMCoreUtils.getUserSessionProvider());
+        Utils.addEditedConfiguredData(templateName, ManageViewPlugin.class.getSimpleName(), ManageViewPlugin.EDITED_CONFIGURED_VIEWS_TEMPLATES, true);
       } catch (AccessDeniedException ex) {
         UIApplication app = uiECMTemp.getAncestorOfType(UIApplication.class);
         Object[] args = { "UIViewFormTabPane.label.option." + templateName };

--- a/core/webui-administration/src/main/java/org/exoplatform/ecm/webui/component/admin/views/UIViewList.java
+++ b/core/webui-administration/src/main/java/org/exoplatform/ecm/webui/component/admin/views/UIViewList.java
@@ -36,6 +36,7 @@ import org.exoplatform.services.cms.drives.DriveData;
 import org.exoplatform.services.cms.drives.ManageDriveService;
 import org.exoplatform.services.cms.views.ManageViewService;
 import org.exoplatform.services.cms.views.ViewConfig;
+import org.exoplatform.services.cms.views.impl.ManageViewPlugin;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.web.application.ApplicationMessage;
 import org.exoplatform.web.application.RequestContext;
@@ -197,6 +198,7 @@ public class UIViewList extends UIPagingGrid {
       }
 
       manageViewService.removeView(viewName);
+      org.exoplatform.services.cms.impl.Utils.addEditedConfiguredData(viewName, ManageViewPlugin.class.getSimpleName(), ManageViewPlugin.EDITED_CONFIGURED_VIEWS, true);
       viewList.refresh(viewList.getUIPageIterator().getCurrentPage());
       event.getRequestContext().addUIComponentToUpdateByAjax(viewList.getParent());
     }

--- a/upgrade-plugins/src/main/java/org/exoplatform/ecms/upgrade/script/ScriptUpgradePlugin.java
+++ b/upgrade-plugins/src/main/java/org/exoplatform/ecms/upgrade/script/ScriptUpgradePlugin.java
@@ -31,10 +31,8 @@ import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
 import org.exoplatform.commons.utils.PrivilegedSystemHelper;
 import org.exoplatform.commons.version.util.VersionComparator;
 import org.exoplatform.container.xml.InitParams;
-import org.exoplatform.services.cms.impl.Utils;
 import org.exoplatform.services.cms.scripts.ScriptService;
 import org.exoplatform.services.cms.scripts.impl.ScriptServiceImpl;
-import org.exoplatform.services.cms.views.impl.ApplicationTemplateManagerServiceImpl;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -57,7 +55,6 @@ public class ScriptUpgradePlugin extends UpgradeProductPlugin {
   
   private static final Log log = ExoLogger.getLogger(ScriptUpgradePlugin.class.getName());
   private ScriptService scriptService_;
-  private static final String EDITED_CONFIGURED_SCRIPTS = "EditedConfiguredScripts";
 
   
   public ScriptUpgradePlugin(ScriptService scriptService, InitParams initParams) {
@@ -99,14 +96,7 @@ public class ScriptUpgradePlugin extends UpgradeProductPlugin {
       //remove all old script nodes
       for (Node removedNode : removedNodes) {
         try {
-          String editedScript = removedNode.getParent().getParent().getName()
-                                .concat("/").concat(removedNode.getParent().getName())
-                                .concat("/").concat(removedNode.getName());
           removedNode.remove();
-          Utils.removeEditedConfiguredData(editedScript,
-                                           ScriptServiceImpl.class.getSimpleName(),
-                                           EDITED_CONFIGURED_SCRIPTS,
-                                           true);
           ecmExplorer.save();
         } catch (Exception e) {
           if (log.isInfoEnabled()) {

--- a/upgrade-plugins/src/main/java/org/exoplatform/ecms/upgrade/templates/WCMTemplateUpgradePlugin.java
+++ b/upgrade-plugins/src/main/java/org/exoplatform/ecms/upgrade/templates/WCMTemplateUpgradePlugin.java
@@ -31,7 +31,6 @@ import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
 import org.exoplatform.commons.utils.PrivilegedSystemHelper;
 import org.exoplatform.commons.version.util.VersionComparator;
 import org.exoplatform.container.xml.InitParams;
-import org.exoplatform.services.cms.impl.Utils;
 import org.exoplatform.services.cms.views.ApplicationTemplateManagerService;
 import org.exoplatform.services.cms.views.impl.ApplicationTemplateManagerServiceImpl;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
@@ -112,13 +111,8 @@ public class WCMTemplateUpgradePlugin extends UpgradeProductPlugin {
       //remove all old script nodes
       for (Node removedNode : removedNodes) {
         try {
-          String editedTemplate = removedNode.getParent().getName().concat(removedNode.getName());
           removedNode.remove();
           templateHomeNode.save();
-          Utils.removeEditedConfiguredData(editedTemplate,
-                                           ApplicationTemplateManagerServiceImpl.class.getSimpleName(),
-                                           ApplicationTemplateManagerServiceImpl.EDITED_CONFIGURED_TEMPLATES,
-                                           true);
         } catch (Exception e) {
           if (log.isInfoEnabled()) {
             log.error("Error in " + this.getName() + ": Can not remove old template: " + removedNode.getPath());


### PR DESCRIPTION
Problem analysis
- CLV templates, views, ecm templates are added to edited list during import progress. So they cannot be re-imported anymore.

Fix description
- Only add an item to edited list when it is removed.
