### PR TITLE
ECMs-6686: [Add view] View Name is automatically disappeared

### DIFF
--- a/core/webui-administration/src/main/java/org/exoplatform/ecm/webui/component/admin/views/UITabForm.java
+++ b/core/webui-administration/src/main/java/org/exoplatform/ecm/webui/component/admin/views/UITabForm.java
@@ -48,7 +48,7 @@ import org.exoplatform.webui.form.input.UICheckBoxInput;
         template = "app:/groovy/webui/component/admin/view/UITabForm.gtmpl",
         lifecycle = UIFormLifecycle.class,
         events = {    
-          @EventConfig(listeners = UITabForm.SaveActionListener.class),
+          @EventConfig(listeners = UITabForm.SaveActionListener.class, phase = Phase.DECODE),
           @EventConfig(listeners = UITabForm.CancelActionListener.class, phase = Phase.DECODE)
       }
 )


### PR DESCRIPTION
Problem analysis: View Name is refresh because of MandatoryValidator of Tab Name
Fix description: Add phase.Decode for Save Tab action
