### PR TITLE
ECMS-6798:Category's name is displayed incorrectly in AS when categor…

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/taxonomy/impl/TaxonomyServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/taxonomy/impl/TaxonomyServiceImpl.java
@@ -476,6 +476,9 @@ public class TaxonomyServiceImpl implements TaxonomyService, Startable {
           categoryNode = (Node) rootNodeTaxonomy.getSession().getItem(category);
         }
         String categoryName = categoryNode.getName();
+        if (categoryNode.hasProperty("exo:title")) {
+          categoryName = categoryNode.getProperty("exo:title").getString();
+        }
         //add mix referenceable for node
         if (node.canAddMixin("mix:referenceable")) {
           node.addMixin("mix:referenceable");


### PR DESCRIPTION
…y contains accent chars

Fix description:
- Use Category's title for comment if it exist
