### PR TITLE
ECMS-7128 [Open in Office] Unable to save a document to Public folder

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/jcrext/activity/EditFilePropertyActivityAction.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/jcrext/activity/EditFilePropertyActivityAction.java
@@ -45,11 +45,11 @@ public class EditFilePropertyActivityAction implements Action{
     if(node.isNodeType(NodetypeConstant.NT_RESOURCE)) node = node.getParent();
     if(!node.getPrimaryNodeType().getName().equals(NodetypeConstant.NT_FILE)) return false;
     if(propertyName.equals(NodetypeConstant.JCR_DATA)) {
-      Node parent = node.getParent();
+      Node parent = WCMCoreUtils.getNodeBySystemSession(node).getParent();
       if(parent.hasNode(NodetypeConstant.EXO_THUMBNAILS_FOLDER)) {
         Node thumnail = parent.getNode(NodetypeConstant.EXO_THUMBNAILS_FOLDER);
         if(thumnail.hasNode(node.getUUID())) thumnail.getNode(node.getUUID()).remove();
-        node.getSession().save();
+        parent.save();
       }
     }
     //Notify to update activity

--- a/core/services/src/main/java/org/exoplatform/services/cms/jcrext/activity/EditFilePropertyActivityAction.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/jcrext/activity/EditFilePropertyActivityAction.java
@@ -45,6 +45,10 @@ public class EditFilePropertyActivityAction implements Action{
     if(node.isNodeType(NodetypeConstant.NT_RESOURCE)) node = node.getParent();
     if(!node.getPrimaryNodeType().getName().equals(NodetypeConstant.NT_FILE)) return false;
     if(propertyName.equals(NodetypeConstant.JCR_DATA)) {
+      // Save temporary data in current session for system session can see the update
+      node.getSession().save();
+
+      // Need system session to remove old thumbnail node
       Node parent = WCMCoreUtils.getNodeBySystemSession(node).getParent();
       if(parent.hasNode(NodetypeConstant.EXO_THUMBNAILS_FOLDER)) {
         Node thumnail = parent.getNode(NodetypeConstant.EXO_THUMBNAILS_FOLDER);

--- a/core/services/src/main/java/org/exoplatform/services/wcm/utils/WCMCoreUtils.java
+++ b/core/services/src/main/java/org/exoplatform/services/wcm/utils/WCMCoreUtils.java
@@ -716,4 +716,11 @@ public class WCMCoreUtils {
     }
     return barNavigationStyle;
   }
+
+  public static Node getNodeBySystemSession(Node node) throws RepositoryException {
+    node.getSession().save();
+    SessionProvider systemSessionProvider = getSystemSessionProvider();
+    return (Node) systemSessionProvider.getSession(node.getSession().getWorkspace().getName(), getRepository())
+            .getItem(node.getPath());
+  }
 }

--- a/core/services/src/main/java/org/exoplatform/services/wcm/utils/WCMCoreUtils.java
+++ b/core/services/src/main/java/org/exoplatform/services/wcm/utils/WCMCoreUtils.java
@@ -718,7 +718,6 @@ public class WCMCoreUtils {
   }
 
   public static Node getNodeBySystemSession(Node node) throws RepositoryException {
-    node.getSession().save();
     SessionProvider systemSessionProvider = getSystemSessionProvider();
     return (Node) systemSessionProvider.getSession(node.getSession().getWorkspace().getName(), getRepository())
             .getItem(node.getPath());


### PR DESCRIPTION
Analysis:
- Office file has thubmnail view.
- Updating an office file cause removing its old thumbnail.
- Login user can have no permission to edit on thumbnail folder
  Solution:
- Thubnail folder is specific for the system then we should always use system session to remove thumbmail
