### PR TITLE
Task-41197: Remove log warn related to doc breadcrumb when user is anonymous

### DIFF
--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/connector/FileSearchServiceConnector.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/connector/FileSearchServiceConnector.java
@@ -166,6 +166,7 @@ public class FileSearchServiceConnector extends ElasticSearchServiceConnector {
 
     String userId = ConversationState.getCurrent() != null ? ConversationState.getCurrent().getIdentity().getUserId() : null;
     boolean isAnonymous = userId == null || userId.isEmpty() || userId.equals(IdentityConstants.ANONIM);
+    ecmsSearchResult.setBreadcrumb(isAnonymous ? null : getBreadcrumb(nodePath));
     if (isAnonymous) {
       ecmsSearchResult.setPreviewUrl(downloadUrl.toString());
       ecmsSearchResult.setUrl(downloadUrl.toString());

--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/connector/FileSearchServiceConnector.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/connector/FileSearchServiceConnector.java
@@ -162,7 +162,6 @@ public class FileSearchServiceConnector extends ElasticSearchServiceConnector {
 
     String formattedDate = getFormattedDate(searchResult.getDate(), lang);
     ecmsSearchResult.setDetail(driveName + formattedFileSize + " - " + formattedDate);
-    ecmsSearchResult.setBreadcrumb(getBreadcrumb(nodePath));
 
     String userId = ConversationState.getCurrent() != null ? ConversationState.getCurrent().getIdentity().getUserId() : null;
     boolean isAnonymous = userId == null || userId.isEmpty() || userId.equals(IdentityConstants.ANONIM);


### PR DESCRIPTION
Before this fix, frequently we have this warn in logs : 
"Can't find associated drive of node with path"  related to dlp process

This fix will remove log warn related to doc breadcrum when user is anonymous