### PR TITLE
Task 35945: Fix selected users or spaces are lost When changing permission(user or space tagged aren't displayed in text mode when changing permission)

### DIFF
--- a/ecm-wcm-extension/src/main/webapp/groovy/ecm/social-integration/share-document/UIShareDocuments.gtmpl
+++ b/ecm-wcm-extension/src/main/webapp/groovy/ecm/social-integration/share-document/UIShareDocuments.gtmpl
@@ -1,4 +1,5 @@
 <%
+import org.json.JSONObject;
 def rcontext = _ctx.getRequestContext();
 def jsManager = rcontext.getJavascriptManager();
 def requireJs = jsManager.getRequireJS();
@@ -71,8 +72,9 @@ String SHARE_PERMISSION_MODIFY      = "modify";
           </div>
         </div>
         <% if(value) {
+            JSONObject object = new JSONObject(initialValues);
             requireJs.require("SHARED/userInvitation", "invite");
-            requireJs.addScripts("invite.buildInitialized('userSuggester', '$restUrl', '$placeholder', '$initialValues');");
+            requireJs.addScripts("invite.buildInitialized('userSuggester', '$restUrl', '$placeholder', '$object');");
           } else {
             requireJs.require("SHARED/userInvitation", "invite");
             requireJs.addScripts("invite.build('userSuggester', '$restUrl', '$placeholder');");

--- a/ecms-social-integration/src/main/java/org/exoplatform/ecm/webui/component/explorer/popup/actions/UIShareDocuments.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/ecm/webui/component/explorer/popup/actions/UIShareDocuments.java
@@ -619,8 +619,8 @@ public class UIShareDocuments extends UIForm implements UIPopupComponent{
         if (invited.equals(userId)) {
           continue;
         }
-        Space space = spaceService.getSpaceByDisplayName(invited);
-        if (space != null) {
+        if ( invited.contains("space::")) {
+          Space space = spaceService.getSpaceByPrettyName(invited.split("::")[1]);
           inviteeNames.putIfAbsent(SPACE_PREFIX1 + space.getPrettyName(), invited);
         } else {
           org.exoplatform.social.core.identity.model.Identity identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, invited);


### PR DESCRIPTION
Problems: the selected user or space was lost when changing the permission because the expected form of data after changing permission is JSON.
Selected spaces are lost after changing permission even after changing the data in JSON form.
How they was solved: by putting the data in JSON form.
Test if the selected data is user or space before charging it.