### PR TITLE
ECMS-6258: Broken Document Preview with specific creation date.

### DIFF
--- a/core/viewer/src/main/java/org/exoplatform/ecm/webui/viewer/PDFViewer.java
+++ b/core/viewer/src/main/java/org/exoplatform/ecm/webui/viewer/PDFViewer.java
@@ -21,6 +21,8 @@ import org.exoplatform.download.InputStreamDownloadResource;
 import org.exoplatform.portal.webui.util.Util;
 import org.exoplatform.portal.webui.workspace.UIPortalApplication;
 import org.exoplatform.services.cms.mimetype.DMSMimeTypeResolver;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
 import org.exoplatform.services.pdfviewer.PDFViewerService;
 import org.exoplatform.services.resources.ResourceBundleService;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
@@ -83,6 +85,8 @@ import java.util.ResourceBundle;
  * PDF Viewer component which will be used to display PDF file on web browser
  */
 public class PDFViewer extends UIForm {
+
+  private static final Log LOG = ExoLogger.getExoLogger(PDFViewer.class);
 
   final static private String PAGE_NUMBER = "pageNumber";
   final static private String SCALE_PAGE = "scalePage";
@@ -186,11 +190,19 @@ public class PDFViewer extends UIForm {
       if(documentInfo.getProducer() != null && documentInfo.getProducer().length() > 0) {
         metadatas.put("producer", documentInfo.getProducer());
       }
-      if(documentInfo.getCreationDate() != null) {
-        metadatas.put("creationDate", documentInfo.getCreationDate().toString());
+      try {
+        if(documentInfo.getCreationDate() != null) {
+          metadatas.put("creationDate", documentInfo.getCreationDate().toString());
+        }
+      } catch (Exception e) {
+        LOG.debug("Error when getting creation date.", e);
       }
-      if(documentInfo.getModDate() != null) {
-        metadatas.put("modDate", documentInfo.getModDate().toString());
+      try {
+        if(documentInfo.getModDate() != null) {
+          metadatas.put("modDate", documentInfo.getModDate().toString());
+        }
+      } catch (Exception e) {
+        LOG.debug("Exception when getting modification date.", e);
       }
     }
   }

--- a/core/viewer/src/main/resources/resources/templates/PDFJSViewer.gtmpl
+++ b/core/viewer/src/main/resources/resources/templates/PDFJSViewer.gtmpl
@@ -34,11 +34,7 @@ if (uiParent != null) {
   }
 
   def rqcontext = _ctx.getRequestContext();
-  def currentPage = uicomponent.getPageNumber();
   def maximumPage = uicomponent.getMaximumOfPage();
-  def currentRotation = uicomponent.getCurrentRotation();
-  def currentScale = uicomponent.getCurrentScale();
-  def metadatas = uicomponent.getMetadataExtraction();
   
   PortalRequestContext portalRequestContext = Util.getPortalRequestContext();
   def lang = portalRequestContext.getLocale().getLanguage();
@@ -49,7 +45,12 @@ if (maximumPage > 0 && maximumPage <= PDFViewerService.MAX_PAGES && fileSize <= 
 
 if(uicomponent.isNotModernBrowser()) {
     rqcontext.getJavascriptManager().require("SHARED/ecm-utils", "ecmutil").
-    addScripts('ecmutil.ECMUtils.onKeyPDFViewerPress();') ;
+    addScripts('ecmutil.ECMUtils.onKeyPDFViewerPress();');
+
+    def currentPage = uicomponent.getPageNumber();
+    def currentRotation = uicomponent.getCurrentRotation();
+    def currentScale = uicomponent.getCurrentScale();
+    def metadatas = uicomponent.getMetadataExtraction();
 
   %>
     <head>


### PR DESCRIPTION
Problem analysis:
- PDFJSViewer.gtmpl triggers some methods in PDFViewer class which will read document's metadata information via ICEPdf's library.
- ICEPdf can parse date value in Ghostscript format but it requires the correct syntax.
- PDFViewer class doesn't handle possible exceptions thrown from ICEPdf's date parsing.

Fix description:
- Catch exception in PDFViewer when getting ICEPdf's date values.
- In PDFJSViewer.gtmpl: move the methods of PDFViewer specific to old browsers to the appropriate place.
