### PR TITLE
TASK-37339 Fix displaying connect to drive button in composer

### DIFF
--- a/apps/portlet-clouddrives/src/test/specs/ConnectCloudDrive.test.js
+++ b/apps/portlet-clouddrives/src/test/specs/ConnectCloudDrive.test.js
@@ -1,5 +1,5 @@
 import { shallowMount } from "@vue/test-utils";
-import ConnectCloudDrive from "../../main/webapp/vue-app/components/ConnectCloudDrive.vue";
+import ConnectCloudDrive from "../../main/webapp/vue-app/connectCloudDrive/components/ConnectCloudDrive.vue";
 import Vuetify from "vuetify";
 import Vue from "vue";
 
@@ -43,7 +43,13 @@ describe("ConnectCloudDrive.test.js", () => {
 
     process.nextTick(() => {
       expect(global.fetch).toHaveBeenCalledTimes(1);
-      expect(cmp.userDrive).toEqual({ name: "Personal Documents", title: "Personal Documents", isSelected: false });
+      expect(cmp.userDrive).toEqual({
+        name: "Personal Documents",
+        title: "Personal Documents",
+        isSelected: false,
+        homePath: "/Personal__Documents",
+        workspace: "collaboration",
+      });
       expect(wrapper.findAll(".cloudDriveListItem")).toHaveLength(2);
       global.fetch.mockClear();
       wrapper.destroy();

--- a/apps/portlet-clouddrives/webpack.dev.js
+++ b/apps/portlet-clouddrives/webpack.dev.js
@@ -10,7 +10,8 @@ const exoServerPath = "/exo-server";
 
 let config = merge(webpackCommonConfig, {
   output: {
-    path: path.resolve(`${exoServerPath}/webapps/${app}/`)
+    path: path.resolve(`${exoServerPath}/webapps/${app}/`),
+    filename: 'js/[name].bundle.js'
   },
   devtool: "inline-source-map"
 });

--- a/ecm-wcm-extension/src/main/webapp/attachments-selector/extension.js
+++ b/ecm-wcm-extension/src/main/webapp/attachments-selector/extension.js
@@ -6,7 +6,7 @@
 let attachmentsComposerActions = null;
 
 export function getAttachmentsComposerExtensions() {
-  if(attachmentsComposerActions == null) {
+  if(attachmentsComposerActions == null || !attachmentsComposerActions.length) {
     const allExtensions = getExtensionsByType('attachments-composer-action');
     // if some extension registered but has flag 'enabled' set to false, we don't add this extension
     attachmentsComposerActions = allExtensions.filter(extension => isExtensionEnabled(extension));

--- a/ecm-wcm-extension/webpack.dev.js
+++ b/ecm-wcm-extension/webpack.dev.js
@@ -6,7 +6,7 @@ const webpackCommonConfig = require('./webpack.common.js');
 const app = 'ecm-wcm-extension';
 
 // add the server path to your server location path
-const exoServerPath = "/work/platform-6.0.x-SNAPSHOT";
+const exoServerPath = "/exo-server";
 
 let config = merge(webpackCommonConfig, {
   output: {


### PR DESCRIPTION
The extension registry returns an empty array when no extension is registered for a given extension, thus this condition has been changed:
`  if(attachmentsComposerActions == null) {`
into
`  if(attachmentsComposerActions == null || !attachmentsComposerActions.length) {`
to ensure to attempt to retrieve the extensions defined in other JS Modules. In fact, some JS Modules are loaded late in page loading phase.

( The other **test files** was modified because some errors was raised when using command `npm run watch` that is used for development mode )