### PR TITLE
Remove exo.core.component.jdbc dependency

### DIFF
--- a/ecms-social-integration/pom.xml
+++ b/ecms-social-integration/pom.xml
@@ -156,11 +156,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.exoplatform.core</groupId>
-      <artifactId>exo.core.component.organization.jdbc</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
When removing xstream dependency, we completly remove module exo.core.component.jdbc which was deprecated
This commit remove the dependency on this module