### PR TITLE
Optimize indexed file contents in Elasticsearch (#704)

### DIFF
--- a/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-search-configuration.xml
+++ b/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-search-configuration.xml
@@ -100,6 +100,10 @@
             <type>org.exoplatform.services.wcm.search.connector.FileindexingConnector</type>
             <description>File ElasticSearch Indexing Connector</description>
             <init-params>
+                <value-param>
+                  <name>documents.content.indexing.mimetypes</name>
+                  <value>${exo.unified-search.indexing.supportedMimeTypes: text/.*, application/ms.* , application/vnd.* , application/xml , application/excel , application/powerpoint , application/xls, application/ppt , application/pdf , application/xhtml+xml , application/javascript , application/x-javascript , application/x-jaxrs+groovy , script/groovy}</value>
+                </value-param>
                 <properties-param>
                     <name>constructor.params</name>
                     <property name="index_alias" value="file_alias"/>

--- a/core/search/src/test/resources/conf/wcm/test-search-configuration.xml
+++ b/core/search/src/test/resources/conf/wcm/test-search-configuration.xml
@@ -965,6 +965,14 @@
       <type>org.exoplatform.services.wcm.search.connector.FileindexingConnector</type>
       <description>File ElasticSearch Indexing Connector</description>
       <init-params>
+        <value-param>
+          <name>documents.content.indexing.mimetypes</name>
+          <value>${exo.unified-search.indexing.file.supportedMimeTypes: text/.*, application/ms.* , application/vnd.* , application/xml , application/excel , application/powerpoint , application/xls, application/ppt , application/pdf , application/xhtml+xml , application/javascript , application/x-javascript , application/x-jaxrs+groovy , script/groovy}</value>
+        </value-param>
+        <value-param>
+          <name>documents.content.max.size.mb</name>
+          <value>${exo.unified-search.indexing.file.maxSize:20}</value>
+        </value-param>
         <properties-param>
           <name>constructor.params</name>
           <property name="index_alias" value="file_alias"/>


### PR DESCRIPTION
Currently content of all file types are indexed in ES while, it's whorthless to index content of files that aren't readable like images, videos, zip files...
This improvement will add two properties in Files Indexing Connector to limit file contents to index by:
1/ Mimetype
2/ File content size
When the file content or mimetype doesn't match allowed both conditions, an empty content of file will be sent to ES.

(cherry picked from commit ac51926dca1c2e1dc149569fbf34945c8d17cbf1)