### PR TITLE
Fix the backport effect of Maint-39276 over Maint-36333

### DIFF
--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/notification/plugin/FileActivityChildPlugin.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/notification/plugin/FileActivityChildPlugin.java
@@ -135,7 +135,7 @@ public class FileActivityChildPlugin extends AbstractNotificationChildPlugin {
         }
       }
 
-      templateContext.put("ACTIVITY_URL", LinkProviderUtils.contentLink);
+      templateContext.put("ACTIVITY_URL", contentLink);
       templateContext.put("DOCUMENT_TITLE", this.docName);
       templateContext.put("SUMMARY", summaries);
       templateContext.put("SIZE", sizes);

--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/notification/plugin/FileActivityChildPlugin.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/notification/plugin/FileActivityChildPlugin.java
@@ -135,8 +135,8 @@ public class FileActivityChildPlugin extends AbstractNotificationChildPlugin {
         }
       }
 
-      templateContext.put("ACTIVITY_URL", LinkProviderUtils.getOpenLink(activity));
-      templateContext.put("DOCUMENT_TITLE", this.documentTitle);
+      templateContext.put("ACTIVITY_URL", LinkProviderUtils.contentLink);
+      templateContext.put("DOCUMENT_TITLE", this.docName);
       templateContext.put("SUMMARY", summaries);
       templateContext.put("SIZE", sizes);
       templateContext.put("VERSION", versions);

--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/notification/plugin/FileActivityChildPlugin.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/notification/plugin/FileActivityChildPlugin.java
@@ -135,7 +135,7 @@ public class FileActivityChildPlugin extends AbstractNotificationChildPlugin {
         }
       }
 
-      templateContext.put("ACTIVITY_URL", contentLink);
+      templateContext.put("ACTIVITY_URL", this.contentLink);
       templateContext.put("DOCUMENT_TITLE", this.docName);
       templateContext.put("SUMMARY", summaries);
       templateContext.put("SIZE", sizes);


### PR DESCRIPTION
As checked with @hakermi, the backport order of [Maint-39276](https://github.com/exoplatform/ecms/pull/1098) after [Maint-36333](https://github.com/exoplatform/ecms/pull/1093) did restore some faulty lines, this PR should make things ok now for Maint-36333 backport on stable/6.1.x