### PR TITLE
TASK-36121: Fix the document preview display

### DIFF
--- a/apps/resources-wcm/src/main/webapp/skin/less/ecms/skin/UIDocumentPreview/Style.less
+++ b/apps/resources-wcm/src/main/webapp/skin/less/ecms/skin/UIDocumentPreview/Style.less
@@ -768,6 +768,15 @@
 	}
 }
 
+.fileContent .navigationContainer {
+	.content {
+		height: 100%;
+	}
+	.document-preview-default {
+		height: 565px;
+	}
+}
+
 .toolbar .actionIcon.disabled {
   .opacity(50);
   &:hover {


### PR DESCRIPTION
**Problem:** In order to fix display documents with onlyoffice in stream  we [PR](https://github.com/exoplatform/onlyoffice/pull/69) have removed height from only office,the problem in stream was fixed but it results a regression in the preview,
**Solution:** so to solve this problem we add height UIDocumentPreview to  insure that we display correctly in preview.
**IT will fix:**  the display in stream, preview embedded in documents app