### PR TITLE
TASK-37045: Update new created document language before opening it in onlyOffice

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/documents/DocumentMetadataPlugin.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/documents/DocumentMetadataPlugin.java
@@ -6,6 +6,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.exoplatform.services.cms.documents.exception.DocumentExtensionNotSupportedException;
+import org.exoplatform.webui.application.WebuiRequestContext;
 
 /**
  * The Interface DocumentMetadataPlugin is used to add metadata to the documents.
@@ -23,10 +24,12 @@ public interface DocumentMetadataPlugin {
    * @throws IOException the IOException
    * @throws DocumentExtensionNotSupportedException the DocumentExtensionNotSupportedException
    */
-  InputStream updateMetadata(String extension,
+  InputStream updateMetadata(WebuiRequestContext context,
+                             String extension,
                              InputStream source,
                              Date created,
-                             String creator) throws IOException, DocumentExtensionNotSupportedException;
+                             String creator,
+                             String language) throws IOException, DocumentExtensionNotSupportedException;
 
   /**
    * Gets the supported extensions.

--- a/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImpl.java
@@ -42,6 +42,10 @@ import javax.jcr.query.QueryResult;
 
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.portal.localization.LocaleContextInfoUtils;
+import org.exoplatform.services.resources.LocaleContextInfo;
+import org.exoplatform.services.resources.LocalePolicy;
 import org.gatein.api.Portal;
 import org.gatein.api.navigation.Navigation;
 import org.gatein.api.navigation.Nodes;
@@ -566,7 +570,8 @@ public class DocumentServiceImpl implements DocumentService {
       DocumentMetadataPlugin metadataPlugin = metadataPlugins.get(template.getExtension());
       if(metadataPlugin != null && metadataPlugin.isExtensionSupported(template.getExtension())) {
         try {
-          data = metadataPlugin.updateMetadata(template.getExtension(), data, new Date(), getCurrentUserDisplayName());
+          String userId = ConversationState.getCurrent().getIdentity().getUserId();
+          data = metadataPlugin.updateMetadata(context, template.getExtension(), data, new Date(), getCurrentUserDisplayName(userId), getCurrentUserLanguage(userId));
         } catch (DocumentExtensionNotSupportedException e) {
           LOG.error("Document extension is not supported by metadata plugin.", e);
         } catch (IOException e) {
@@ -919,13 +924,32 @@ public class DocumentServiceImpl implements DocumentService {
    * 
    * @return the display name
    */
-  protected String getCurrentUserDisplayName() {
-    String userId = ConversationState.getCurrent().getIdentity().getUserId();
+  protected String getCurrentUserDisplayName(String userId) {
     try {
       return organizationService.getUserHandler().findUserByName(userId).getDisplayName();
     } catch (Exception e) {
       LOG.error("Error searching user " + userId, e);
       return userId;
+    }
+  }
+  /**
+   * Gets platform language of current user. In case of any errors return null.
+   *
+   * @return the platform language
+   */
+  protected String getCurrentUserLanguage(String userId) {
+    try {
+      LocaleContextInfo localeCtx = LocaleContextInfoUtils.buildLocaleContextInfo(userId);
+      LocalePolicy localePolicy = ExoContainerContext.getCurrentContainer().getComponentInstanceOfType(LocalePolicy.class);
+      String lang = null;
+      if(localePolicy != null) {
+        Locale locale = localePolicy.determineLocale(localeCtx);
+        lang = locale.toString();
+      }
+      return lang;
+    } catch (Exception e) {
+      LOG.error("Error searching user " + userId, e);
+      return null;
     }
   }
   


### PR DESCRIPTION
After modifying the three templates languages settings in [only office](https://github.com/exoplatform/onlyoffice/pull/71), We need to modify each document editing language to the user's platform one.