### PR TITLE
Task-41504: Documents are not detected if they contain a keyword composed of more than a word

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDlpConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDlpConnector.java
@@ -134,7 +134,7 @@ public class FileDlpConnector extends DlpServiceConnector {
       try {
         searchContext = new SearchContext(new Router(new ControllerDescriptor()), "");
         Collection<SearchResult> searchResults = fileSearchServiceConnector.dlpSearch(searchContext, dlpKeywords, entityId);
-        if (searchResults.size() > 0) {
+        if (!getDetectedKeywords(searchResults, dlpOperationProcessor.getKeywords()).isEmpty()) {
           treatItem(entityId, searchResults);
         }
       } catch (Exception ex) {
@@ -250,7 +250,7 @@ public class FileDlpConnector extends DlpServiceConnector {
                  .flatMap(Collection::stream)
                  .flatMap(Collection::stream)
                  .forEach(s -> {
-                   dlpKeywordsList.stream().filter(key -> removeAccents(s).contains(escapeSpecialCharacters(removeAccents(key)))).forEach(key -> {
+                   dlpKeywordsList.stream().filter(key -> removeAccents(s).contains(escapeSpecialCharacters(removeAccents(key))) || removeAccents(s).contains(key)).forEach(key -> {
                      if (!key.isEmpty() && !detectedKeywords.contains(key)) {
                        detectedKeywords.add(key);
                      }

--- a/core/connector/src/test/java/org/exoplatform/ecm/connector/dlp/TestFileDlpConnector.java
+++ b/core/connector/src/test/java/org/exoplatform/ecm/connector/dlp/TestFileDlpConnector.java
@@ -84,7 +84,13 @@ public class TestFileDlpConnector {
     when(dlpOperationProcessor.getKeywords()).thenReturn("keyword1,keyword2");
 
     List<SearchResult> results = new ArrayList<>();
-    results.add(new SearchResult("url","title","excerpt","detail", "imageUrl",5,4));
+    SearchResult searchResult = new SearchResult("url","title","excerpt","detail", "imageUrl",5,4);
+    Map<String, List<String>> excerpts = new HashMap<>();
+    List<String> strings = new ArrayList<>();
+    strings.add("<em>keyword1</em> <em>keyword2</em>");
+    excerpts.put("test", strings);
+    searchResult.setExcerpts(excerpts);
+    results.add(searchResult);
     when(fileSearchServiceConnector.dlpSearch(Mockito.any(),Mockito.eq("keyword1,keyword2"),Mockito.eq(uuid))).thenReturn(results);
     fileDlpConnector = new FileDlpConnector(initParams, fileSearchServiceConnector, repositoryService, indexingService, dlpOperationProcessor, restoredDlpItemService, linkManager);
     FileDlpConnector fileDlpConnectorSpy = Mockito.spy(fileDlpConnector);


### PR DESCRIPTION
The problem is that when the document contains only composed keyword and the dlp keywords contain both types (composed and single words), the document is not detected.

To fix this problem, we need to update the ES query (**should** instead of **must**) and only process the item that it contains the **expert** keywords.