### PR TITLE
ECMS-7271 Wrong display of PDF content after modification.

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/viewer/PDFViewerRESTService.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/viewer/PDFViewerRESTService.java
@@ -298,7 +298,10 @@ public class PDFViewerRESTService implements ResourceContainer {
     Node contentNode = currentNode.getNode("jcr:content");
     String lastModified = getJcrLastModified(currentNode);
 
-    if (path == null || !(content = new File(path)).exists() || !lastModified.equals(lastModifiedTime)) {
+    if (path == null
+            || !(content = new File(path)).exists()
+            || !lastModified.equals(lastModifiedTime)
+            || (content.length() != contentNode.getProperty("jcr:data").getLength())) {
       String mimeType = contentNode.getProperty("jcr:mimeType").getString();
       InputStream input = new BufferedInputStream(contentNode.getProperty("jcr:data").getStream());
       // Create temp file to store converted data of nt:file node
@@ -336,7 +339,9 @@ public class PDFViewerRESTService implements ResourceContainer {
       }
       if (content.exists()) {
         pdfCache.put(new ObjectKey(bd.toString()), content.getPath());
-        pdfCache.put(new ObjectKey(bd1.toString()), lastModified);
+        contentNode.setProperty("jcr:lastModified", content.lastModified());
+        contentNode.save();
+        pdfCache.put(new ObjectKey(bd1.toString()), Utils.getJcrContentLastModified(currentNode));
       }
     }
     return content;

--- a/core/services/src/main/java/org/exoplatform/services/pdfviewer/PDFViewerService.java
+++ b/core/services/src/main/java/org/exoplatform/services/pdfviewer/PDFViewerService.java
@@ -130,7 +130,10 @@ public class PDFViewerService {
     Node contentNode = currentNode.getNode("jcr:content");
     
     String lastModified = Utils.getJcrContentLastModified(currentNode);
-    if (path == null || !(content = new File(path)).exists() || !lastModified.equals(lastModifiedTime)) {
+    if (path == null
+            || !(content = new File(path)).exists()
+            || !lastModified.equals(lastModifiedTime)
+            || (content.length() != contentNode.getProperty("jcr:data").getLength())) {
       String mimeType = contentNode.getProperty("jcr:mimeType").getString();
       InputStream input = new BufferedInputStream(contentNode.getProperty("jcr:data").getStream());
       // Create temp file to store converted data of nt:file node
@@ -169,7 +172,9 @@ public class PDFViewerService {
       if (content.exists()) {
         if (contentNode.hasProperty("jcr:lastModified")) {
           pdfCache.put(new ObjectKey(bd.toString()), content.getPath());
-          pdfCache.put(new ObjectKey(bd1.toString()), lastModified);
+          contentNode.setProperty("jcr:lastModified", content.lastModified());
+          contentNode.save();
+          pdfCache.put(new ObjectKey(bd1.toString()), Utils.getJcrContentLastModified(currentNode));
         }
       }
     }


### PR DESCRIPTION
Analysis: jcr:lastModified of jcr:content is not updated after changing jcr:data
Solution: add condition comparing jcr:data stream size with file size to regenerate pdf and update pdfcache
