### PR TITLE
ECMS-7628: Avoid displaying duplicated viewable node if their transla…

### DIFF
--- a/core/publication/src/main/java/org/exoplatform/services/wcm/publication/WCMComposerImpl.java
+++ b/core/publication/src/main/java/org/exoplatform/services/wcm/publication/WCMComposerImpl.java
@@ -353,7 +353,7 @@ public class WCMComposerImpl implements WCMComposer, Startable {
       while (nodeIterator.hasNext()) {
         node = nodeIterator.nextNode();
         viewNode = getViewableContent(node, filters);
-        if (viewNode != null) {
+        if (viewNode != null && !nodes.contains(viewNode)) {
           nodes.add(viewNode);
         }
       }


### PR DESCRIPTION
When displaying a  viewable node their translation should be not displayed, this fix's aim  to avoid displaying a node and its translation in paginated content 