### PR TITLE
MAINT-26283 : Fix Document & PDF preview in File Explorer (#688)

### DIFF
--- a/core/viewer/src/main/resources/resources/templates/PDFJSViewer.gtmpl
+++ b/core/viewer/src/main/resources/resources/templates/PDFJSViewer.gtmpl
@@ -31,10 +31,7 @@ if (uiParent != null) {
   def mimeType = contentNode.getProperty("jcr:mimeType").getString();
   def title = org.exoplatform.ecm.webui.utils.Utils.getTitle(currentNode);
   def downloadLink = Utils.getDownloadRestServiceLink(originalNode);
-  def viewLink = downloadLink;
-  if(mimeType.toLowerCase().contains("pdf")) {
-    viewLink = Utils.getPDFViewerLink(originalNode);
-  }
+  def viewLink = Utils.getPDFViewerLink(originalNode);
 
   def rqcontext = _ctx.getRequestContext();
   def maximumPage = uicomponent.getMaximumOfPage();


### PR DESCRIPTION
PDF viewer link for Office documents was wrong and it sends directly the file without converting it to PDF.
This PR will use the same URL for all Office and PDF files.

(cherry picked from commit d04d14ca35ca694eae5858defc63a7a8050930e7)