### PR TITLE
MAINT-28623 : Create file activity just when commented (#711)

### DIFF
--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/CommentAddedActivityListener.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/CommentAddedActivityListener.java
@@ -57,7 +57,7 @@ public class CommentAddedActivityListener extends Listener<Node, Node> {
     commentContent = commentContent.replaceAll("&#64;","@");
     ExoSocialActivity commentActivity;
     if(currentNode.isNodeType(NodetypeConstant.NT_FILE)) {
-      commentActivity = Utils.postFileActivity(currentNode, commentContent, false, false, null, null);
+      commentActivity = Utils.postFileActivity(currentNode, commentContent, false, true, null, null);
     }else{
       commentActivity= Utils.postActivity(currentNode, commentContent, false, false, null, null);
     }

--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/ContentCreateActivityListener.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/ContentCreateActivityListener.java
@@ -42,6 +42,6 @@ public class ContentCreateActivityListener extends Listener<Object, Node> {
     if(!currentNode.getPrimaryNodeType().getName().equals(NodetypeConstant.NT_FILE))
       Utils.postActivity(currentNode, RESOURCE_BUNDLE_KEY_CREATED_BY, true, false, "", "");
     else
-    	Utils.postFileActivity(currentNode, RESOURCE_BUNDLE_KEY_CREATED_BY, true, false, "", "");
+    	Utils.postFileActivity(currentNode, RESOURCE_BUNDLE_KEY_CREATED_BY, true, true, "", "");
   }
 }

--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/ContentMovedActivityListener.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/ContentMovedActivityListener.java
@@ -18,9 +18,12 @@ package org.exoplatform.wcm.ext.component.activity.listener;
 
 import javax.jcr.Node;
 
+import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
 import org.exoplatform.services.wcm.core.NodetypeConstant;
+import org.exoplatform.social.core.manager.ActivityManager;
+
 /**
  * Created by The eXo Platform SAS
  * Author : Nguyen The Vinh From ECM Of eXoPlatform
@@ -31,8 +34,14 @@ import org.exoplatform.services.wcm.core.NodetypeConstant;
 public class ContentMovedActivityListener extends Listener<Node, String>{
   private static final String CONTENT_MOVED_BUNDLE = "SocialIntegration.messages.contentMoved";
   private static final String FILE_MOVED_BUNDLE    = "SocialIntegration.messages.fileMoved";
+  private static final String MOVE_CONTENT = "files:spaces.MOVE_COMMENT";
+
   @Override
   public void onEvent(Event<Node, String> event) throws Exception {
+    ActivityManager activityManager = CommonsUtils.getService(ActivityManager.class);
+    if(!activityManager.isActivityTypeEnabled(MOVE_CONTENT)) {
+      return;
+    }
     Node currentNode = event.getSource();
     String target = event.getData();
     if(!currentNode.getPrimaryNodeType().getName().equals(NodetypeConstant.NT_FILE))

--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/FileAddPropertyActivityListener.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/FileAddPropertyActivityListener.java
@@ -18,12 +18,14 @@ package org.exoplatform.wcm.ext.component.activity.listener;
 
 import javax.jcr.*;
 
+import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.services.cms.jcrext.activity.ActivityCommonService;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.wcm.core.NodetypeConstant;
+import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.webui.application.WebuiRequestContext;
 import org.exoplatform.webui.application.portlet.PortletRequestContext;
 
@@ -34,6 +36,7 @@ import org.exoplatform.webui.application.portlet.PortletRequestContext;
 public class FileAddPropertyActivityListener extends Listener<Node, String> {
 
   private static final Log LOG = ExoLogger.getExoLogger(FileAddPropertyActivityListener.class);
+  private static final String ADD_PROPERTY = "files:spaces.ADD_PROPERTY";
 
   private String[]  editedField     = {"dc:title", "dc:description", "dc:creator", "dc:source"};
   private String[]  bundleMessage   = {"SocialIntegration.messages.editTitle",
@@ -51,6 +54,11 @@ public class FileAddPropertyActivityListener extends Listener<Node, String> {
 
   @Override
   public void onEvent(Event<Node, String> event) throws Exception {
+  	ActivityManager activityManager = CommonsUtils.getService(ActivityManager.class);
+	if(!activityManager.isActivityTypeEnabled(ADD_PROPERTY)) {
+		return;
+	}
+
     Node currentNode = event.getSource();
     String propertyName = event.getData();
     StringBuilder newValueBuilder = new StringBuilder();

--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/FileCreateActivityListener.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/FileCreateActivityListener.java
@@ -18,8 +18,10 @@ package org.exoplatform.wcm.ext.component.activity.listener;
 
 import javax.jcr.Node;
 
+import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
+import org.exoplatform.social.core.manager.ActivityManager;
 
 /**
  * Created by The eXo Platform SAS Author : eXoPlatform exo@exoplatform.com Mar
@@ -28,7 +30,9 @@ import org.exoplatform.services.listener.Listener;
 public class FileCreateActivityListener extends Listener<Object, Node> {
   
   private static final String RESOURCE_BUNDLE_KEY_CREATED_BY = "SocialIntegration.messages.createdBy";
-  
+  private static final String FILES_SPACES = "files:spaces";
+  private static final String CREATION_COMMENT = "files:spaces.CREATION_COMMENT";
+
   /**
    * Instantiates a new post create content event listener.
    */
@@ -38,6 +42,9 @@ public class FileCreateActivityListener extends Listener<Object, Node> {
   @Override
   public void onEvent(Event<Object, Node> event) throws Exception {
     Node currentNode = event.getData();
-    Utils.postFileActivity(currentNode, RESOURCE_BUNDLE_KEY_CREATED_BY, true, false, "", "");
+    ActivityManager activityManager = CommonsUtils.getService(ActivityManager.class);
+    if(activityManager.isActivityTypeEnabled(FILES_SPACES) && activityManager.isActivityTypeEnabled(CREATION_COMMENT)) {
+      Utils.postFileActivity(currentNode, RESOURCE_BUNDLE_KEY_CREATED_BY, true, true, "", "");
+    }
   }
 }

--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/FileRemovePropertyActivityListener.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/FileRemovePropertyActivityListener.java
@@ -18,9 +18,11 @@ package org.exoplatform.wcm.ext.component.activity.listener;
 
 import javax.jcr.Node;
 
+import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
 import org.exoplatform.services.wcm.core.NodetypeConstant;
+import org.exoplatform.social.core.manager.ActivityManager;
 
 /**
  * Created by The eXo Platform SAS Author : eXoPlatform exo@exoplatform.com Mar
@@ -36,6 +38,7 @@ public class FileRemovePropertyActivityListener extends Listener<Node, String> {
                                        "SocialIntegration.messages.removeSource"};
   private boolean[] needUpdate       = {true, true, false, false, false};
   private int consideredFieldCount   = removedField.length;
+  private static final String REMOVE_PROPERTY = "files:spaces.REMOVE_PROPERTY";
   /**
    * Instantiates a new post edit content event listener.
    */
@@ -45,6 +48,10 @@ public class FileRemovePropertyActivityListener extends Listener<Node, String> {
 
   @Override
   public void onEvent(Event<Node, String> event) throws Exception {
+    ActivityManager activityManager = CommonsUtils.getService(ActivityManager.class);
+    if(!activityManager.isActivityTypeEnabled(REMOVE_PROPERTY)) {
+      return;
+    }
     Node currentNode = event.getSource();
     String propertyName = event.getData();
     

--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/FileUpdateActivityListener.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/FileUpdateActivityListener.java
@@ -23,6 +23,7 @@ import javax.jcr.*;
 
 import org.apache.commons.chain.Context;
 
+import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.services.cms.jcrext.activity.ActivityCommonService;
 import org.exoplatform.services.ext.action.InvocationContext;
 import org.exoplatform.services.jcr.dataflow.persistent.PersistedPropertyData;
@@ -33,6 +34,7 @@ import org.exoplatform.services.listener.Listener;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.wcm.core.NodetypeConstant;
+import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.webui.application.WebuiRequestContext;
 import org.exoplatform.webui.application.portlet.PortletRequestContext;
 
@@ -44,6 +46,7 @@ import org.exoplatform.webui.application.portlet.PortletRequestContext;
 public class FileUpdateActivityListener extends Listener<Context, String> {
 
   private static final Log LOG = ExoLogger.getLogger(FileUpdateActivityListener.class);
+  private static final String UPDATE_COMMENT = "files:spaces.UPDATE_COMMENT";
 
   private String[]  editedField     = {"exo:title", "exo:summary", "exo:language", "dc:title", "dc:description", "dc:creator", "dc:source", "jcr:data"};
   private String[]  bundleMessage   = {"SocialIntegration.messages.editName",
@@ -74,6 +77,10 @@ public class FileUpdateActivityListener extends Listener<Context, String> {
 
   @Override
   public void onEvent(Event<Context, String> event) throws Exception {
+	ActivityManager activityManager = CommonsUtils.getService(ActivityManager.class);
+	if(!activityManager.isActivityTypeEnabled(UPDATE_COMMENT)) {
+	  return;
+	}
     Context context = event.getSource();
     Property currentProperty = (Property) context.get(InvocationContext.CURRENT_ITEM);
     Property previousProperty = (Property) context.get(InvocationContext.PREVIOUS_ITEM);

--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/Utils.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/Utils.java
@@ -122,7 +122,7 @@ public class Utils {
   }
   public static Map<String, String> populateActivityData(Node node,
                                                          String activityOwnerId, String activityMsgBundleKey, 
-                                                         boolean isSystemComment, String systemComment, String perm) throws Exception {
+                                                         boolean isComment, String systemComment, String perm) throws Exception {
     /** The date formatter. */
     DateFormat dateFormatter = null;
     dateFormatter = new SimpleDateFormat(ISO8601.SIMPLE_DATETIME_FORMAT);
@@ -176,8 +176,8 @@ public class Utils {
     activityParams.put(ContentUIActivity.MIME_TYPE, getMimeType(linkManager.isLink(node)?linkManager.getTarget(node, true):node));
     activityParams.put(ContentUIActivity.IMAGE_PATH, illustrationImg);
     activityParams.put(ContentUIActivity.IMAGE_PATH, illustrationImg);
-    if (isSystemComment) {
-      activityParams.put(ContentUIActivity.IS_SYSTEM_COMMENT, String.valueOf(isSystemComment));
+    if (isComment && StringUtils.isNotBlank(systemComment)) {
+      activityParams.put(ContentUIActivity.IS_SYSTEM_COMMENT, String.valueOf(isComment));
     	activityParams.put(ContentUIActivity.SYSTEM_COMMENT, systemComment);
     }else{
       activityParams.put(ContentUIActivity.IS_SYSTEM_COMMENT, String.valueOf(false));
@@ -419,13 +419,13 @@ public class Utils {
    * 
    * @param node : activity raised from this source
    * @param activityMsgBundleKey
-   * @param isSystemComment
+   * @param isComment
    * @param systemComment the new value of System Posted activity, 
    *        if (isSystemComment) systemComment can not be set to null, set to empty string instead of.
    * @throws Exception
    */
   public static ExoSocialActivity postFileActivity(Node node, String activityMsgBundleKey, boolean needUpdate, 
-                                  boolean isSystemComment, String systemComment, String perm) throws Exception {
+                                  boolean isComment, String systemComment, String perm) throws Exception {
     Object isSkipRaiseAct = DocumentContext.getCurrent()
                                            .getAttributes()
                                            .get(DocumentContext.IS_SKIP_RAISE_ACT);
@@ -451,7 +451,7 @@ public class Utils {
     // get owner
     String activityOwnerId = getActivityOwnerId(node);
     String nodeActivityID;
-    ExoSocialActivity exa =null;    
+    ExoSocialActivity exa =null;
     if (node.isNodeType(ActivityTypeUtils.EXO_ACTIVITY_INFO)) {
       try {
         nodeActivityID = node.getProperty(ActivityTypeUtils.EXO_ACTIVITY_ID).getString();
@@ -472,11 +472,11 @@ public class Utils {
     }
     if (activity==null) {
       activity = createActivity(identityManager, activityOwnerId,
-                                node, activityMsgBundleKey, activityType, isSystemComment, systemComment, perm);
+                                node, activityMsgBundleKey, activityType, isComment, systemComment, perm);
       setActivityType(null);
     }
     
-    if (exa!=null) {
+    if (exa != null) {
       if (commentFlag) {
         Map<String, String> paramsMap = activity.getTemplateParams();
         String paramMessage = paramsMap.get(ContentUIActivity.MESSAGE);
@@ -539,7 +539,7 @@ public class Utils {
         } catch (Exception e) {
           LOG.info("No activity is deleted, return no related activity");
         }
-        if (exa != null && !commentFlag && isSystemComment) {
+        if (exa != null && !commentFlag && isComment) {
           activity.setId(null);
           updateNotifyMessages(activity, activity.getTemplateParams().get(ContentUIActivity.MESSAGE), activity.getTemplateParams().get(ContentUIActivity.SYSTEM_COMMENT));
           activityManager.saveComment(exa, activity);


### PR DESCRIPTION
This fix makes sure that :

 - File activities are created when the files:spaces activity type and the comment activity type are enabled
 - For every action we have a comment activity type that we can enable/disable
 - Only when commenting directly a File will generate the activity will be created with a comment

(cherry picked from commit 7510b8ede128a3fadcd0a1c70824389a9396e321)