### PR TITLE
TASK-41334: fixed new drives are not displayed when we add a user in a new group

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/drives/impl/ManageDriveServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/drives/impl/ManageDriveServiceImpl.java
@@ -748,6 +748,7 @@ public class ManageDriveServiceImpl implements ManageDriveService, Startable {
   public void clearGroupCache(String userId) {
     drivesCache.remove(getRepoName() + "_" + userId + ALL_GROUP_CACHED_DRIVES);
     drivesCache.remove(getRepoName() + "_" + userId + ALL_DRIVES_CACHED_BY_ROLES);
+    drivesCache.remove(getRepoName() + "_" + userId + ALL_MAIN_CACHED_DRIVE);
   }
 
   /**


### PR DESCRIPTION
- on each add/remove of a user in a group the listener clears the cache of groups except generalDrives (ALL_MAIN_CACHED_DRIVE )
- clear cache of generalDrives (ALL_MAIN_CACHED_DRIVE ) on add/remove a user in a group