### PR TITLE
ECMS-6763: [WCMAdvancedSearch] Missing search results in comparison with...

### DIFF
--- a/ext/authoring/services/src/main/java/org/exoplatform/services/wcm/extensions/publication/lifecycle/authoring/AuthoringPublicationPlugin.java
+++ b/ext/authoring/services/src/main/java/org/exoplatform/services/wcm/extensions/publication/lifecycle/authoring/AuthoringPublicationPlugin.java
@@ -19,6 +19,7 @@ import javax.jcr.ValueFactory;
 import javax.jcr.version.Version;
 import javax.portlet.PortletMode;
 
+import org.apache.commons.lang.StringUtils;
 import org.exoplatform.commons.utils.PageList;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.ecm.webui.utils.Utils;
@@ -538,9 +539,10 @@ public class AuthoringPublicationPlugin extends  WebpagePublicationPlugin {
    */
   private Node getLiveRevision(Node node) {
     try {
-      String nodeVersionUUID = node.getProperty(AuthoringPublicationConstant.LIVE_REVISION_PROP)
-                                   .getString();
-      if ("".equals(nodeVersionUUID)
+      String nodeVersionUUID = (node.hasProperty(AuthoringPublicationConstant.LIVE_REVISION_PROP)) ?
+        node.getProperty(AuthoringPublicationConstant.LIVE_REVISION_PROP).getString() : null;
+
+      if (StringUtils.isEmpty(nodeVersionUUID)
           && PublicationDefaultStates.PUBLISHED.equals(node.getProperty(AuthoringPublicationConstant.CURRENT_STATE)
                                                            .getString()))
         return node;


### PR DESCRIPTION
... Platform 4.0.7

Problem analysis:
- publication:liveRevision is an optional property.
- In AuthoringPublicationPlugin.getLiveRevision, this property is implicitly considered as mandatory.
  Exception happens when a published node hasn't that property but it wasn't thrown to server log.
  The node is therefore considered as non viewable.

Fix description:
- Check the existence of publication:liveRevision before getting its value.
- Handle also the case when this value is null.
