### PR TITLE
Fix/PLF-8622: Make sure that Unified Search doesn't throw an  ERROR in the logs while clicking on "Show more results" (#504)

### DIFF
--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/base/PageListFactory.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/base/PageListFactory.java
@@ -83,6 +83,9 @@ public class PageListFactory {
     results = new ArrayList<>(new LinkedHashSet<>(results));
 
     if(criteria != null && criteria.getOffset() > 0) {
+      if(criteria.getOffset() >= results.size()) {
+        return new ArrayNodePageList<>(0);
+      }
       results = results.subList((int) criteria.getOffset(), results.size());
     }
 

--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/connector/BaseSearchServiceConnector.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/connector/BaseSearchServiceConnector.java
@@ -112,6 +112,7 @@ public abstract class BaseSearchServiceConnector extends SearchServiceConnector 
       if (LOG.isErrorEnabled()) {
         LOG.error(e.getMessage(), e);
       }
+      return null;
     }
     return ret;
   }

--- a/core/search/src/test/java/org/exoplatform/services/wcm/search/TestSearchService.java
+++ b/core/search/src/test/java/org/exoplatform/services/wcm/search/TestSearchService.java
@@ -912,9 +912,9 @@ public class TestSearchService extends BaseSearchTest {
     int limit = pageSize;
     boolean isItemDuplicated = false;
 
+    queryCriteria = new QueryCriteria();
     queryCriteria.setSiteName("acme");
     queryCriteria.setKeyword(duplicationSearchKeyword);
-    queryCriteria = new QueryCriteria();
     queryCriteria.setSearchDocument(true);
     queryCriteria.setSearchWebContent(true);
     queryCriteria.setLiveMode(true);

--- a/core/search/src/test/java/org/exoplatform/services/wcm/search/connector/TestDocumentSearchServiceConnector.java
+++ b/core/search/src/test/java/org/exoplatform/services/wcm/search/connector/TestDocumentSearchServiceConnector.java
@@ -181,7 +181,14 @@ public class TestDocumentSearchServiceConnector extends BaseSearchTest {
           = documentSearch_.search(new SearchContext(new Router(new ControllerDescriptor()), "classic"), "anthony Felix~",
                                    sites, 
                                    1, 20, "title", "asc");
-    assertEquals(1, ret.size());//2
+    assertEquals(1, ret.size());//1
+    // Check when offset is greater than results size
+    ret
+            = documentSearch_.search(new SearchContext(new Router(new ControllerDescriptor()), "classic"), "anthony Felix~",
+            sites,
+            5, 20, "title", "asc");
+    assertNotNull(ret);// Should not fail
+    assertEquals(0, ret.size());//return 0
   }
   
   public void testSearchMultipleWithLimit() throws Exception {


### PR DESCRIPTION
While digging in this issue we found out that a process of subList method throws the error when there is no results. We added a condition for the case where the results size is lower than the offset to avoid executing the subList memthod.