### PR TITLE
ECMS-7960:media file format .WebM not supported

### DIFF
--- a/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/mimetype/mimetypes.properties
+++ b/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/mimetype/mimetypes.properties
@@ -203,3 +203,4 @@ zip=application/zip
 vsd=application/x-visio
 vst=application/x-visio
 vsw=application/x-visio
+webm=video/webm

--- a/core/services/src/test/resources/conf/mimetype/mimetypes.properties
+++ b/core/services/src/test/resources/conf/mimetype/mimetypes.properties
@@ -155,3 +155,4 @@ pptx=application/vnd.openxmlformats-officedocument.presentationml.presentation
 odg=application/vnd.oasis.opendocument.graphics
 svg=image/svg+xml
 sxw=application/vnd.sun.xml.writer
+webm=video/webm


### PR DESCRIPTION
- Problem: file format webM not played.
- Cause: Mime proprieties webM missing
- Solution:I add to file mimetypes.proprieties "webm=video/webm" to allow to media player play this type of video.