### PR TITLE
ECMS-6916: Error syntax displays when open office file from activity …

### DIFF
--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/wcm/frontoffice/public/OpenDocumentInOffice.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/wcm/frontoffice/public/OpenDocumentInOffice.js
@@ -50,13 +50,13 @@
       } else {
         openStatus = documentManager.JavaEditDocument(absolutePath, null, "/open-document/applet/ITHitMountOpenDocument.jar");
       }
-      console.log("Open "+ absolutePath+" is "+openStatus);
+      //console.log("Open "+ absolutePath+" is "+openStatus);
     } else {
       //ITHIT not detected, Use ActiveX to edit document.
       if(checkMSOfficeVersion()){
         eXo.ecm.OpenDocumentInOffice.EditDocument(absolutePath);
       }else{
-        console.log("Cannot open. MSOffice version is not support!");
+        //console.log("Cannot open. MSOffice version is not support!");
       }
     }
     if(uisideBarWidth === 0){ //hide side bar
@@ -100,7 +100,7 @@
 
           if(eXo.ecm.ECMWebDav !== undefined) {
             //showButton
-            console.log("ITHIT detected!");
+            //console.log("ITHIT detected!");
             if (data.isLocked) return;//can not edit, just show popup(do not change href)
           }else{
             if(!data.isMsoffice){
@@ -108,7 +108,7 @@
             }else{
               openDocument.removeClass("hidden");
             }
-            console.log("ITHIT not detected!");
+            //console.log("ITHIT not detected!");
             defaultEnviromentFilter(openDocument);//only show with support enviroment.
           }
         });
@@ -148,9 +148,9 @@
     var allowVersion = word.Version >= "14.0";
     if(allowVersion){
       var openStatus = obj.EditDocument(path, word.Version);
-      console.log("Open Document status: "+openStatus);
+      //console.log("Open Document status: "+openStatus);
     }else{
-      console.log("Open document not support!");
+      //console.log("Open document not support!");
       return false;
     }
   }
@@ -220,7 +220,7 @@
       var word = new ActiveXObject("Word.Application");
       return word.Version >= "14.0";
     }catch(err){
-      console.log("ActiveX is not support \n"+err);
+      //console.log("ActiveX is not support \n"+err);
       return false;
     }
     return false;


### PR DESCRIPTION
…stream on IE9

Problem analysis
- _console_ object is not available in IE 9 and below if user does not open Dev toolbar. Calling method of undefined object causes java script error.

Fix description
- Remove console.log from code because this line makes no sense in production.
