### PR TITLE
MAINT-28064: Make sure that documents name with Cyrillic chars have correct file name on download.

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
@@ -16,37 +16,11 @@
  */
 package org.exoplatform.wcm.connector;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.HashSet;
-import java.util.Hashtable;
-import java.util.Locale;
-import java.util.Map;
-import java.util.ResourceBundle;
-import java.util.Set;
-
-import javax.jcr.ItemExistsException;
-import javax.jcr.Node;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.CacheControl;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.transform.dom.DOMSource;
-
-import com.ibm.icu.text.Transliterator;
 import org.apache.commons.lang.StringUtils;
 import org.exoplatform.common.http.HTTPStatus;
 import org.exoplatform.ecm.connector.fckeditor.FCKMessage;
 import org.exoplatform.ecm.connector.fckeditor.FCKUtils;
 import org.exoplatform.ecm.utils.lock.LockUtil;
-import org.exoplatform.ecm.utils.text.Text;
 import org.exoplatform.services.cms.documents.AutoVersionService;
 import org.exoplatform.services.cms.impl.Utils;
 import org.exoplatform.services.cms.jcrext.activity.ActivityCommonService;
@@ -65,6 +39,23 @@ import org.exoplatform.upload.UploadService.UploadLimit;
 import org.json.JSONObject;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+
+import javax.jcr.ItemExistsException;
+import javax.jcr.Node;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.CacheControl;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.dom.DOMSource;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.net.URLDecoder;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.*;
 
 /**
  * Created by The eXo Platform SAS
@@ -448,7 +439,7 @@ public class FileUploadHandler {
       Node file = null;
       Node jcrContent=null;
       boolean fileCreated = false;
-      String exoTitle = fileName;
+      String exoTitle = URLDecoder.decode(fileName, "UTF-8");
       
       fileName = Utils.cleanNameWithAccents(fileName);
       DMSMimeTypeResolver mimeTypeResolver = DMSMimeTypeResolver.getInstance();

--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/DownloadConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/DownloadConnector.java
@@ -1,8 +1,11 @@
 package org.exoplatform.wcm.connector.collaboration;
 
-import java.io.InputStream;
-import java.net.URLDecoder;
-import java.net.URLEncoder;
+import org.exoplatform.common.http.HTTPStatus;
+import org.exoplatform.ecm.utils.text.Text;
+import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.rest.resource.ResourceContainer;
+import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 
 import javax.jcr.AccessDeniedException;
 import javax.jcr.Node;
@@ -14,13 +17,9 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import org.exoplatform.common.http.HTTPStatus;
-import org.exoplatform.ecm.utils.text.Text;
-import org.exoplatform.services.jcr.core.ManageableRepository;
-import org.exoplatform.services.jcr.ext.common.SessionProvider;
-import org.exoplatform.services.rest.resource.ResourceContainer;
-import org.exoplatform.services.wcm.utils.WCMCoreUtils;
+import java.io.InputStream;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 
 /**
  * Enables downloading the content of _nt\:file_.
@@ -66,6 +65,8 @@ public class DownloadConnector implements ResourceContainer{
       if (node.hasProperty("exo:title")){
         fileName = node.getProperty("exo:title").getString();
       }
+      // decode the fileName in case the fileName is already encoded, for the old uploaded files.
+      fileName = URLDecoder.decode(fileName, "UTF-8");
       fileName = Text.unescapeIllegalJcrChars(fileName);
       fileName = URLEncoder.encode(fileName, "utf-8").replace("+", "%20");
       // In case version is specified, get file from version history


### PR DESCRIPTION
After digging in this issue we noticed that the uploaded file name in Cyrillic chars is stored in jcr encoded, so we made sure to store it in the correct way. Also we made sure that existing files that gets downloaded have the correct file name on upload by adding an additional decode for the file name.