### PR TITLE
TASK-28194 Escape Synchronized file name from Connected Drives

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/clouddrives/jcr/JCRLocalCloudDrive.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/clouddrives/jcr/JCRLocalCloudDrive.java
@@ -6403,21 +6403,26 @@ public abstract class JCRLocalCloudDrive extends CloudDrive implements CloudDriv
     // delete special character
     if (cleanedStr.length() == 1) {
       char c = cleanedStr.charAt(0);
-      if (c == '.' || c == '/' || c == ':' || c == '[' || c == ']' || c == '*' || c == '\'' || c == '"' || c == '|') {
+      if (c == '.' || c == '/' || c == ':' || c == '[' || c == ']' || c == '*' || c == '\'' || c == '"' || c == '|' || c == 'ʿ' || c == 'ˇ') {
         // any -> _<NEXNUM OF c>
         cleanedStr.deleteCharAt(0);
         cleanedStr.append('_');
         cleanedStr.append(Integer.toHexString(c).toUpperCase());
       }
     } else {
-      for (int i = 0; i < cleanedStr.length(); i++) {
+      int strLength = cleanedStr.length();
+      int i = 0;
+      while (i < strLength) {
         char c = cleanedStr.charAt(i);
-        if (c == '/' || c == ':' || c == '[' || c == ']' || c == '*' || c == '\'' || c == '"' || c == '|') {
+        if (c == '/' || c == ':' || c == '[' || c == ']' || c == '*' || c == '\'' || c == '"' || c == '|' || c == 'ʿ' || c == 'ˇ') {
           cleanedStr.deleteCharAt(i);
           cleanedStr.insert(i, '_');
         } else if (!(Character.isLetterOrDigit(c) || Character.isWhitespace(c) || c == '.' || c == '-' || c == '_')) {
-          cleanedStr.deleteCharAt(i--);
+          cleanedStr.deleteCharAt(i);
+          strLength = cleanedStr.length();
+          continue;
         }
+        i++;
       }
     }
     return cleanedStr.toString().trim(); // finally trim also

--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -655,23 +655,19 @@ public class Utils {
     //the character ? seems to not be changed to d by the transliterate function
     StringBuffer cleanedStr = new StringBuffer(str.trim());
     // delete special character
-    for(int i = 0; i < cleanedStr.length(); i++) {
+    int strLength = cleanedStr.length();
+    int i = 0;
+    while (i < strLength) {
       char c = cleanedStr.charAt(i);
-      if(c == ' ') {
-        if (i > 0 && cleanedStr.charAt(i - 1) == '-') {
-          cleanedStr.deleteCharAt(i--);
-        } else {
-          c = '-';
-          cleanedStr.setCharAt(i, c);
-        }
+      if (c == '/' || c == ':' || c == '[' || c == ']' || c == '*' || c == '\'' || c == '"' || c == '|' || c == 'ʿ' || c == 'ˇ') {
+        cleanedStr.deleteCharAt(i);
+        cleanedStr.insert(i, '_');
+      } else if (!(Character.isLetterOrDigit(c) || Character.isWhitespace(c) || c == '.' || c == '-' || c == '_')) {
+        cleanedStr.deleteCharAt(i);
+        strLength = cleanedStr.length();
         continue;
       }
-      if(i > 0 && !(Character.isLetterOrDigit(c) || c == '-')) {
-        cleanedStr.deleteCharAt(i--);
-        continue;
-      }
-      if(i > 0 && c == '-' && cleanedStr.charAt(i-1) == '-')
-        cleanedStr.deleteCharAt(i--);
+      i++;
     }
     while (StringUtils.isNotEmpty(cleanedStr.toString()) && !Character.isLetterOrDigit(cleanedStr.charAt(0))) {
       cleanedStr.deleteCharAt(0);


### PR DESCRIPTION
Using mysql, when having a file name that uses one of those characters 'ˇ' or 'ʿ', the synchronization fails and thus, the user can't connect to his Drive.
The fix will add those characters to the list of special characters to espace