### PR TITLE
TASK-39859 Return HTTP 404 on OpenInOffice endpoint when user doesn't have access to node

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/OpenInOfficeConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/OpenInOfficeConnector.java
@@ -13,6 +13,8 @@ import org.exoplatform.services.resources.ResourceBundleService;
 import org.exoplatform.services.rest.resource.ResourceContainer;
 import org.exoplatform.services.wcm.core.NodetypeConstant;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
+import org.exoplatform.social.rest.api.RestUtils;
+
 import org.json.JSONObject;
 import org.picocontainer.Startable;
 
@@ -137,6 +139,10 @@ public class OpenInOfficeConnector implements ResourceContainer, Startable {
       nodePath = node.getPath();
       isFile = node.isNodeType(NodetypeConstant.NT_FILE);
     } catch (PathNotFoundException | AccessDeniedException e) {
+      if (log.isDebugEnabled()) {
+        String currentUser = RestUtils.getCurrentUser();
+        log.debug("User {} can't access document {}:{}", currentUser, workspace, filePath, e);
+      }
       return Response.status(Status.NOT_FOUND).build();
     } catch(RepositoryException ex){
       if(log.isErrorEnabled()){log.error("Exception when get node with path: "+filePath, ex);}
@@ -218,6 +224,10 @@ public class OpenInOfficeConnector implements ResourceContainer, Startable {
 
       return Response.ok(String.valueOf(node.isCheckedOut()), MediaType.TEXT_PLAIN).build();
     } catch (PathNotFoundException | AccessDeniedException e) {
+      if (log.isDebugEnabled()) {
+        String currentUser = RestUtils.getCurrentUser();
+        log.debug("User {} can't access document {}:{}", currentUser, workspace, filePath, e);
+      }
       return Response.status(Status.NOT_FOUND).build();
     } catch (Exception e) {
       log.warn("Error checking out document {}:{}", workspace, filePath, e);
@@ -261,6 +271,10 @@ public class OpenInOfficeConnector implements ResourceContainer, Startable {
                      .header("Content-type", "application/internet-shortcut")
                      .build();
     } catch (PathNotFoundException | AccessDeniedException e) {
+      if (log.isDebugEnabled()) {
+        String currentUser = RestUtils.getCurrentUser();
+        log.debug("User {} can't access document {}:{}", currentUser, workspace, filePath, e);
+      }
       return Response.status(Status.NOT_FOUND).build();
     } catch (Exception e) {
       log.warn("Error getting shortcut of document {}:{}", workspace, filePath, e);

--- a/core/connector/src/test/java/org/exoplatform/wcm/connector/collaboration/TestOpenInOfficeConnector.java
+++ b/core/connector/src/test/java/org/exoplatform/wcm/connector/collaboration/TestOpenInOfficeConnector.java
@@ -55,6 +55,100 @@ public class TestOpenInOfficeConnector extends BaseConnectorTestCase{
     this.binder.addResource(openInOfficeConnector, null);
   }
 
+  public void testCreateShortcut() throws Exception {
+    String parentPath = "sites1";
+    String restPath = "http://localhost:8080/office/test.doc?workspace=collaboration&filePath=/" + parentPath + "/test.doc";
+    applyUserSession("john", "gtn", "collaboration");
+    manageableRepository = repositoryService.getCurrentRepository();
+    Session session = WCMCoreUtils.getSystemSessionProvider().getSession(COLLABORATION_WS, manageableRepository);
+    Node rootNode = session.getRootNode();
+    Node sites = rootNode.addNode(parentPath);
+    sites.addNode("test.doc");
+    rootNode.save();
+    ContainerResponse response = service(HTTPMethods.GET.toString(), restPath, StringUtils.EMPTY, null, null);
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    assertEquals("application/internet-shortcut", response.getHttpHeaders().get("Content-type").get(0));
+    assertEquals("attachment; filename=test.doc.url", response.getHttpHeaders().get("Content-Disposition").get(0));
+  }
+
+  public void testCreateShortcutWithNoPermission() throws Exception {
+    String parentPath = "sites1";
+    String restPath = "http://localhost:8080/office/test.doc?workspace=collaboration&filePath=/" + parentPath + "/test.doc";
+    applyUserSession("john", "gtn", "collaboration");
+    manageableRepository = repositoryService.getCurrentRepository();
+    Session session = WCMCoreUtils.getSystemSessionProvider().getSession(COLLABORATION_WS, manageableRepository);
+    Node rootNode = session.getRootNode();
+    Node sites = rootNode.addNode(parentPath);
+    sites.addNode("test.doc");
+    rootNode.save();
+
+    applyUserSession("demo", "gtn", "collaboration");
+    ContainerResponse response = service(HTTPMethods.GET.toString(), restPath, StringUtils.EMPTY, null, null);
+    assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  public void testCheckout() throws Exception {
+    String parentPath = "sites1";
+    String restPath = "/office/checkout?workspace=collaboration&filePath=/" + parentPath + "/test.doc";
+    applyUserSession("john", "gtn", "collaboration");
+    manageableRepository = repositoryService.getCurrentRepository();
+    Session session = WCMCoreUtils.getSystemSessionProvider().getSession(COLLABORATION_WS, manageableRepository);
+    Node rootNode = session.getRootNode();
+    Node sites = rootNode.addNode(parentPath);
+    sites.addNode("test.doc");
+    rootNode.save();
+
+    ContainerResponse response = service(HTTPMethods.GET.toString(), restPath, StringUtils.EMPTY, null, null);
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    assertEquals("true", response.getResponse().getEntity().toString());
+  }
+
+  public void testCheckoutWithNoPermission() throws Exception {
+    String parentPath = "sites1";
+    String restPath = "/office/checkout?workspace=collaboration&filePath=/" + parentPath + "/test.doc";
+    applyUserSession("john", "gtn", "collaboration");
+    manageableRepository = repositoryService.getCurrentRepository();
+    Session session = WCMCoreUtils.getSystemSessionProvider().getSession(COLLABORATION_WS, manageableRepository);
+    Node rootNode = session.getRootNode();
+    Node sites = rootNode.addNode(parentPath);
+    sites.addNode("test.doc");
+    rootNode.save();
+
+    applyUserSession("demo", "gtn", "collaboration");
+    ContainerResponse response = service(HTTPMethods.GET.toString(), restPath, StringUtils.EMPTY, null, null);
+    assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  public void testUpdateDocumentTitleWithNoPermission() throws Exception {
+    String parentPath = "sites1";
+    String restPath = "/office/updateDocumentTitle?objId=collaboration:/" + parentPath + "/test.doc&lang=en";
+    applyUserSession("john", "gtn", "collaboration");
+    manageableRepository = repositoryService.getCurrentRepository();
+    Session session = WCMCoreUtils.getSystemSessionProvider().getSession(COLLABORATION_WS, manageableRepository);
+    Node rootNode = session.getRootNode();
+    Node sites = rootNode.addNode(parentPath);
+    sites.addNode("test.doc");
+    rootNode.save();
+
+    applyUserSession("demo", "gtn", "collaboration");
+    ContainerResponse response = service(HTTPMethods.GET.toString(), restPath, StringUtils.EMPTY, null, null);
+    assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+  }
+
+  public void testUpdateDocumentTitleWithIncorrectObjId() throws Exception {
+    String parentPath = "sites2";
+    String restPath = "/office/updateDocumentTitle?objId=/" + parentPath + "/test.doc&lang=en";
+    applyUserSession("john", "gtn", "collaboration");
+    manageableRepository = repositoryService.getCurrentRepository();
+    Session session = WCMCoreUtils.getSystemSessionProvider().getSession(COLLABORATION_WS, manageableRepository);
+    Node rootNode = session.getRootNode();
+    Node sites = rootNode.addNode(parentPath);
+    sites.addNode("test.doc");
+    rootNode.save();
+    ContainerResponse response = service(HTTPMethods.GET.toString(), restPath, StringUtils.EMPTY, null, null);
+    assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+  }
+
   public void testUpdateDocumentTitle() throws Exception{
     String parentPath = "sites1";
     String restPath = "/office/updateDocumentTitle?objId=collaboration:/" + parentPath + "/test.doc&lang=en";
@@ -67,20 +161,6 @@ public class TestOpenInOfficeConnector extends BaseConnectorTestCase{
     rootNode.save();
     ContainerResponse response = service(HTTPMethods.GET.toString(), restPath, StringUtils.EMPTY, null, null);
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-  }
-
-  public void testUpdateDocumentTitleWithIncorrectObjId() throws Exception{
-    String parentPath = "sites2";
-    String restPath = "/office/updateDocumentTitle?objId=/" + parentPath + "/test.doc&lang=en";
-    applyUserSession("john", "gtn", "collaboration");
-    manageableRepository = repositoryService.getCurrentRepository();
-    Session session = WCMCoreUtils.getSystemSessionProvider().getSession(COLLABORATION_WS, manageableRepository);
-    Node rootNode = session.getRootNode();
-    Node sites = rootNode.addNode(parentPath);
-    sites.addNode("test.doc");
-    rootNode.save();
-    ContainerResponse response = service(HTTPMethods.GET.toString(), restPath, StringUtils.EMPTY, null, null);
-    assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
   }
 
   public void testUpdateDocumentTitleWithDocumentNamedWithColon() throws Exception{

--- a/testsuite/test/src/main/java/org/exoplatform/ecms/test/BaseECMSResourceTestCase.java
+++ b/testsuite/test/src/main/java/org/exoplatform/ecms/test/BaseECMSResourceTestCase.java
@@ -68,7 +68,7 @@ public abstract class BaseECMSResourceTestCase extends BaseECMSTestCase {
     }
 
     EnvironmentContext envctx = new EnvironmentContext();
-    HttpServletRequest httpRequest = new MockHttpServletRequest("", in, in != null ? in.available() : 0, method, headers);
+    HttpServletRequest httpRequest = new MockHttpServletRequest(requestURI, in, in != null ? in.available() : 0, method, headers);
     envctx.put(HttpServletRequest.class, httpRequest);
     EnvironmentContext.setCurrent(envctx);
     ContainerRequest request = new ContainerRequest(method,


### PR DESCRIPTION
Returning an HTTP code different from 404 gives the information to the user that the node exists with the given name. Thus this can be considered as a vulnerability