### PR TITLE
ECMS-6697: Preview for CSV files

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/viewer/PDFViewerRESTService.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/viewer/PDFViewerRESTService.java
@@ -317,7 +317,7 @@ public class PDFViewerRESTService implements ResourceContainer {
         read(input, new BufferedOutputStream(new FileOutputStream(content)));
       } else {
         // create temp file to store original data of nt:file node
-        File in = File.createTempFile(name + "_tmp", null);
+        File in = File.createTempFile(name + "_tmp", "." + extension);
         read(input, new BufferedOutputStream(new FileOutputStream(in)));
         try {
           boolean success = jodConverter_.convert(in, content, "pdf");

--- a/core/services/src/main/java/org/exoplatform/services/pdfviewer/PDFViewerService.java
+++ b/core/services/src/main/java/org/exoplatform/services/pdfviewer/PDFViewerService.java
@@ -134,7 +134,7 @@ public class PDFViewerService {
         read(input, new BufferedOutputStream(new FileOutputStream(content)));
       } else {
         // create temp file to store original data of nt:file node
-        File in = File.createTempFile(name + "_tmp", null);
+        File in = File.createTempFile(name + "_tmp", "." + extension);
         read(input, new BufferedOutputStream(new FileOutputStream(in)));
         long fileSize = in.length(); // size in byte
         LOG.info("File size: " + fileSize + " B. Size limit for preview: " + (MAX_FILE_SIZE/(1024*1024)) + " MB");

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/dms-ext-configuration.xml
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/dms-ext-configuration.xml
@@ -841,6 +841,7 @@
 												<value><string>application/xlt</string></value>
 												<value><string>application/vnd.ms-powerpoint</string></value>
 												<value><string>application/vnd.ms-excel</string></value>
+												<value><string>text/csv</string></value>
 											</collection>
 										</field>
 									</object>

--- a/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/dms-thumbnail-configuration.xml
+++ b/packaging/wcm/webapp/src/main/webapp/WEB-INF/conf/dms-extension/dms/dms-thumbnail-configuration.xml
@@ -104,6 +104,7 @@
                                 <value><string>application/xlt</string></value>
                                 <value><string>application/vnd.ms-powerpoint</string></value>
                                 <value><string>application/vnd.ms-excel</string></value>
+                                <value><string>text/csv</string></value>
 							</collection>
 						</field>
 	        </object>


### PR DESCRIPTION
Fix description:
* Add MIMEtype of CSV files to the list for File Preview and Thumbnail Generation.
* Keep the original file extension in temporary file. That makes JODConverter work correctly.