### PR TITLE
ECMS-7784 : Fix error "Invalid locale format" when Locale is an empty…

### DIFF
--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/connector/PageSearchServiceConnector.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/connector/PageSearchServiceConnector.java
@@ -81,7 +81,7 @@ public class PageSearchServiceConnector extends BaseSearchServiceConnector {
     } else {
       String[] siteNames = criteria.getSiteName().split(",");
       String localeParam = context.getParamValue(SearchContext.RouterParams.LANG.create());
-      Locale locale = localeParam != null ? LocaleUtils.toLocale(localeParam) : null;
+      Locale locale = StringUtils.isNotBlank(localeParam) ? LocaleUtils.toLocale(localeParam) : Locale.ENGLISH;
       if (siteNames.length == 1) {//just search for 1 site
         return siteSearch_.searchPageContents(WCMCoreUtils.getUserSessionProvider(),
                                               criteria, locale,(int)criteria.getLimit(), false);


### PR DESCRIPTION
… string (#498)

Fix error "Invalid locale format" when Locale is an empty String, If the LocalParam is not null or empty, we convert it from Locale param, otherwise, we return English as default Locale