### PR TITLE
ECMS-6185:SuperType is mandatory while adding a mixin

### DIFF
--- a/apps/portlet-administration/src/main/resources/locale/portlet/administration/ECMAdminPortlet_en.xml
+++ b/apps/portlet-administration/src/main/resources/locale/portlet/administration/ECMAdminPortlet_en.xml
@@ -561,7 +561,7 @@
     </action>
     <msg>
       <register-successfully>The '{0}' node type was registered successfully.</register-successfully>
-      <supertype-is-madatory>The super type is mandatory when you register a new node type. Please select at least one super type.</supertype-is-madatory>
+      <supertype-is-madatory>The super type is mandatory when you register a new non-mixin node type. Please select at least one super type.</supertype-is-madatory>
       <register-failed>The node type registration was unsuccessful. It either already exists or the super type is invalid.</register-failed>
       <nodeType-name>The node type name is required.</nodeType-name>
       <fileName-invalid>The file name has some invalid characters.</fileName-invalid>

--- a/core/webui-administration/src/main/java/org/exoplatform/ecm/webui/component/admin/nodetype/UINodeTypeForm.java
+++ b/core/webui-administration/src/main/java/org/exoplatform/ecm/webui/component/admin/nodetype/UINodeTypeForm.java
@@ -157,8 +157,7 @@ public class UINodeTypeForm extends UIFormTabPane {
                                         HAS_ORDERABLE_CHILDNODES,
                                         null))
                                         .addUIFormInput(new UIFormStringInput(PRIMARY_ITEMNAME, PRIMARY_ITEMNAME, null))
-                                        .addUIFormInput(new UIFormStringInput(SUPER_TYPE, SUPER_TYPE, null)
-                                        .addValidator(MandatoryValidator.class))
+                                        .addUIFormInput(new UIFormStringInput(SUPER_TYPE, SUPER_TYPE, null))
                                         .addUIFormInput(new UIFormInputInfo(PROPERTY_DEFINITIONS, PROPERTY_DEFINITIONS, null))
                                         .addUIFormInput(new UIFormInputInfo(CHILDNODE_DEFINITIONS,
                                                                             CHILDNODE_DEFINITIONS,


### PR DESCRIPTION
Fix description: remove mandatory validator of SuperType field
