### PR TITLE
Fix/27380 - Can't see OneDrive attachments preview when we launch the platform and open stream or space (#690)

### DIFF
--- a/ext/clouddrives-onedrive/services/src/main/java/org/exoplatform/services/cms/clouddrives/onedrive/JCRLocalOneDriveFile.java
+++ b/ext/clouddrives-onedrive/services/src/main/java/org/exoplatform/services/cms/clouddrives/onedrive/JCRLocalOneDriveFile.java
@@ -8,14 +8,14 @@ import java.util.Calendar;
 public class JCRLocalOneDriveFile extends JCRLocalCloudFile {
 
   /**
-   * The constant PERSONAL.
-   */
-  protected static final String PERSONAL = "personal";
-
-  /**
    * The constant BUSINESS.
    */
-  protected static final String BUSINESS = "business";
+  protected static final String BUSINESS     = "business";
+
+  /**
+   * The constant EMPTY_STRING.
+   */
+  protected static final String EMPTY_STRING = "";
 
   /**
    * The one drive api.
@@ -267,14 +267,18 @@ public class JCRLocalOneDriveFile extends JCRLocalCloudFile {
    */
   @Override
   public String getPreviewLink() {
-    String previewLink = "";
+    String previewLink;
 
     if (BUSINESS.equals(accountType)) {
       previewLink = api.getBusinessPreviewLink(this.getId());
-    }
+    } else {
+      // we try to get the personal onedrive file preview link
+      previewLink = super.getPreviewLink();
 
-    if (PERSONAL.equals(accountType)) {
-      previewLink = super.getPreviewLink();;
+      // if it's empty we get the business onedrive file preview link
+      if (previewLink == null || EMPTY_STRING.equals(previewLink)) {
+        previewLink = api.getBusinessPreviewLink(this.getId());
+      }
     }
 
     return previewLink;


### PR DESCRIPTION
Cloud Drive: correct the onedrive file preview link generation

(cherry picked from commit 7803c793c717590b9364e313d51bc9aee0016a05)
(cherry picked from commit 7ff25bdd92d95510cffbaffcb35a1983a86d2935)