### PR TITLE
MAINT-27234 : Enable/disable thumbnails by configuration

### DIFF
--- a/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-services-configuration.xml
+++ b/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-services-configuration.xml
@@ -139,33 +139,6 @@
     </component>
 
     <component>
-        <key>org.exoplatform.services.cms.thumbnail.ThumbnailService</key>
-        <type>org.exoplatform.services.cms.thumbnail.impl.ThumbnailServiceImpl</type>
-        <init-params>
-            <value-param>
-                <name>smallSize</name>
-                <value>32x32</value>
-            </value-param>
-            <value-param>
-                <name>mediumSize</name>
-                <value>116x116</value>
-            </value-param>
-            <value-param>
-                <name>bigSize</name>
-                <value>300x300</value>
-            </value-param>
-            <value-param>
-                <name>enable</name>
-                <value>false</value>
-            </value-param>
-            <value-param>
-                <name>mimetypes</name>
-                <value>image/jpeg;image/png;image/gif;image/bmp</value>
-            </value-param>
-        </init-params>
-    </component>
-
-    <component>
         <key>org.exoplatform.services.cms.views.ApplicationTemplateManagerService</key>
         <type>org.exoplatform.services.cms.views.impl.ApplicationTemplateManagerServiceImpl</type>
     </component>

--- a/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/dms-extension/dms/dms-thumbnail-configuration.xml
+++ b/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/dms-extension/dms/dms-thumbnail-configuration.xml
@@ -23,7 +23,7 @@
       </value-param>
       <value-param>
       	<name>enable</name>
-	      <value>true</value>
+	      <value>${exo.ecms.document.thumbnails.enabled:true}</value>
       </value-param>
       <value-param>
         <name>mimetypes</name>


### PR DESCRIPTION
Added the external configuration **exo.ecms.document.thumbnails.enabled** to enable/disable generating thumbnail icons 