### PR TITLE
MAINT-39705 : Upload new version  is not working when the file is renamed with with a space in the name

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
@@ -277,6 +277,7 @@ public class FileUploadHandler {
     DocumentBuilder builder = factory.newDocumentBuilder();
     Document fileExistence = builder.newDocument();
     fileName = Text.escapeIllegalJcrChars(fileName);
+    fileName = URLDecoder.decode(URLDecoder.decode(fileName,"UTF-8"),"UTF-8");
     fileName = Utils.cleanNameWithAccents(fileName);
     Element rootElement = fileExistence.createElement(
                               parent.hasNode(fileName) ? "Existed" : "NotExisted");

--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/fckeditor/DriverConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/fckeditor/DriverConnector.java
@@ -16,6 +16,7 @@
  */
 package org.exoplatform.wcm.connector.fckeditor;
 
+import java.net.URLDecoder;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -465,6 +466,7 @@ public class DriverConnector extends BaseConnector implements ResourceContainer 
                                                      Text.escapeIllegalJcrChars(driverName),
                                                      Text.escapeIllegalJcrChars(currentFolder));
         fileName = Text.escapeIllegalJcrChars(fileName);
+        fileName = URLDecoder.decode(fileName, "UTF-8");
         return createProcessUploadResponse(workspaceName,
                                            currentFolderNode,
                                            currentPortal,


### PR DESCRIPTION
**The problem** when uploading a new version does not work with a filename that contains space so **the solution** is to decode the file name.