### PR TITLE
TASK-37929 Fix JCR index corruption when massively uploading files

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
@@ -366,7 +366,17 @@ public class FileUploadHandler {
     return saveAsNTFile(parent, uploadId, fileName, language, siteName, userId, existenceAction,false);
   }
   /**
-   * Save as nt file.
+   * Save already uploaded file (identified by uploadId) as nt file.
+   * 
+   * 'synchronized' is used to avoid JCR index corruption when uploading massively files.
+   * The JCR index (that uses a very old version of Apache lucene)
+   * gets corrupted when doing massive modifications on the same parent node.
+   * 
+   * Thus here we have made this central method as synchronized to avoid corruption
+   * and ensure Data consistency in favor of performances. The upload itself is not synchronized,
+   * we still be able to upload concurrently using org.exoplatform.web.handler.UploadHandler
+   * but the commit of uploaded file to be stored on JCR is made using this method, thus this critical
+   * operation has been made synchronized.
    *
    * @param parent the parent
    * @param uploadId the upload id
@@ -377,7 +387,7 @@ public class FileUploadHandler {
    *
    * @throws Exception the exception
    */
-  public Response saveAsNTFile(Node parent,
+  public synchronized Response saveAsNTFile(Node parent,
                                String uploadId,
                                String fileName,
                                String language,


### PR DESCRIPTION
The ECMS Explorer portlet displays the content of a folder by using JCR query (= JCR index query). Thus when the JCR index gets corrupted, the files listing in Drives portlet is wrong (this means that the data is stored but not displayed to end user).
This JCR index corruption happens when uploading multiple files (> 20) at the same time on a given folder.
So 'synchronized' is used to avoid JCR index corruption when uploading massively files.
The JCR index (that uses a very old version of Apache lucene) gets corrupted when doing massive modifications on the same parent node.
Thus here we have made this central method as synchronized to avoid corruption and ensure Data consistency in favor of performances.
The upload itself is not synchronized, we still be able to upload concurrently using org.exoplatform.web.handler.UploadHandler
but the commit of uploaded file to be stored on JCR is made using this method, thus this critical operation has been made synchronized.