### PR TITLE
PLF-8622-02: Avoid Arithmetic Exception when method getPageSize returns zero. (#505)

### DIFF
--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/base/PageListFactory.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/base/PageListFactory.java
@@ -84,7 +84,7 @@ public class PageListFactory {
 
     if(criteria != null && criteria.getOffset() > 0) {
       if(criteria.getOffset() >= results.size()) {
-        return new ArrayNodePageList<>(0);
+        return new ArrayNodePageList<>(pageSize);
       }
       results = results.subList((int) criteria.getOffset(), results.size());
     }


### PR DESCRIPTION
An Arithmetic Exception is thrown due the fact that the method getPageSize returns zero which is used as a Divisor in method checkAndSetPageand can not be zero, after diggingwe found out that the cause of this issue is due the fact that we instantiated a new ArrayNodePageList with pageSize equal to zero which must not be zero.