### PR TITLE
ECMS-6904: [MultiUpload] Unicode values in the confirmation message w…

### DIFF
--- a/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/upload/UIMultiUpload.gtmpl
+++ b/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/upload/UIMultiUpload.gtmpl
@@ -2,8 +2,12 @@
   import java.net.URLEncoder;
   import org.apache.commons.lang.StringEscapeUtils;
   
-  public String getMsg(String msg) {
+  public String getMsgEscapeJS(String msg) {
     return StringEscapeUtils.escapeJavaScript(_ctx.appRes(uicomponent.getId() + ".label." + msg));
+  }
+
+  public String getMsg(String msg) {
+    return _ctx.appRes(uicomponent.getId() + ".label." + msg);
   }
 
   def rcontext = _ctx.getRequestContext() ;
@@ -12,18 +16,18 @@
   addScripts("multiUpload.initDropBox('" + uicomponent.getId() + "');").
   addScripts("multiUpload.setMaxFileSize(" + uicomponent.getLimitFileSize() + ");").
   addScripts("multiUpload.setMaxUploadCount(" + uicomponent.getMaxUploadCount() + ");").
-  addScripts("multiUpload.loadMsg('" + getMsg("in") + "','" + 
-                                       getMsg("MaxFileSizeAlert") + "','" + 
-                                       getMsg("Waiting") + "','" +
-                                       getMsg("Error") + "','" +
-                                       getMsg("or") + "','" +
-                                       getMsg("AlreadyInUse") + "','" +
-                                       getMsg("Keep") + "','" +
-                                       getMsg("Replace") + "','" +
-                                       getMsg("Canceled") + "','" +
-                                       getMsg("Cancel") + "','" +
-                                       getMsg("AbortAllConfirmation") + "');").
-  addScripts("multiUpload.setDropFileMessage('" + getMsg("DropFileMessage") + "');");
+  addScripts("multiUpload.loadMsg('" + getMsgEscapeJS("in") + "','" +
+                                       getMsgEscapeJS("MaxFileSizeAlert") + "','" +
+                                       getMsgEscapeJS("Waiting") + "','" +
+                                       getMsgEscapeJS("Error") + "','" +
+                                       getMsgEscapeJS("or") + "','" +
+                                       getMsgEscapeJS("AlreadyInUse") + "','" +
+                                       getMsgEscapeJS("Keep") + "','" +
+                                       getMsgEscapeJS("Replace") + "','" +
+                                       getMsgEscapeJS("Canceled") + "','" +
+                                       getMsgEscapeJS("Cancel") + "','" +
+                                       getMsgEscapeJS("AbortAllConfirmation") + "');").
+  addScripts("multiUpload.setDropFileMessage('" + getMsgEscapeJS("DropFileMessage") + "');");
 %>
 
 <div id="$uicomponent.id" class="uiMultiUpload clearfix noShow" >


### PR DESCRIPTION
…hen Aborting All Files

Problem analysis:
* Some messages are used as Javascript's parameter and HTML's value.
  In the former case, the illegal characters must be escaped.
  In the latter case, it doesn't need any processing else.

Fix description:
* Get the i18n label without escaping when it is used for HTML's value.