### PR TITLE
Task-40565 :  Favorites documents in quarantine should not be accessible

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDlpConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDlpConnector.java
@@ -19,6 +19,7 @@ import org.exoplatform.commons.dlp.queue.QueueDlpService;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.cms.drives.DriveData;
 import org.exoplatform.services.cms.drives.ManageDriveService;
+import org.exoplatform.services.cms.impl.Utils;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.access.PermissionType;
 import org.exoplatform.services.jcr.core.ExtendedNode;
@@ -163,6 +164,7 @@ public class FileDlpConnector extends DlpServiceConnector {
       if (!node.getPath().startsWith("/"+DLP_SECURITY_FOLDER+"/") && (restoredDlpItem == null ||  getNodeLastModifiedDate(node) > restoredDlpItem.getDetectionDate())) {
         workspace.move(node.getPath(), "/" + DLP_SECURITY_FOLDER + "/" + fileName);
         indexingService.unindex(TYPE, entityId);
+        Utils.removeDeadSymlinks(node);
         saveDlpPositiveItem(node,searchResults);
         addRestorePathInfo(node.getName(), restorePath, workspace.getName());
         long endTime = System.currentTimeMillis();

--- a/core/connector/src/test/java/org/exoplatform/ecm/connector/dlp/TestFileDlpConnector.java
+++ b/core/connector/src/test/java/org/exoplatform/ecm/connector/dlp/TestFileDlpConnector.java
@@ -7,6 +7,8 @@ import org.exoplatform.commons.api.search.data.SearchResult;
 import org.exoplatform.commons.dlp.processor.DlpOperationProcessor;
 import org.exoplatform.commons.dlp.queue.QueueDlpService;
 import org.exoplatform.commons.dlp.service.RestoredDlpItemService;
+import org.exoplatform.services.cms.documents.TrashService;
+import org.exoplatform.services.cms.link.LinkManager;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.core.ExtendedSession;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
@@ -57,6 +59,12 @@ public class TestFileDlpConnector {
 
   @Mock
   private DlpOperationProcessor dlpOperationProcessor;
+
+  @Mock
+  private LinkManager linkManager;
+
+  @Mock
+  private TrashService trashService;
   
   @Test
   public void testProcessItemWhenIsIndexed() throws Exception {
@@ -107,10 +115,12 @@ public class TestFileDlpConnector {
     SessionProvider sessionProvider = mock(SessionProvider.class);
     when(sessionProvider.getSession(Mockito.any(), Mockito.any())).thenReturn(session);
     when(WCMCoreUtils.getSystemSessionProvider()).thenReturn(sessionProvider);
-  
-  
+    when(WCMCoreUtils.getService(LinkManager.class)).thenReturn(linkManager);
+    when(WCMCoreUtils.getService(TrashService.class)).thenReturn(trashService);
+
+
     fileDlpConnectorSpy.processItem(uuid);
-  
+
     // Then
     Mockito.verify(fileDlpConnectorSpy,Mockito.times(1)).treatItem(Mockito.eq(uuid),Mockito.any());
     Mockito.verify(workspace, Mockito.times(1)).move(path,"/"+fileDlpConnector.DLP_SECURITY_FOLDER+"/"+nodeName);
@@ -159,7 +169,9 @@ public class TestFileDlpConnector {
     SessionProvider sessionProvider = mock(SessionProvider.class);
     when(sessionProvider.getSession(Mockito.any(), Mockito.any())).thenReturn(session);
     when(WCMCoreUtils.getSystemSessionProvider()).thenReturn(sessionProvider);
-    
+    when(WCMCoreUtils.getService(LinkManager.class)).thenReturn(linkManager);
+    when(WCMCoreUtils.getService(TrashService.class)).thenReturn(trashService);
+
     
     fileDlpConnectorSpy.processItem(uuid);
     


### PR DESCRIPTION
- Before this fix favorite documents are displayed in the favorite widget on the snapshot page when are detected by quarantine and the symlinks also are displayed on the favorite folder without permissions to access.
- This fix will assure that documents on the quarantine page aren't displayed on the snapshot page and the symlinks also are deleted.