### PR TITLE
ECMS-7248 Error showing PDF file in a linked detail page

### DIFF
--- a/apps/portlet-presentation/src/main/java/org/exoplatform/wcm/webui/scv/UIPresentationContainer.java
+++ b/apps/portlet-presentation/src/main/java/org/exoplatform/wcm/webui/scv/UIPresentationContainer.java
@@ -161,11 +161,12 @@ public class UIPresentationContainer extends UIContainer{
   public String getCurrentState() throws Exception {
     UIPresentation presentation = getChild(UIPresentation.class);
     Node node = presentation.getOriginalNode();
-    if (node!=null) {
+    if (node != null && node.hasProperty("publication:currentState")) {
       PublicationService publicationService = WCMCoreUtils.getService(PublicationService.class);
       return publicationService.getCurrentState(node);
+    } else {
+      return StringUtils.EMPTY;
     }
-    return "";
   }
 
   /**


### PR DESCRIPTION
Analysis: PDF file having no any publication life cycle causes NotInPublicationLifecycleException
Solution: Return StringUtils.EMPTY when getting current publication status if file has no any publication life cycle.
