### PR TITLE
ECMS-6902: [IE9, IE10] Document Preview doesn't work

### DIFF
--- a/core/viewer/src/main/resources/resources/templates/PDFJSViewer.gtmpl
+++ b/core/viewer/src/main/resources/resources/templates/PDFJSViewer.gtmpl
@@ -489,6 +489,7 @@ if(uicomponent.isNotModernBrowser()) {
     <div id="printContainer"></div>
 
     <link rel="resource" type="application/l10n" href="/eXoWCMResources/pdf.js/locale/locale.properties" />
+    <script type="text/javascript" src="/eXoWCMResources/pdf.js/compatibility.js"></script>
     <script type="text/javascript" src="/eXoWCMResources/pdf.js/l10n.js"></script>
     <script type="text/javascript" src="/eXoWCMResources/pdf.js/pdf.js"></script>
     <script type="text/javascript">


### PR DESCRIPTION
Problem analysis:
* It lacks some JavaScript supports in IE 9 and IE 10 browsers.
  pdf.js handles this in compatibility.js but this file isn't loaded in Platform.

Fix description:
* Load compatibility.js in PDFJSViewer.gtmpl.