### PR TITLE
MAINT-26897 Fix Activity composer performances

### DIFF
--- a/ecm-wcm-extension/src/main/webapp/groovy/ecm/social-integration/plugin/space/FileUIActivity.gtmpl
+++ b/ecm-wcm-extension/src/main/webapp/groovy/ecm/social-integration/plugin/space/FileUIActivity.gtmpl
@@ -105,6 +105,7 @@ import static org.exoplatform.social.webui.activity.BaseUIActivity.TEMPLATE_PARA
     //params for init UIActivity javascript object
     def params = """ {
       activityId: '${activity.id}',
+      activityBody: `${activity.title}`,
       placeholderComment: '${placeholder}',
       inputWriteAComment: '$inputWriteAComment',
       commentMinCharactersAllowed: '${uicomponent.getCommentMinCharactersAllowed()}',
@@ -117,22 +118,10 @@ import static org.exoplatform.social.webui.activity.BaseUIActivity.TEMPLATE_PARA
       labels: $labels
     } """
 
-    String ckEditorType = new StringBuilder("editActivity").append(activity.id);
-    //params for init edit composer component
-    def composerParams = """ {
-      activityId: '${activity.id}',
-      composerAction: 'update',
-      ckEditorType: '${ckEditorType}',
-      activityBody: `${activity.title}`
-    } """
-
     def jsManager = Util.getPortalRequestContext().getJavascriptManager();
     jsManager.require("SHARED/jquery", "gj").addScripts("gj(document).ready(function() { gj(\"*[rel='tooltip']\").tooltip();});");
     jsManager.require("SHARED/social-ui-activity","activity").addScripts("activity.onLoad($params);");
-    jsManager.require("SHARED/wcm-utils", "wcmutil")
-    .require("SHARED/ActivityComposer", "activityComposer").addScripts("activityComposer.init($composerParams);");
-
-
+    jsManager.require("SHARED/wcm-utils", "wcmutil");
 
     //make sures commentFormFocused is set to false to prevent any refresh to focus, only focus after post a comment
     uicomponent.setCommentFormFocused(false);
@@ -156,7 +145,7 @@ import static org.exoplatform.social.webui.activity.BaseUIActivity.TEMPLATE_PARA
     uiform.begin();
     def viewerId = Utils.getViewerIdentity().getId();
 %>
-    <div id="activityComposer"></div>
+    <div id="activityComposer${activity.id}"></div>
     <div class="activityStream uiActivityStreamWrapper uiContentActivity fileActivity multiFilesActivity" id="activityContainer${activity.id}">
     <div class="boxContainer" id="boxContainer">
         <div id="ContextBox${activity.id}"class="uiBox contentBox">


### PR DESCRIPTION
Activity Composer is instanciated multiple times in Activity Stream: one for the activity composer to post new activities and other instances, one per Activity present in Stream to allow editing activity in composer. this strategy is very heavy on browser especially when posting new activity, in fact the AS gets updated and the Composer gets instantiated again each time there is an update in the AS (like, comment...)
To avoid this performance regression, a single instance of Activity composer will be used, and events through document.dispatchEvent will be used to open composer with editing activity details. See https://github.com/Meeds-io/social/pull/220