### PR TITLE
ECMS-6561: Too many logs when previewing documents

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/pdfviewer/PDFViewerService.java
+++ b/core/services/src/main/java/org/exoplatform/services/pdfviewer/PDFViewerService.java
@@ -20,9 +20,7 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
@@ -137,8 +135,11 @@ public class PDFViewerService {
         File in = File.createTempFile(name + "_tmp", null);
         read(input, new BufferedOutputStream(new FileOutputStream(in)));
         long fileSize = in.length(); // size in byte
-        LOG.info("File size: " + fileSize + " B. Size limit for preview: " + (MAX_FILE_SIZE/(1024*1024)) + " MB");
-        if (fileSize < MAX_FILE_SIZE) { // ECMS-6329 only converts small file
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("File: " + name + "." + extension + 
+        		   ". Size: " + fileSize + " B. Size limit for preview: " + (MAX_FILE_SIZE/(1024*1024)) + " MB");
+        }
+        if (fileSize <= MAX_FILE_SIZE) { // ECMS-6329 only converts small file
         try {          	
           boolean success = jodConverter_.convert(in, content, "pdf");
           // If the converting failed then delete the content of temporary file
@@ -157,7 +158,7 @@ public class PDFViewerService {
           in.delete();
         }
         } else {
-          LOG.info("File is too big for preview.");	
+          LOG.info("File '" + name + "." + extension + "' is too big for preview.");	
           content.delete();
           content = null;
           in.delete();

--- a/core/services/src/main/java/org/exoplatform/services/pdfviewer/PDFViewerService.java
+++ b/core/services/src/main/java/org/exoplatform/services/pdfviewer/PDFViewerService.java
@@ -136,8 +136,8 @@ public class PDFViewerService {
         read(input, new BufferedOutputStream(new FileOutputStream(in)));
         long fileSize = in.length(); // size in byte
         if (LOG.isDebugEnabled()) {
-          LOG.debug("File: " + name + "." + extension + 
-        		   ". Size: " + fileSize + " B. Size limit for preview: " + (MAX_FILE_SIZE/(1024*1024)) + " MB");
+          LOG.debug("File '" + currentNode.getPath() +
+                    "' of " + fileSize + " B. Size limit for preview: " + (MAX_FILE_SIZE/(1024*1024)) + " MB");
         }
         if (fileSize <= MAX_FILE_SIZE) { // ECMS-6329 only converts small file
         try {          	
@@ -158,7 +158,7 @@ public class PDFViewerService {
           in.delete();
         }
         } else {
-          LOG.info("File '" + name + "." + extension + "' is too big for preview.");	
+          LOG.info("File '" + currentNode.getPath() + "' is too big for preview.");
           content.delete();
           content = null;
           in.delete();


### PR DESCRIPTION
Fix description:
* Only LOG in debug mode. Remove unused imports