### PR TITLE
Task-35945: Fix selected users or spaces are lost When you change permission

### DIFF
--- a/ecm-wcm-extension/src/main/webapp/groovy/ecm/social-integration/share-document/UIShareDocuments.gtmpl
+++ b/ecm-wcm-extension/src/main/webapp/groovy/ecm/social-integration/share-document/UIShareDocuments.gtmpl
@@ -6,7 +6,8 @@ requireJs.require("SHARED/share-content", "shareContent");
 requireJs.addScripts("eXo.ecm.ShareContent.init();");
 String addAction = uicomponent.event("Add") + "; return false;";
 String restUrl = uicomponent.getRestURL();
-//String value = uicomponent.getValue();
+String value = uicomponent.getValue();
+Map<String, String> initialValues = ((value != null) && (!value.isEmpty())) ? uicomponent.getInitialValues(value) : null;
 String placeholder = _ctx.appRes("UIShareDocuments.label.invite.placeholder");
 placeholder = placeholder?.replace("'", "\\'").replace("&#39;", "\\&#39;");
 
@@ -69,9 +70,13 @@ String SHARE_PERMISSION_MODIFY      = "modify";
           <% } %>
           </div>
         </div>
-        <%
-        requireJs.require("SHARED/userInvitation", "invite");
-        requireJs.addScripts("invite.build('userSuggester', '$restUrl', '$placeholder');");
+        <% if(value) {
+            requireJs.require("SHARED/userInvitation", "invite");
+            requireJs.addScripts("invite.buildInitialized('userSuggester', '$restUrl', '$placeholder', '$initialValues');");
+          } else {
+            requireJs.require("SHARED/userInvitation", "invite");
+            requireJs.addScripts("invite.build('userSuggester', '$restUrl', '$placeholder');");
+          }
         %>
 	</div>
   </div>

--- a/ecms-social-integration/src/main/java/org/exoplatform/ecm/webui/component/explorer/popup/actions/UIShareDocuments.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/ecm/webui/component/explorer/popup/actions/UIShareDocuments.java
@@ -25,8 +25,10 @@ import java.util.stream.Collectors;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
-
+import org.apache.commons.lang.StringUtils;
+import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.commons.api.notification.NotificationContext;
+import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.commons.api.notification.model.PluginKey;
 import org.exoplatform.commons.notification.impl.NotificationContextImpl;
 import org.exoplatform.commons.utils.CommonsUtils;
@@ -605,6 +607,33 @@ public class UIShareDocuments extends UIForm implements UIPopupComponent{
   private String getMimeType(Node node) throws Exception {
     return DMSMimeTypeResolver.getInstance().getMimeType(node.getName());
   }
+
+  public Map<String, String> getInitialValues(String invitees) {
+    Map<String, String> inviteeNames = new HashMap<>();
+    if (StringUtils.isNotBlank(invitees)) {
+      SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
+      IdentityManager identityManager = CommonsUtils.getService(IdentityManager.class);
+      String[] invitedList = invitees.split(",");
+      String userId = ConversationState.getCurrent().getIdentity().getUserId();
+      for (String invited : invitedList) {
+        if (invited.equals(userId)) {
+          continue;
+        }
+        Space space = spaceService.getSpaceByDisplayName(invited);
+        if (space != null) {
+          inviteeNames.putIfAbsent(SPACE_PREFIX1 + space.getPrettyName(), invited);
+        } else {
+          org.exoplatform.social.core.identity.model.Identity identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, invited);
+          if (identity != null) {
+            Profile profile = identity.getProfile();
+            inviteeNames.putIfAbsent(invited, profile.getFullName());
+          }
+        }
+      }
+    }
+    return inviteeNames;
+  }
+
 
   @Override
   public void activate() {  }


### PR DESCRIPTION
Problem: When changing the permission all the content of share drawer is updated and the entry values are lost.
How it was solved: add method (getInitialValues) in which we save the initial values before changing the permission and recover them later. 