### PR TITLE
MAINT-29010 : No need to remove dot from file names (#712)

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -694,7 +694,7 @@ public class Utils {
 
   public static String cleanName(String oldName) {
     if (StringUtils.isEmpty(oldName)) return oldName;
-    String specialChar = "&#*@'\"\t\r\n$\\><:;[]/%|.";
+    String specialChar = "&#*@'\"\t\r\n$\\><:;[]/%|";
     StringBuilder ret = new StringBuilder();
     for (int i = 0; i < oldName.length(); i++) {
       char currentChar = oldName.charAt(i);

--- a/core/services/src/test/java/org/exoplatform/services/cms/impl/UtilsTest.java
+++ b/core/services/src/test/java/org/exoplatform/services/cms/impl/UtilsTest.java
@@ -9,7 +9,7 @@ public class UtilsTest extends TestCase {
     String title1 = "test | test";
     String title2 = "test % test";
     String title3 = "test & test";
-    String title4 = "test . test";
+    String title4 = "test @ test";
     String title5 = "test $ test";
     String title6 = "test / test";
     String title7 = "test [ test";
@@ -25,7 +25,6 @@ public class UtilsTest extends TestCase {
     String title17 = "test < test";
     String title18 = "test # test";
     String title19 = "test * test";
-    String title20 = "test @ test";
 
     // When
     String titleClean1 = Utils.cleanName(title1);
@@ -47,10 +46,8 @@ public class UtilsTest extends TestCase {
     String titleClean17 = Utils.cleanName(title17);
     String titleClean18 = Utils.cleanName(title18);
     String titleClean19 = Utils.cleanName(title19);
-    String titleClean20 = Utils.cleanName(title20);
 
     // Then
-    assertEquals(titleClean20,"test-test");
     assertEquals(titleClean1,"test-test");
     assertEquals(titleClean2,"test-test");
     assertEquals(titleClean3,"test-test");


### PR DESCRIPTION
There is no need to clean the dot (.) character from file names.

(cherry picked from commit b1e10cea87dd7943553ffd90519d1a8924819baf)