### PR TITLE
Task-40572: avoid dlp item processing when updating it via co-editing

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDLPAction.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDLPAction.java
@@ -31,9 +31,7 @@ public class FileDLPAction implements AdvancedAction {
   private ExoFeatureService featureService;
   
   private static final String EXO_EDITORS_RUNTIME_ID = "exo:editorsId";
-
-  private static final String EXO_CURRENT_PROVIDER   = "exo:currentProvider";
-
+ 
   public FileDLPAction() {
     this.trashService = CommonsUtils.getService(TrashService.class);
     this.queueDlpService = CommonsUtils.getService(QueueDlpService.class);
@@ -61,7 +59,7 @@ public class FileDLPAction implements AdvancedAction {
       case Event.PROPERTY_ADDED:
       case Event.PROPERTY_CHANGED:
         PropertyImpl property = (PropertyImpl) context.get(InvocationContext.CURRENT_ITEM);
-        if (property != null && !property.getName().equals(EXO_EDITORS_RUNTIME_ID) && !property.getName().equals(EXO_CURRENT_PROVIDER) && !property.getName().equals(FileDlpConnector.RESTORE_WORKSPACE) && !property.getName().equals(FileDlpConnector.RESTORE_PATH)) {
+        if (property != null && !property.getName().equals(EXO_EDITORS_RUNTIME_ID) && !property.getName().equals(FileDlpConnector.EXO_CURRENT_PROVIDER) && !property.getName().equals(FileDlpConnector.RESTORE_WORKSPACE) && !property.getName().equals(FileDlpConnector.RESTORE_PATH)) {
           node = property.getParent();
           if (node != null && !trashService.isInTrash(node)) {
             if (node.isNodeType(NodetypeConstant.NT_RESOURCE)) {

--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDLPAction.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDLPAction.java
@@ -18,6 +18,10 @@ import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.wcm.core.NodetypeConstant;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * JCR action which listens on all nodes events to validate them
  */
@@ -31,6 +35,11 @@ public class FileDLPAction implements AdvancedAction {
   private ExoFeatureService featureService;
   
   private static final String EXO_EDITORS_RUNTIME_ID = "exo:editorsId";
+
+  private static final List<String> EXCLUDED_PROPERTY_NAMES   = Collections.unmodifiableList(Arrays.asList(EXO_EDITORS_RUNTIME_ID,
+                                                                                                           FileDlpConnector.EXO_CURRENT_PROVIDER,
+                                                                                                           FileDlpConnector.RESTORE_PATH,
+                                                                                                           FileDlpConnector.RESTORE_WORKSPACE));
  
   public FileDLPAction() {
     this.trashService = CommonsUtils.getService(TrashService.class);
@@ -59,7 +68,7 @@ public class FileDLPAction implements AdvancedAction {
       case Event.PROPERTY_ADDED:
       case Event.PROPERTY_CHANGED:
         PropertyImpl property = (PropertyImpl) context.get(InvocationContext.CURRENT_ITEM);
-        if (property != null && !property.getName().equals(EXO_EDITORS_RUNTIME_ID) && !property.getName().equals(FileDlpConnector.EXO_CURRENT_PROVIDER) && !property.getName().equals(FileDlpConnector.RESTORE_WORKSPACE) && !property.getName().equals(FileDlpConnector.RESTORE_PATH)) {
+        if (property != null && !EXCLUDED_PROPERTY_NAMES.contains(property.getName())) {
           node = property.getParent();
           if (node != null && !trashService.isInTrash(node)) {
             if (node.isNodeType(NodetypeConstant.NT_RESOURCE)) {

--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDLPAction.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDLPAction.java
@@ -36,10 +36,10 @@ public class FileDLPAction implements AdvancedAction {
   
   private static final String EXO_EDITORS_RUNTIME_ID = "exo:editorsId";
 
-  private static final List<String> EXCLUDED_PROPERTY_NAMES   = Collections.unmodifiableList(Arrays.asList(EXO_EDITORS_RUNTIME_ID,
-                                                                                                           FileDlpConnector.EXO_CURRENT_PROVIDER,
-                                                                                                           FileDlpConnector.RESTORE_PATH,
-                                                                                                           FileDlpConnector.RESTORE_WORKSPACE));
+  private static final List<String> excludedPropertyNames = Collections.unmodifiableList(Arrays.asList(EXO_EDITORS_RUNTIME_ID,
+                                                                                                       FileDlpConnector.EXO_CURRENT_PROVIDER,
+                                                                                                       FileDlpConnector.RESTORE_PATH,
+                                                                                                       FileDlpConnector.RESTORE_WORKSPACE));
  
   public FileDLPAction() {
     this.trashService = CommonsUtils.getService(TrashService.class);
@@ -68,7 +68,7 @@ public class FileDLPAction implements AdvancedAction {
       case Event.PROPERTY_ADDED:
       case Event.PROPERTY_CHANGED:
         PropertyImpl property = (PropertyImpl) context.get(InvocationContext.CURRENT_ITEM);
-        if (property != null && !EXCLUDED_PROPERTY_NAMES.contains(property.getName())) {
+        if (property != null && !excludedPropertyNames.contains(property.getName())) {
           node = property.getParent();
           if (node != null && !trashService.isInTrash(node)) {
             if (node.isNodeType(NodetypeConstant.NT_RESOURCE)) {

--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDLPAction.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDLPAction.java
@@ -8,9 +8,7 @@ import org.exoplatform.commons.api.settings.ExoFeatureService;
 import org.exoplatform.commons.dlp.processor.DlpOperationProcessor;
 import org.exoplatform.commons.dlp.queue.QueueDlpService;
 import org.exoplatform.commons.utils.CommonsUtils;
-import org.exoplatform.services.cms.documents.DocumentService;
 import org.exoplatform.services.cms.documents.TrashService;
-import org.exoplatform.services.cms.documents.impl.DocumentServiceImpl;
 import org.exoplatform.services.ext.action.InvocationContext;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.services.jcr.impl.core.PropertyImpl;
@@ -33,7 +31,9 @@ public class FileDLPAction implements AdvancedAction {
   private ExoFeatureService featureService;
   
   private static final String EXO_EDITORS_RUNTIME_ID = "exo:editorsId";
- 
+
+  private static final String EXO_CURRENT_PROVIDER   = "exo:currentProvider";
+
   public FileDLPAction() {
     this.trashService = CommonsUtils.getService(TrashService.class);
     this.queueDlpService = CommonsUtils.getService(QueueDlpService.class);
@@ -61,7 +61,7 @@ public class FileDLPAction implements AdvancedAction {
       case Event.PROPERTY_ADDED:
       case Event.PROPERTY_CHANGED:
         PropertyImpl property = (PropertyImpl) context.get(InvocationContext.CURRENT_ITEM);
-        if(property != null && !property.getName().equals(EXO_EDITORS_RUNTIME_ID) && !property.getName().equals(FileDlpConnector.RESTORE_WORKSPACE) && !property.getName().equals(FileDlpConnector.RESTORE_PATH)) {
+        if (property != null && !property.getName().equals(EXO_EDITORS_RUNTIME_ID) && !property.getName().equals(EXO_CURRENT_PROVIDER) && !property.getName().equals(FileDlpConnector.RESTORE_WORKSPACE) && !property.getName().equals(FileDlpConnector.RESTORE_PATH)) {
           node = property.getParent();
           if (node != null && !trashService.isInTrash(node)) {
             if (node.isNodeType(NodetypeConstant.NT_RESOURCE)) {

--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDlpConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDlpConnector.java
@@ -51,6 +51,8 @@ public class FileDlpConnector extends DlpServiceConnector {
   public static final String TYPE = "file";
 
   public static final String DLP_SECURITY_FOLDER = "Security";
+  
+  public static final String EXO_CURRENT_PROVIDER = "exo:currentProvider";
 
   private static final Log LOGGER = ExoLogger.getExoLogger(FileDlpConnector.class);
 
@@ -93,7 +95,7 @@ public class FileDlpConnector extends DlpServiceConnector {
 
   @Override
   public boolean processItem(String entityId) {
-    if (!isIndexedByEs(entityId)) {
+    if (!isIndexedByEs(entityId) || editorOpened(entityId)) {
       return false;
     } else {
       checkMatchKeywordAndTreatItem(entityId);
@@ -388,6 +390,18 @@ public class FileDlpConnector extends DlpServiceConnector {
       if (node.isNodeType(EXO_RESTORE_LOCATION))
         node.removeMixin(EXO_RESTORE_LOCATION);
     }
+  }
+
+  private boolean editorOpened(String entityId) {
+    Node node = null;
+    try {
+      ExtendedSession session = (ExtendedSession) WCMCoreUtils.getSystemSessionProvider().getSession(COLLABORATION_WS, repositoryService.getCurrentRepository());
+      node = session.getNodeByIdentifier(entityId);
+      return node.hasProperty(EXO_CURRENT_PROVIDER);
+    } catch (RepositoryException e) {
+      LOGGER.error("Error while checking editor status", e);
+    }
+    return false;
   }
   
   private String removeAccents(String string) {


### PR DESCRIPTION
Bugs:
**1-** Once a document is restored, when the user updates it via the coediting option and adds new keywords, the document is sent to quarantine but the detected keywords are not displayed ==> We should display the newly detected keywords

**2-** Once a document is restored, when the user opens the document in coedition, this document is sent to the quarantine page even if the user doesn't change the document content ==> The document must be sent to the quarantine page only if the new version contains keywords