### PR TITLE
ECMS-6423 [PDF Viewer] Missing file information when there isn't preview

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/pdfviewer/PDFViewerService.java
+++ b/core/services/src/main/java/org/exoplatform/services/pdfviewer/PDFViewerService.java
@@ -53,7 +53,8 @@ public class PDFViewerService {
   private static final Log LOG  = ExoLogger.getLogger(PDFViewerService.class.getName());
   private JodConverterService jodConverter_;
   private ExoCache<Serializable, Object> pdfCache;
-  private static final long MAX_FILE_SIZE = 5 * 1024 * 1024;//5MB
+  public static final long MAX_FILE_SIZE = 5 * 1024 * 1024; //5 MB
+  public static final long MAX_PAGES = 100; // 100 pages
   
   public PDFViewerService(RepositoryService repositoryService,
                           CacheService caService,

--- a/core/viewer/src/main/resources/resources/templates/PDFViewer.gtmpl
+++ b/core/viewer/src/main/resources/resources/templates/PDFViewer.gtmpl
@@ -234,13 +234,15 @@ if (uiParent != null) {
 	</div>
   </div>
 <% }else {
-    def errorMessage = "";
+    def errorMessage = _ctx.appRes("File.view.label.not-viewable");
+    def pageMsg = _ctx.appRes("File.view.label.pdf-max-page");
+    pageMsg = pageMsg.replace("{0}", (String) PDFViewerService.MAX_PAGES);
+    def sizeMsg = _ctx.appRes("File.view.label.pdf-max-size");
+    sizeMsg = sizeMsg.replace("{0}", (String) PDFViewerService.MAX_FILE_SIZE/(1024*1024));
     if (maximumPage > PDFViewerService.MAX_PAGES) {
-      errorMessage = java.text.MessageFormat.format(_ctx.appRes("File.view.label.pdf-max-page"), PDFViewerService.MAX_PAGES);
+      errorMessage = pageMsg;
     } else if (fileSize > PDFViewerService.MAX_FILE_SIZE) {
-      errorMessage = java.text.MessageFormat.format(_ctx.appRes("File.view.label.pdf-max-size"), (PDFViewerService.MAX_FILE_SIZE/(1024*1024)));
-    } else {
-      errorMessage = _ctx.appRes("File.view.label.not-viewable");
+      errorMessage = sizeMsg;
     }
 %>
       <div class="uiUnEditable clearfix">

--- a/core/viewer/src/main/resources/resources/templates/PDFViewer.gtmpl
+++ b/core/viewer/src/main/resources/resources/templates/PDFViewer.gtmpl
@@ -250,7 +250,7 @@ if (uiParent != null) {
           <i class="<%=Utils.getNodeTypeIcon(org.exoplatform.wcm.webui.Utils.getRealNode(currentNode), "uiIcon64x64")%>"></i>
         </div>
         <div class="detailContainer">
-          <h4><%=_ctx.appRes("File.view.label.not-viewable")%></h4>
+          <h4>$errorMessage</h4>
           <a class="btn btn-primary" href="$downloadLink"><%=_ctx.appRes("File.view.label.download")%></a>
           <span><%=_ctx.appRes("File.view.label.using-webDAV")%></span>
         </div>

--- a/core/viewer/src/main/resources/resources/templates/PDFViewer.gtmpl
+++ b/core/viewer/src/main/resources/resources/templates/PDFViewer.gtmpl
@@ -7,6 +7,7 @@
   import org.exoplatform.ecm.webui.utils.Utils;
   import org.exoplatform.services.jcr.RepositoryService;   
   import org.exoplatform.wcm.webui.reader.ContentReader;
+  import org.exoplatform.services.pdfviewer.PDFViewerService;
   
 	
   UIComponent uiParent = uicomponent.getParent();
@@ -151,6 +152,7 @@ if (uiParent != null) {
   def currentNode = uicomponent.getFileLangNode(uiParent.getNode());
   def contentNode = currentNode.getNode("jcr:content") ;
   def mimeType = contentNode.getProperty("jcr:mimeType").getString() ;
+  def fileSize = contentNode.getProperty("jcr:data").getStream().available();
   def currentPage = uicomponent.getPageNumber();
   def maximumPage = uicomponent.getMaximumOfPage();
   def currentRotation = uicomponent.getCurrentRotation();
@@ -160,7 +162,7 @@ if (uiParent != null) {
   rqcontext.getJavascriptManager().require("SHARED/ecm-utils", "ecmutil").
   addScripts('ecmutil.ECMUtils.onKeyPDFViewerPress();') ;	
 	
-  if (maximumPage > 0 && maximumPage < 100) {	
+  if (maximumPage > 0 && maximumPage <= PDFViewerService.MAX_PAGES) {
 %>    
 	<div class="UIPDFViewerContainer">   
  	 <div class="PDFViewerBar clearfix">
@@ -231,7 +233,16 @@ if (uiParent != null) {
 		</div>
 	</div>
   </div>
-<% }else {%>	
+<% }else {
+    def errorMessage = "";
+    if (maximumPage > PDFViewerService.MAX_PAGES) {
+      errorMessage = java.text.MessageFormat.format(_ctx.appRes("File.view.label.pdf-max-page"), PDFViewerService.MAX_PAGES);
+    } else if (fileSize > PDFViewerService.MAX_FILE_SIZE) {
+      errorMessage = java.text.MessageFormat.format(_ctx.appRes("File.view.label.pdf-max-size"), (PDFViewerService.MAX_FILE_SIZE/(1024*1024)));
+    } else {
+      errorMessage = _ctx.appRes("File.view.label.not-viewable");
+    }
+%>
       <div class="uiUnEditable clearfix">
         <div class="iconContainer">
           <i class="<%=Utils.getNodeTypeIcon(org.exoplatform.wcm.webui.Utils.getRealNode(currentNode), "uiIcon64x64")%>"></i>

--- a/packaging/wcm/webapp/src/main/resources/locale/ecm/views_en.xml
+++ b/packaging/wcm/webapp/src/main/resources/locale/ecm/views_en.xml
@@ -42,6 +42,8 @@
     <view>
       <label>
         <not-viewable>The preview of this document is not available.</not-viewable>
+        <pdf-max-size>The preview is not available for file larger than {0} MB.</pdf-max-size>
+        <pdf-max-page>The preview is not available for document of over {0} pages.</pdf-max-page>
         <using-webDAV>or Open in MS Office</using-webDAV>
         <file-size-too-big>The content of this file is too big. You should download and open in the client.</file-size-too-big>
         <webDAV>WebDAV View</webDAV>


### PR DESCRIPTION
Fix description: Give more information of the file in 2 cases:
* The document has more than 100 pages
* Office file is larger than 5 MB