### PR TITLE
SOC-6150 : Space Groups Binding

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/drives/impl/ManageDriveServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/drives/impl/ManageDriveServiceImpl.java
@@ -624,8 +624,8 @@ public class ManageDriveServiceImpl implements ManageDriveService, Startable {
 
   protected List<String> getUserMemberships(String userId) throws Exception {
     List<String> memberships = null;
-    String currentUser = ConversationState.getCurrent().getIdentity().getUserId();
-    if(currentUser.equals(userId)) {
+    String currentUser = ConversationState.getCurrent() != null ? ConversationState.getCurrent().getIdentity().getUserId() : null;
+    if(currentUser != null && currentUser.equals(userId)) {
       memberships = Utils.getMemberships();
     } else {
       Collection<Membership> colMemberships = organizationService.getMembershipHandler().findMembershipsByUser(userId);


### PR DESCRIPTION
When a binding is added with the job, there is no current converstation, so the listener create a NPE
We add a test to prevent this error.