### PR TITLE
Removed restrictive Google Drive scopes in Cloud Drive

### DIFF
--- a/ext/clouddrives-gdrive/services/src/main/java/org/exoplatform/services/cms/clouddrives/gdrive/GoogleDriveAPI.java
+++ b/ext/clouddrives-gdrive/services/src/main/java/org/exoplatform/services/cms/clouddrives/gdrive/GoogleDriveAPI.java
@@ -100,8 +100,6 @@ class GoogleDriveAPI implements DataStoreFactory {
   public static final List<String> SCOPES             = Arrays.asList(DriveScopes.DRIVE,
                                                                       DriveScopes.DRIVE_FILE,
                                                                       DriveScopes.DRIVE_APPDATA,
-                                                                      DriveScopes.DRIVE_SCRIPTS,
-                                                                      DriveScopes.DRIVE_APPS_READONLY,
                                                                       Oauth2Scopes.USERINFO_EMAIL,
                                                                       Oauth2Scopes.USERINFO_PROFILE);
 


### PR DESCRIPTION
Removed Google Drive scopes in Cloud Drive connector: `drive.scripts`, `drive.apps.readonly`.