### PR TITLE
PLF-6122: Update groupID to icepdf 5.1.1

### DIFF
--- a/core/connector/pom.xml
+++ b/core/connector/pom.xml
@@ -108,7 +108,7 @@
       <artifactId>exo.portal.webui.portal</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.icepdf</groupId>
+      <groupId>org.icepdf.os</groupId>
       <artifactId>icepdf-core</artifactId>
     </dependency>
     <dependency>

--- a/core/services/pom.xml
+++ b/core/services/pom.xml
@@ -162,7 +162,7 @@
       <artifactId>exo.portal.webui.portlet</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.icepdf</groupId>
+      <groupId>org.icepdf.os</groupId>
       <artifactId>icepdf-core</artifactId>
     </dependency>
     <dependency>

--- a/core/services/src/main/java/org/exoplatform/services/pdfviewer/PDFViewerService.java
+++ b/core/services/src/main/java/org/exoplatform/services/pdfviewer/PDFViewerService.java
@@ -40,8 +40,6 @@ import org.exoplatform.services.cms.mimetype.DMSMimeTypeResolver;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.icepdf.core.exceptions.PDFException;
-import org.icepdf.core.exceptions.PDFSecurityException;
 import org.icepdf.core.pobjects.Document;
 /**
  * Created by The eXo Platform SAS

--- a/core/viewer/pom.xml
+++ b/core/viewer/pom.xml
@@ -47,7 +47,7 @@
       <artifactId>exo.portal.webui.portal</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.icepdf</groupId>
+      <groupId>org.icepdf.os</groupId>
       <artifactId>icepdf-core</artifactId>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Fix description:
* Add "os" to the groupID
* Remove unused imports in PDFViewerService