### PR TITLE
Task-40255 : [DLP] a warning is displayed when the admin tries to view a document from the quarantine page

### DIFF
--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIJCRExplorer.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIJCRExplorer.java
@@ -38,6 +38,7 @@ import org.exoplatform.ecm.webui.component.explorer.sidebar.UITreeNodePageIterat
 import org.exoplatform.ecm.webui.utils.PermissionUtil;
 import org.exoplatform.ecm.webui.utils.Utils;
 import org.exoplatform.portal.webui.util.Util;
+import org.exoplatform.services.cms.documents.TrashService;
 import org.exoplatform.services.cms.drives.DriveData;
 import org.exoplatform.services.cms.folksonomy.NewFolksonomyService;
 import org.exoplatform.services.cms.impl.DMSConfiguration;
@@ -863,12 +864,20 @@ public class UIJCRExplorer extends UIContainer {
                                               ApplicationMessage.WARNING));
       return false;
     }
+    TrashService trashService = getApplicationComponent(TrashService.class) ;
     if (testedNode.isNodeType(Utils.EXO_RESTORELOCATION)) {
-      UIApplication uiApp = this.getAncestorOfType(UIApplication.class);
-      uiApp.addMessage(new ApplicationMessage("UIJCRExplorer.msg.target-path-not-found",
-                                              null,
-                                              ApplicationMessage.WARNING));
-      return false;
+      //if testedNode is not in trash, then testedNode is in quarantine folder
+      //we allow access only if the user read the node from the real location (quarantine folder)
+      //else it is an user which read a link to the node in quarantine, so we should not display it
+      if (trashService.isInTrash(testedNode) || !uri.equals(testedNode.getPath())) {
+        UIApplication uiApp = this.getAncestorOfType(UIApplication.class);
+        uiApp.addMessage(new ApplicationMessage("UIJCRExplorer.msg.target-path-not-found",
+                                                null,
+                                                ApplicationMessage.WARNING));
+        return false;
+      } else {
+          return true;
+      }
     }
     return true;
   }


### PR DESCRIPTION
Before this fix, a popup is displayed when an admin tries to open a document in the quarantine folder
This problem is due to the fact that UIJCRExplorerPortlet checks node before displaying, and if the node have restoreLocation properties, it means that it is in trash
In our case, the node is not in trash and should be displayed.

This fix add a check to see if the node is in trash or not. If yes, nothing change.
If not, we check if we are speaking about the real node a linked node. If it is the real, we display it (admin read it in quarantine folder).
If it is a link, we do not allow. It is a case a user read a link to realNode which is quarantine, so we should not display it.