### PR TITLE
Fix/26787- Remove Cloud Drive connect button from explorer (#676)

### DIFF
--- a/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/dms-extension/dms/dms-clouddrives-configuration.xml
+++ b/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/dms-extension/dms/dms-clouddrives-configuration.xml
@@ -171,7 +171,9 @@
       <set-method>registerUIExtensionPlugin</set-method>
       <type>org.exoplatform.webui.ext.UIExtensionPlugin</type>
       <init-params>
-        <object-param>
+        <!-- PLF 6.1 Task 26787.
+         Hide connect cloud drive from explorer by commenting ShowConnectCloudDrive -->
+        <!--<object-param>
           <name>ShowConnectCloudDrive</name>
           <object type="org.exoplatform.webui.ext.UIExtension">
             <field name="type">
@@ -191,7 +193,7 @@
               </collection>
             </field>
           </object>
-        </object-param>
+        </object-param>-->
         <!-- Override ECMS actions that require special handling for Cloud Drive files: ManagePublications, ManageVersions -->
         <object-param>
           <name>ManagePublications</name>

--- a/ext/clouddrives-gdrive/webapp/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/ext/clouddrives-gdrive/webapp/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -66,7 +66,9 @@
   Dedicated ECMS menu action for Google Drive.
   Note that Google Drive will be added automatically to Connect Cloud Documents dialog
   -->
-  <external-component-plugins>
+  <!-- PLF 6.1 Task 26787.
+  Hide connect google drive from explorer by commenting ShowConnectCloudDrive -->
+  <!--<external-component-plugins>
     <target-component>org.exoplatform.webui.ext.UIExtensionManager</target-component>
     <component-plugin>
       <name>Add CloudDrive Actions</name>
@@ -96,7 +98,7 @@
         </object-param>
       </init-params>
     </component-plugin>
-  </external-component-plugins>
+  </external-component-plugins>-->
 
   <!--
   ResourceBundleService with texts for Google Drive UI support.

--- a/ext/clouddrives-onedrive/webapp/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/ext/clouddrives-onedrive/webapp/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -66,7 +66,9 @@
   Dedicated ECMS menu action for One Drive.
   Note that One Drive will be added automatically to Connect Cloud Documents dialog
   -->
-  <external-component-plugins>
+  <!-- PLF 6.1 Task 26787.
+  Hide connect OneDrive from explorer by commenting ShowConnectCloudDrive -->
+  <!--<external-component-plugins>
     <target-component>org.exoplatform.webui.ext.UIExtensionManager</target-component>
     <component-plugin>
       <name>Add CloudDrive Actions</name>
@@ -96,7 +98,7 @@
         </object-param>
       </init-params>
     </component-plugin>
-  </external-component-plugins>
+  </external-component-plugins>-->
 
   <!--
   ResourceBundleService with texts for One Drive UI support.


### PR DESCRIPTION
* Cloud Drives: fix cloud drive connect button in explorer (hide displaying via config)

(cherry picked from commit 0a688430dc0ef81ef6ecac8983f6d4ee8bcdd95f)

* Cloud Drives: fix onedrive and gdirve connect buttons in explorer (hide displaying via config)

(cherry picked from commit c57eb2701a1fa794e62309814d269dda5d5d5a36)

* Cloud Drives: add comments for hiding connect clouddrive buttons from explorer

(cherry picked from commit f9724bcc0cb147635cb442c1ce7fd70bb09d72ce)
(cherry picked from commit c422d57a8f5baf96614f0e5c803d046ac03be4da)