### PR TITLE
ECMS-7956 Can't remove a copy of default personal folder

### DIFF
--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/base/LazyPageList.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/base/LazyPageList.java
@@ -99,7 +99,10 @@ public class LazyPageList<E> extends PageList{
         NodeIterator iter = ret.getNodes();
         RowIterator rowIter = ret.getRows();
         while (iter.hasNext()) {
-          currentListPage_.add(dataCreator_.createData(iter.nextNode(), rowIter.nextRow(), null));
+          E nodeData = dataCreator_.createData(iter.nextNode(), rowIter.nextRow(), null);
+          if (nodeData != null) {
+            currentListPage_.add(nodeData);
+          }
         }
       } catch (Exception e) {
         if (LOG.isErrorEnabled()) {

--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/base/PageListFactory.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/base/PageListFactory.java
@@ -282,7 +282,10 @@ public class PageListFactory {
             node = filter.filterNodeToDisplay(node);
           }
           if (node != null) {
-            filteredResults.add(dataCreator.createData(node, null, searchResult));
+            E nodeData = dataCreator.createData(node, null, searchResult);
+            if (nodeData != null) {
+              filteredResults.add(nodeData);
+            }
           }
         }
       } catch (RepositoryException e) {

--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -980,16 +980,48 @@ public class Utils {
   * @return personal default folder or not
  */
  public static boolean isPersonalDefaultFolder(Node node) throws Exception {
-   if (node.hasProperty(NodetypeConstant.JCR_PRIMARY_TYPE)) {
-     String nodeType = node.getProperty(NodetypeConstant.JCR_PRIMARY_TYPE).getString();
-     if (nodeType.equals(NodetypeConstant.NT_UNSTRUCTURED) || nodeType.equals(NodetypeConstant.NT_FOLDER)) {
-       for (String specificFolder : SPECIFIC_FOLDERS) {
-         if (node.isNodeType(specificFolder)) {
-           return true;
-         }
-       }
-     }
-   }
+    if (node.hasProperty(NodetypeConstant.JCR_PRIMARY_TYPE)) {
+      String nodeType = node.getProperty(NodetypeConstant.JCR_PRIMARY_TYPE).getString();
+      if (nodeType.equals(NodetypeConstant.NT_UNSTRUCTURED) || nodeType.equals(NodetypeConstant.NT_FOLDER)) {
+        for (String specificFolder : SPECIFIC_FOLDERS) {
+          if (node.isNodeType(specificFolder)) {
+            NodeHierarchyCreator nodeHierarchyCreator = WCMCoreUtils.getService(NodeHierarchyCreator.class);
+            String relativePathAlias = null;
+            switch (specificFolder) {
+            case "exo:folksonomyFolder":
+              relativePathAlias = "userPrivateFolksonomy";
+              break;
+            case NodetypeConstant.EXO_DOCUMENTFOLDER:
+              relativePathAlias = "userPrivateDocuments";
+              break;
+            case NodetypeConstant.EXO_FAVOURITE_FOLDER:
+              relativePathAlias = "userPrivateFavorites";
+              break;
+            case NodetypeConstant.EXO_PICTUREFOLDER:
+              relativePathAlias = "userPrivatePicture";
+              break;
+            case NodetypeConstant.EXO_MUSICFOLDER:
+              relativePathAlias = "userPrivateAudio";
+              break;
+            case NodetypeConstant.EXO_VIDEOFOLDER:
+              relativePathAlias = "userPrivateVideo";
+              break;
+            case NodetypeConstant.EXO_SEARCHFOLDER:
+              relativePathAlias = "userPrivateSearches";
+              break;
+            default:
+              break;
+            }
+            if (relativePathAlias != null) {
+              String relativePath = nodeHierarchyCreator.getJcrPath(relativePathAlias);
+              if (relativePath != null && node.getPath().endsWith(relativePath)) {
+                return true;
+              }
+            }
+          }
+        }
+      }
+    }
    String path = node.getPath();
    String owner = ((ExtendedNode) node).getACL().getOwner();
    if (StringUtils.isNotBlank(path) && StringUtils.isNotBlank(owner)) {

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/DocumentProviderUtils.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/DocumentProviderUtils.java
@@ -341,7 +341,9 @@ public class DocumentProviderUtils {
     @Override
     public NodeLinkAware createData(Node node, Row row, SearchResult searchResult) {
       try {
-        return (NodeLinkAware)parent.getNode(StringUtils.substringAfterLast(node.getPath(), "/"));
+        if (parent.hasNode(node.getName())) {
+          return (NodeLinkAware) parent.getNode(StringUtils.substringAfterLast(node.getPath(), "/"));
+        }
       } catch (RepositoryException e) {
         LOG.error("Can not create NodeLinkAware", e);
       }

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIDocumentNodeList.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIDocumentNodeList.java
@@ -126,12 +126,15 @@ public class UIDocumentNodeList extends UIContainer {
     }
     //add new UIDocumentNodeList children
     for (Node node : getNodeChildrenList()) {
+      if (node == null) {
+        continue;
+      }
       if (node instanceof NodeLinkAware) {
         node = ((NodeLinkAware)node).getRealNode();
       }
       try {
         Node targetNode = linkManager_.isLink(node) ? linkManager_.getTarget(node) : node;
-        if (targetNode.isNodeType(NodetypeConstant.NT_FOLDER) || targetNode.isNodeType(NodetypeConstant.NT_UNSTRUCTURED)) {
+        if (targetNode != null && targetNode.isNodeType(NodetypeConstant.NT_FOLDER) || targetNode.isNodeType(NodetypeConstant.NT_UNSTRUCTURED)) {
           addUIDocList(getID(node));
         }
       } catch(ItemNotFoundException ine) {

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/PasteManageComponent.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/PasteManageComponent.java
@@ -43,6 +43,8 @@ import org.exoplatform.services.cms.jcrext.activity.ActivityCommonService;
 import org.exoplatform.services.cms.link.LinkUtils;
 import org.exoplatform.services.cms.relations.RelationsService;
 import org.exoplatform.services.cms.thumbnail.ThumbnailService;
+import org.exoplatform.services.jcr.access.PermissionType;
+import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -63,20 +65,9 @@ import org.exoplatform.webui.ext.filter.UIExtensionFilters;
 import org.exoplatform.webui.ext.manager.UIAbstractManager;
 import org.exoplatform.webui.ext.manager.UIAbstractManagerComponent;
 
-import javax.jcr.AccessDeniedException;
-import javax.jcr.ItemExistsException;
-import javax.jcr.ItemNotFoundException;
-import javax.jcr.LoginException;
-import javax.jcr.Node;
-import javax.jcr.PathNotFoundException;
-import javax.jcr.Property;
-import javax.jcr.PropertyIterator;
-import javax.jcr.Session;
-import javax.jcr.Value;
-import javax.jcr.Workspace;
+import javax.jcr.*;
 import javax.jcr.lock.LockException;
-import javax.jcr.nodetype.ConstraintViolationException;
-import javax.jcr.nodetype.NodeType;
+import javax.jcr.nodetype.*;
 import javax.jcr.version.VersionException;
 
 import java.util.ArrayList;
@@ -587,24 +578,28 @@ public class PasteManageComponent extends UIAbstractManagerComponent {
         thumbnailService.copyThumbnailNode(srcThumbnailNode, destNode);
       }
     } catch (ConstraintViolationException ce) {
+      LOG.debug("Error pasting document from {} to {}", srcPath, destPath, ce);
       uiApp.addMessage(new ApplicationMessage("UIPopupMenu.msg.current-node-not-allow-paste", null,
           ApplicationMessage.WARNING));
 
       uiExplorer.updateAjax(event);
       return;
     } catch (VersionException ve) {
+      LOG.debug("Error pasting document from {} to {}", srcPath, destPath, ve);
       uiApp.addMessage(new ApplicationMessage("UIPopupMenu.msg.copied-node-in-versioning", null,
           ApplicationMessage.WARNING));
 
       uiExplorer.updateAjax(event);
       return;
     } catch (ItemExistsException iee) {
+      LOG.debug("Error pasting document from {} to {}", srcPath, destPath, iee);
       uiApp.addMessage(new ApplicationMessage("UIPopupMenu.msg.paste-node-same-name", null,
           ApplicationMessage.WARNING));
 
       uiExplorer.updateAjax(event);
       return;
     } catch (LoginException e) {
+      LOG.debug("Error pasting document from {} to {}", srcPath, destPath, e);
       if (ClipboardCommand.CUT.equals(type)) {
         uiApp.addMessage(new ApplicationMessage("UIPopupMenu.msg.cannot-login-node", null,
             ApplicationMessage.WARNING));
@@ -618,12 +613,14 @@ public class PasteManageComponent extends UIAbstractManagerComponent {
       uiExplorer.updateAjax(event);
       return;
     } catch (AccessDeniedException ace) {
+      LOG.debug("Error pasting document from {} to {}", srcPath, destPath, ace);
       uiApp.addMessage(new ApplicationMessage("UIPopupMenu.msg.access-denied", null,
           ApplicationMessage.WARNING));
 
       uiExplorer.updateAjax(event);
       return;
     } catch (LockException locke) {
+      LOG.debug("Error pasting document from {} to {}", srcPath, destPath, locke);
       Object[] arg = { srcPath };
       uiApp.addMessage(new ApplicationMessage("UIPopupMenu.msg.paste-lock-exception", arg,
           ApplicationMessage.WARNING));
@@ -633,6 +630,25 @@ public class PasteManageComponent extends UIAbstractManagerComponent {
 
       uiExplorer.updateAjax(event);
       return;
+    }
+  }
+
+  private static void changeCopiedNodeOwner(Node destNode) throws RepositoryException {
+    Node destNodeSystem = WCMCoreUtils.getNodeBySystemSession(destNode);
+    String userID = destNode.getSession().getUserID();
+
+    if (destNodeSystem.isNodeType(NodetypeConstant.EXO_OWNEABLE)) {
+      destNodeSystem.removeMixin(NodetypeConstant.EXO_OWNEABLE);
+      destNodeSystem.save();
+      destNode.refresh(true);
+    }
+    if (destNodeSystem.isNodeType(NodetypeConstant.EXO_PRIVILEGEABLE)) {
+      ((NodeImpl) destNodeSystem).setPermission(userID, PermissionType.ALL);
+      destNodeSystem.save();
+      destNode.refresh(true);
+    }
+    if (destNode.canAddMixin(NodetypeConstant.EXO_OWNEABLE)) {
+      destNode.addMixin(NodetypeConstant.EXO_OWNEABLE);
     }
   }
 
@@ -655,7 +671,9 @@ public class PasteManageComponent extends UIAbstractManagerComponent {
     Workspace workspace = session.getWorkspace();
     if (workspace.getName().equals(srcWorkspaceName)) {
       workspace.copy(srcPath, destPath);
+
       Node destNode = (Node) session.getItem(destPath);
+      changeCopiedNodeOwner(destNode);
       removeReferences(destNode);
     } else {
       try {

--- a/core/webui-explorer/src/test/java/org/exoplatform/ecm/webui/component/explorer/control/filter/IsNotSpecificFolderNodeFilterTest.java
+++ b/core/webui-explorer/src/test/java/org/exoplatform/ecm/webui/component/explorer/control/filter/IsNotSpecificFolderNodeFilterTest.java
@@ -4,6 +4,7 @@ import org.exoplatform.component.test.ConfigurationUnit;
 import org.exoplatform.component.test.ConfiguredBy;
 import org.exoplatform.component.test.ContainerScope;
 import org.exoplatform.ecms.test.BaseECMSTestCase;
+import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
 
 import javax.jcr.Node;
 import java.util.HashMap;
@@ -31,22 +32,6 @@ public class IsNotSpecificFolderNodeFilterTest extends BaseECMSTestCase {
     testFolder = session.getRootNode().addNode("testNotSpecificFolderNodeFilter", "nt:unstructured");
   }
 
-  public void testShouldReturnFalseWhenSpecificFolder() throws Exception {
-    // Given
-    Node folder = testFolder.addNode("testFolder", "nt:folder");
-    folder.addMixin("exo:favoriteFolder");
-    session.getRootNode().save();
-    Map<String, Object> context = new HashMap<>();
-    context.put(Node.class.getName(), folder);
-    IsNotSpecificFolderNodeFilter filter = new IsNotSpecificFolderNodeFilter();
-
-    // When
-    boolean accept = filter.accept(context);
-
-    // Then
-    assertFalse(accept);
-  }
-
   public void testShouldReturnFalseWhenPersonalPublicFolder() throws Exception {
     // Given
     Node folderPublic = testFolder.addNode("Private", "nt:folder").addNode("Public", "nt:folder");
@@ -60,6 +45,30 @@ public class IsNotSpecificFolderNodeFilterTest extends BaseECMSTestCase {
 
     // Then
     assertFalse(accept);
+  }
+
+  public void testShouldReturnTrueWhenNotPersonalFolder() throws Exception {
+    Node folderPublic = testFolder.addNode("Private", "nt:folder").addNode("Public", "nt:folder");
+    Node folderVideo = folderPublic.addNode("Videos", "nt:folder");
+    folderVideo.addMixin("exo:videoFolder");
+    session.save();
+
+    Map<String, Object> context = new HashMap<>();
+    context.put(Node.class.getName(), folderVideo);
+
+    assertTrue(new IsNotSpecificFolderNodeFilter().accept(context));
+  }
+
+  public void testShouldReturnFalseWhenPersonalFolder() throws Exception {
+    Node folderPrivate = testFolder.addNode("Private", "nt:folder");
+    Node folderVideo = folderPrivate.addNode("Videos", "nt:folder");
+    folderVideo.addMixin("exo:videoFolder");
+    session.save();
+
+    Map<String, Object> context = new HashMap<>();
+    context.put(Node.class.getName(), folderVideo);
+
+    assertFalse(new IsNotSpecificFolderNodeFilter().accept(context));
   }
 
   public void testShouldReturnTrueWhenNotSpecificFolder() throws Exception {

--- a/core/webui-explorer/src/test/resources/conf/ecms/configuration.xml
+++ b/core/webui-explorer/src/test/resources/conf/ecms/configuration.xml
@@ -40,4 +40,52 @@
 			</init-params>
 		</component-plugin>
 	</external-component-plugins>
+  <external-component-plugins>
+    <target-component>org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator</target-component>
+    <component-plugin>
+      <name>addUserPaths</name>
+      <set-method>addPlugin</set-method>
+      <type>org.exoplatform.services.jcr.ext.hierarchy.impl.UserAddPathPlugin</type>
+      <init-params>
+        <object-param>
+          <name>user.paths</name>
+          <description>User paths to create when initializing user home node</description>
+          <object type="org.exoplatform.services.jcr.ext.hierarchy.impl.HierarchyConfig">
+            <field name="workspaces">
+              <collection type="java.util.ArrayList">
+                <value>
+                  <string>collaboration</string>
+                </value>
+              </collection>
+            </field>
+            <field name="jcrPaths">
+              <collection type="java.util.ArrayList">
+                <value>
+                  <object type="org.exoplatform.services.jcr.ext.hierarchy.impl.HierarchyConfig$JcrPath">
+                    <field name="path">
+                      <string>Private/Videos</string>
+                    </field>
+                    <field name="permissions">
+                      <collection type="java.util.ArrayList"/>
+                    </field>
+                    <field name="mixinTypes">
+                      <collection type="java.util.ArrayList">
+                        <value>
+                          <string>exo:videoFolder</string>
+                        </value>
+                      </collection>
+                    </field>
+                    <field name="alias">
+                      <string>userPrivateVideo</string>
+                    </field>
+                  </object>
+                </value>
+              </collection>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
 </configuration>


### PR DESCRIPTION
The problem is that the filter applied to display or not the "Delete" button is not precise. It tests only on node mixinType. To make it more complete, the test to check if the folder is a default personal folder created by the system or not, is to check if the path and the mixin type matches configured default folders.
In addition, when copying a folder, the owner must be the user having copied the folder it self.