### PR TITLE
FileDlpConnector : improve error log

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDlpConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDlpConnector.java
@@ -235,7 +235,7 @@ public class FileDlpConnector extends DlpServiceConnector {
       Node node = session.getNodeByIdentifier(itemReference);
       return WCMCoreUtils.getLinkInDocumentsApplication(node.getPath());
     } catch (Exception e) {
-      LOGGER.error("Error while getting dlp item url", e);
+      LOGGER.error("Error while getting dlp item url, itemId={}", itemReference, e);
     }
     return null;
   }


### PR DESCRIPTION
Before this commit, when the function throws an error, we dont know which item is impacted
This fix improve the log to display it