### PR TITLE
ECMS-6936: [WCM] Insert Content Link: Image displayed with redundant …

### DIFF
--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/wcm/frontoffice/private/ContentSelector.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/wcm/frontoffice/private/ContentSelector.js
@@ -976,6 +976,7 @@
 					window.opener.document.getElementById(eXp.getParameterValueByName("browserType")).value=strHTML;
 				} else {
 					if(nodeType.indexOf("image") >=0) {
+						name = escape(name);
 						strHTML += "<img src=\""+url+"\" name=\""+name+"\" alt=\""+name+"\"/>";
 					} else {
 						strHTML += "<a href=\"" + url+"\">"+name+"</a>";		


### PR DESCRIPTION
…text.

Fix description: Escape image's name before inserting into CKEditor
