### PR TITLE
ECMS-6590: Node not found when using the LDAP when user logins

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/actions/impl/ScriptActionPlugin.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/actions/impl/ScriptActionPlugin.java
@@ -136,6 +136,9 @@ public class ScriptActionPlugin extends BaseActionPlugin implements ComponentPlu
   }
 
   public void executeAction(String userId, String executable, Map variables) throws Exception {
+    if (!variables.containsKey("userId")) {
+      variables.put("userId", userId);
+    }
     ScriptService scriptService =  WCMCoreUtils.getService(ScriptService.class);
     CmsScript cmsScript = scriptService.getScript(executable);
     cmsScript.execute(variables);

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/scripts/ecm-explorer/action/AddToFavorites.groovy
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/scripts/ecm-explorer/action/AddToFavorites.groovy
@@ -54,12 +54,16 @@ public class AddToFavoriteScript implements CmsScript {
     Map variables = (Map) context;
     String nodePath = (String) variables.get("nodePath");
     String workspace = (String) variables.get("srcWorkspace");
+    String activateUser = null;
+    if (variables.containsKey("userId")) {
+      activateUser = (String) variables.get("userId");
+    }
     try {
       if (ConversationState.getCurrent() == null) { 
         return;
       }
       String userID = ConversationState.getCurrent().getIdentity().getUserId();
-      if(userID.equals(IdentityConstants.ANONIM) || userID.equals(IdentityConstants.SYSTEM)) return;
+      if(userID.equals(IdentityConstants.ANONIM) || userID.equals(IdentityConstants.SYSTEM) || (activateUser != null && activateUser.equals(IdentityConstants.SYSTEM))) return;
       ExtendedNode userNode = (ExtendedNode)nodeHierarchyCreator_.getUserNode(WCMCoreUtils.getSystemSessionProvider(), userID);
       String favoritePath = nodeHierarchyCreator_.getJcrPath(FAVORITE_ALIAS);
       ExtendedNode favoriteNode = (ExtendedNode)userNode.getNode(favoritePath);


### PR DESCRIPTION
Problem analysis
- When user in a LDAP login without synchronization, the FirstLoginListener is activated to create user data. This listener requires to create several user nodes for example User Folder, Public Folder, Application Data.
- When a node is saved, the script AddToFavoriteScript, which requires User Favorite node, is triggered.
- During the first login, at first, the listener above creates User folder which is parent of User Favorite node. As the result, platform cannot find the favorite node in this case then exception occurs.
- When a user is synchronized, AddToFavoriteScript is still triggered but it incorrectly gets User Favorite node. In stead of getting one of synchronizing user, it gets one of current user which calls this REST or JMX. Because of this incorrect retrieval, the exception does not occur.

Fix description
- When user is synchronized, the AddToFavorite scripted will be triggered with __system user. Platform can verify this behavior to avoid running this script in this case.