### PR TITLE
ECMS-7784 : check nullity on Row in ResultNode to avoid missing results

### DIFF
--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/ResultNode.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/ResultNode.java
@@ -81,9 +81,11 @@ public class ResultNode implements Node{
    */
   public ResultNode(Node node, Row row) throws RepositoryException{
     this.nodeLocation = NodeLocation.getNodeLocationByNode(node);
-    Value excerpt = row.getValue("rep:excerpt(.)");
-    this.excerpt = excerpt == null ? "" : excerpt.getString();
-    this.score = row.getValue("jcr:score").getLong();
+    if(row != null) {
+      Value excerpt = row.getValue("rep:excerpt(.)");
+      this.excerpt = excerpt == null ? "" : excerpt.getString();
+      this.score = row.getValue("jcr:score").getLong();
+    }
   }
 
   public ResultNode(Node node, float score, String excerpt) {

--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/SiteSearchServiceImpl.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/SiteSearchServiceImpl.java
@@ -843,7 +843,11 @@ public class SiteSearchServiceImpl implements SiteSearchService {
     @Override
     public ResultNode createData(Node node, Row row, SearchResult searchResult) {
       try {
-        return new ResultNode(node, row);
+        if(row == null && searchResult != null) {
+          return new ResultNode(node, searchResult.getRelevancy(), searchResult.getExcerpt());
+        } else {
+          return new ResultNode(node, row);
+        }
       } catch (Exception e) {
         return null;
       }


### PR DESCRIPTION
In the Documents search connector, if the content is retrieved from the Elasticsearch search results, the Row object (JCR) is null and since the ResultNode object is built on a Row object, it fails and the result is not added to the results list.
This fix check for Row nullity and use the Elasticsearch result data if Row is null.