### PR TITLE
Fix/PLF-8622: Make sure that method createPageList doesn't throw an error.

### DIFF
--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/base/PageListFactory.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/base/PageListFactory.java
@@ -82,7 +82,7 @@ public class PageListFactory {
     // remove duplications
     results = new ArrayList<>(new LinkedHashSet<>(results));
 
-    if(criteria != null && criteria.getOffset() > 0) {
+    if(criteria != null && criteria.getOffset() > 0 && results.size() > 0) {
       results = results.subList((int) criteria.getOffset(), results.size());
     }
 


### PR DESCRIPTION
When clicking on show more results after accessing the page list for unified search results an error is thrown. After digging in this issue i found out that a sublist method is executed while the second parameter can be of size zero. I added a check to avoid executing the sublist method if the parameter is of size zero.