### PR TITLE
Fix/27402 - Can't see any cloud file in the explorer or space documents if open and then refresh it (#692)

### DIFF
--- a/core/viewer/src/main/java/org/exoplatform/ecm/webui/filters/AbstractCloudDriveNodeFilter.java
+++ b/core/viewer/src/main/java/org/exoplatform/ecm/webui/filters/AbstractCloudDriveNodeFilter.java
@@ -54,6 +54,9 @@ public abstract class AbstractCloudDriveNodeFilter implements UIExtensionFilter 
   /** The Constant CONTENTVIEWER_REST_PATH. */
   protected static final String CONTENTVIEWER_REST_PATH = "/contentviewer/";
 
+  /** The constant UIJCREXPLORER_CONTEXT_NODE. */
+  public static final String UIJCREXPLORER_CONTEXT_NODE = "UIJCRExplorer.contextNode";
+
   /** The min size. */
   protected long                minSize;
 
@@ -113,7 +116,7 @@ public abstract class AbstractCloudDriveNodeFilter implements UIExtensionFilter 
       Node contextNode = (Node) context.get(Node.class.getName());
       if (contextNode == null) {
         WebuiRequestContext reqContext = WebuiRequestContext.getCurrentInstance();
-        contextNode = (Node) reqContext.getAttribute("uiJCRExplorerCurrentNode");
+        contextNode = (Node) reqContext.getAttribute(UIJCREXPLORER_CONTEXT_NODE);
         // case of file preview in Social activity stream
         if (contextNode == null) {
           contextNode = (Node) reqContext.getAttribute("UIDocumentPreviewNode");

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIJCRExplorer.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIJCRExplorer.java
@@ -89,6 +89,11 @@ public class UIJCRExplorer extends UIContainer {
    */
   private static final Log LOG  = ExoLogger.getLogger(UIJCRExplorer.class.getName());
 
+  /**
+   * The constant CONTEXT_NODE.
+   */
+  public static final String CONTEXT_NODE = "UIJCRExplorer.contextNode";
+
   private LinkedList<String> nodesHistory_ = new LinkedList<String>() ;
   private LinkedList<String> wsHistory_ = new LinkedList<String>();
   private PortletPreferences pref_ ;
@@ -262,8 +267,16 @@ public class UIJCRExplorer extends UIContainer {
       isShowDocumentViewForFile_ = true;
     }
     currentPath_ = currentPath;
+  }
+
+  /**
+   * Init UIJCRExplorer.contextNode attribute in order to use it for clouddrives.
+   * It allows to exclude cycle dependencies on webui-explorer
+   */
+  public void initContext() {
+    WebuiRequestContext ctx = WebuiRequestContext.getCurrentInstance();
     try {
-      ctx.setAttribute("uiJCRExplorerCurrentNode", getCurrentNode());
+      ctx.setAttribute(CONTEXT_NODE, getCurrentNode());
     } catch (Exception e) {
       LOG.warn("Exception while getting the current node for saving in WebuiRequestContext", e);
     }

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIJCRExplorerPortlet.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIJCRExplorerPortlet.java
@@ -224,6 +224,13 @@ public class UIJCRExplorerPortlet extends UIPortletApplication {
       explorerContainer.initExplorer();
       editContainer.getChild(UIJcrExplorerEditForm.class).setFlagSelectRender(false);
     }
+    UIJCRExplorer uiExplorer = explorerContainer.getChild(UIJCRExplorer.class);
+    if (uiExplorer != null) {
+      // Init UIJCRExplorer.contextNode attribute for explorer navigation and the file refreshing
+      // (when open a file in explorer or space documents;
+      // when refresh the session (refresh button) for current file in explorer or space documents)
+      uiExplorer.initContext();
+    }
   }
 
   public String getPreferenceRepository() {
@@ -474,6 +481,10 @@ public class UIJCRExplorerPortlet extends UIPortletApplication {
     uiActionbar.setRendered(isShowActionBar);
     uiExplorer.clearNodeHistory(addressPath);
     uiExplorer.setSelectNode(driveData.getWorkspace(), addressPath, homePath);
+    // Init UIJCRExplorer.contextNode attribute for the file refreshing and opening by link
+    // (when refresh the file current page (update browser page) in explorer or space documents;
+    // when open a file by link)
+    uiExplorer.initContext();
     UIDocumentWorkspace uiDocWorkspace = uiWorkingArea.getChild(UIDocumentWorkspace.class);
     uiDocWorkspace.setRenderedChild(UIDocumentContainer.class);
     uiDocWorkspace.setRendered(true);

--- a/core/webui/src/main/java/org/exoplatform/ecm/webui/clouddrives/CloudDriveContext.java
+++ b/core/webui/src/main/java/org/exoplatform/ecm/webui/clouddrives/CloudDriveContext.java
@@ -53,10 +53,13 @@ import org.exoplatform.webui.core.UIComponent;
 public class CloudDriveContext {
 
   /** The Constant JAVASCRIPT. */
-  protected static final String JAVASCRIPT = "CloudDriveContext_Javascript".intern();
+  protected static final String JAVASCRIPT                 = "CloudDriveContext_Javascript".intern();
 
   /** The Constant LOG. */
-  protected static final Log    LOG        = ExoLogger.getLogger(CloudDriveContext.class);
+  protected static final Log    LOG                        = ExoLogger.getLogger(CloudDriveContext.class);
+
+  /** The constant UIJCREXPLORER_CONTEXT_NODE. */
+  public static final String    UIJCREXPLORER_CONTEXT_NODE = "UIJCRExplorer.contextNode";
 
   /**
    * Initialize request with Cloud Drive support from given WebUI component.
@@ -69,7 +72,7 @@ public class CloudDriveContext {
 
     // when in document explorer
     WebuiRequestContext reqContext = WebuiRequestContext.getCurrentInstance();
-    contextNode = (Node) reqContext.getAttribute("uiJCRExplorerCurrentNode");
+    contextNode = (Node) reqContext.getAttribute(UIJCREXPLORER_CONTEXT_NODE);
 
     if (contextNode == null && uiComponent.getParent() instanceof UIBaseNodePresentation) {
       // when in social activity stream (file view)


### PR DESCRIPTION
* Cloud Drives: fix UIJCRExplorer.contextNode attribute initialization in order to refresh files properly

(cherry picked from commit 50298e1f5f3290040435ff6790971ba627469c06)

* Cloud Drives: clarify UIJCRExplorer.contextNode attribute initialization comments

(cherry picked from commit 273245fa0a9f493fabe318189451987ed2df7aba)
(cherry picked from commit acad36d3fe5937618aaddfefdd666cc8669e69b3)