### PR TITLE
Task-41416_4117: Implement MalwareDetection feature

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/malwareDetection/JcrMalwareDetectionServiceConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/malwareDetection/JcrMalwareDetectionServiceConnector.java
@@ -1,0 +1,82 @@
+package org.exoplatform.ecm.connector.malwareDetection;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.jcr.Node;
+import javax.jcr.Property;
+
+import org.apache.commons.lang.StringUtils;
+
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.core.ExtendedSession;
+import org.exoplatform.services.jcr.impl.core.NodeImpl;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.wcm.core.NodetypeConstant;
+import org.exoplatform.services.wcm.utils.WCMCoreUtils;
+import org.exoplatform.social.service.malwareDetection.MalwareDetectionService;
+import org.exoplatform.social.service.malwareDetection.connector.MalwareDetectionServiceConnector;
+
+public class JcrMalwareDetectionServiceConnector extends MalwareDetectionServiceConnector {
+
+  private static final Log  LOGGER = ExoLogger.getExoLogger(JcrMalwareDetectionServiceConnector.class);
+  
+  private static final String PORTAL_CONTAINER = "_portal";
+
+  private RepositoryService repositoryService;
+
+  public JcrMalwareDetectionServiceConnector(InitParams initParams, RepositoryService repositoryService) {
+    super(initParams);
+    this.repositoryService = repositoryService;
+  }
+
+  @Override
+  public List<Map<String, String>> getInfectedItems(String infectedJcrNodePath) {
+    String infectedJcrNodeIdentifier = getJcrNodeIdentifier(infectedJcrNodePath);
+    String jcrNodeWorkspace = getJcrNodeWorkspace(infectedJcrNodePath);
+    List<Map<String, String>> infectedItems = new ArrayList<Map<String, String>>();
+    try {
+      ExtendedSession session = (ExtendedSession) WCMCoreUtils.getSystemSessionProvider().getSession(jcrNodeWorkspace, repositoryService.getCurrentRepository());
+      Property infectedJcrNodeProperty = session.getPropertyByIdentifier(infectedJcrNodeIdentifier);
+      if (infectedJcrNodeProperty.getName().equals(NodetypeConstant.JCR_DATA)) {
+        Node infectedJcrContentNode = infectedJcrNodeProperty.getParent();
+        Node infectedJcNode = infectedJcrContentNode.getParent();
+        long startTime = System.currentTimeMillis();
+        Map<String, String> infectedItem = new HashMap<String, String>();
+        infectedItem.put(INFECTED_ITEM_NAME, infectedJcNode.getName());
+        infectedItem.put(INFECTED_ITEM_LAST_MODIFIER, infectedJcNode.getProperty(NodetypeConstant.EXO_LAST_MODIFIER).getString());
+        infectedItems.add(infectedItem);
+        long endTime = System.currentTimeMillis();
+        LOGGER.info("service={} operation={} parameters=\"fileId:{}\" \"fileName:{}\" \"lastModifier:{}\" status=ok " + "duration_ms={}",
+                    MALWARE_DETECTION_FEATURE,
+                    MALWARE_INFECTED_FILE_DETECTION,
+                    ((NodeImpl) infectedJcNode).getIdentifier(),
+                    infectedJcNode.getName(),
+                    infectedJcNode.getProperty(NodetypeConstant.EXO_LAST_MODIFIER).getString(),
+                    endTime - startTime);
+      }
+    } catch (Exception e) {
+      LOGGER.error("Error when trying to get the infected item informations from fileIdentifier={}", infectedJcrNodeIdentifier, e);
+    }
+    return infectedItems;
+  }
+
+  public void cleanInfectedItem(String infectedJcrNodePath) {
+    // TODO
+  }
+
+  private String getJcrNodeIdentifier(String infectedJcrNodePath) {
+    String infectedFileIdentifier = StringUtils.substringAfter(infectedJcrNodePath, PORTAL_CONTAINER);
+    infectedFileIdentifier = StringUtils.substringBeforeLast(infectedFileIdentifier, MalwareDetectionService.getJcrNodePathSeparator(infectedJcrNodePath));
+    return StringUtils.remove(infectedFileIdentifier, MalwareDetectionService.getJcrNodePathSeparator(infectedJcrNodePath));
+
+  }
+
+  private String getJcrNodeWorkspace(String infectedJcrNodePath) {
+    return StringUtils.substringBetween(infectedJcrNodePath, MalwareDetectionService.VALUES + MalwareDetectionService.getJcrNodePathSeparator(infectedJcrNodePath), PORTAL_CONTAINER);
+  }
+}

--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/malwareDetection/MalwareDetectionJcrConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/malwareDetection/MalwareDetectionJcrConnector.java
@@ -19,17 +19,23 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.services.wcm.core.NodetypeConstant;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.social.service.malwareDetection.MalwareDetectionService;
-import org.exoplatform.social.service.malwareDetection.connector.MalwareDetectionServiceConnector;
+import org.exoplatform.social.service.malwareDetection.connector.MalwareDetectionItemConnector;
 
-public class JcrMalwareDetectionServiceConnector extends MalwareDetectionServiceConnector {
+public class MalwareDetectionJcrConnector extends MalwareDetectionItemConnector {
 
-  private static final Log  LOGGER = ExoLogger.getExoLogger(JcrMalwareDetectionServiceConnector.class);
+  private static final Log LOGGER = ExoLogger.getExoLogger(MalwareDetectionJcrConnector.class);
   
   private static final String PORTAL_CONTAINER = "_portal";
 
   private RepositoryService repositoryService;
+  
+  private  static final String JCR = "jcr";
+  
+  private static final String VALUES = "values";
+  
+  private static final String MALWARE_INFECTED_JCR_NODE_DETECTION = "MalwareInfectedJcrNodeDetection";
 
-  public JcrMalwareDetectionServiceConnector(InitParams initParams, RepositoryService repositoryService) {
+  public MalwareDetectionJcrConnector(InitParams initParams, RepositoryService repositoryService) {
     super(initParams);
     this.repositoryService = repositoryService;
   }
@@ -38,7 +44,7 @@ public class JcrMalwareDetectionServiceConnector extends MalwareDetectionService
   public List<Map<String, String>> getInfectedItems(String infectedJcrNodePath) {
     String infectedJcrNodeIdentifier = getJcrNodeIdentifier(infectedJcrNodePath);
     String jcrNodeWorkspace = getJcrNodeWorkspace(infectedJcrNodePath);
-    List<Map<String, String>> infectedItems = new ArrayList<Map<String, String>>();
+    List<Map<String, String>> infectedJcrNodes = new ArrayList<Map<String, String>>();
     try {
       ExtendedSession session = (ExtendedSession) WCMCoreUtils.getSystemSessionProvider().getSession(jcrNodeWorkspace, repositoryService.getCurrentRepository());
       Property infectedJcrNodeProperty = session.getPropertyByIdentifier(infectedJcrNodeIdentifier);
@@ -46,37 +52,45 @@ public class JcrMalwareDetectionServiceConnector extends MalwareDetectionService
         Node infectedJcrContentNode = infectedJcrNodeProperty.getParent();
         Node infectedJcNode = infectedJcrContentNode.getParent();
         long startTime = System.currentTimeMillis();
-        Map<String, String> infectedItem = new HashMap<String, String>();
-        infectedItem.put(INFECTED_ITEM_NAME, infectedJcNode.getName());
-        infectedItem.put(INFECTED_ITEM_LAST_MODIFIER, infectedJcNode.getProperty(NodetypeConstant.EXO_LAST_MODIFIER).getString());
-        infectedItems.add(infectedItem);
+        Map<String, String> infectedJcrNode = new HashMap<String, String>();
+        infectedJcrNode.put(INFECTED_ITEM_NAME, infectedJcNode.getName());
+        infectedJcrNode.put(INFECTED_ITEM_LAST_MODIFIER, infectedJcNode.getProperty(NodetypeConstant.EXO_LAST_MODIFIER).getString());
+        infectedJcrNodes.add(infectedJcrNode);
         long endTime = System.currentTimeMillis();
-        LOGGER.info("service={} operation={} parameters=\"fileId:{}\" \"fileName:{}\" \"lastModifier:{}\" status=ok " + "duration_ms={}",
+        LOGGER.info("service={} operation={} parameters=\"jcrNodeIdentifier:{}\" \"jcrNodeName:{}\" \"jcrNodeLastModifier:{}\" status=ok " + "duration_ms={}",
                     MALWARE_DETECTION_FEATURE,
-                    MALWARE_INFECTED_FILE_DETECTION,
+                    MALWARE_INFECTED_JCR_NODE_DETECTION,
                     ((NodeImpl) infectedJcNode).getIdentifier(),
                     infectedJcNode.getName(),
                     infectedJcNode.getProperty(NodetypeConstant.EXO_LAST_MODIFIER).getString(),
                     endTime - startTime);
       }
     } catch (Exception e) {
-      LOGGER.error("Error when trying to get the infected item informations from fileIdentifier={}", infectedJcrNodeIdentifier, e);
+      LOGGER.error("Error when trying to get the infected jcr node informations from jcrNodeIdentifier={}", infectedJcrNodeIdentifier, e);
     }
-    return infectedItems;
+    return infectedJcrNodes;
   }
 
+  @Override
   public void cleanInfectedItem(String infectedJcrNodePath) {
     // TODO
   }
+  
+  @Override
+  public boolean canProcessInfectedItem(String infectedJcrNodePath) {
+    String infectedJcrNodePathSeparator = MalwareDetectionService.getPathSeparator(infectedJcrNodePath);
+    return infectedJcrNodePath.contains(infectedJcrNodePathSeparator + JCR + infectedJcrNodePathSeparator + VALUES + infectedJcrNodePathSeparator);
+  }
 
   private String getJcrNodeIdentifier(String infectedJcrNodePath) {
-    String infectedFileIdentifier = StringUtils.substringAfter(infectedJcrNodePath, PORTAL_CONTAINER);
-    infectedFileIdentifier = StringUtils.substringBeforeLast(infectedFileIdentifier, MalwareDetectionService.getJcrNodePathSeparator(infectedJcrNodePath));
-    return StringUtils.remove(infectedFileIdentifier, MalwareDetectionService.getJcrNodePathSeparator(infectedJcrNodePath));
+    String infectedJcrNodeIdentifier = StringUtils.substringAfter(infectedJcrNodePath, PORTAL_CONTAINER);
+    String infectedJcrNodePathSeparator = MalwareDetectionService.getPathSeparator(infectedJcrNodePath);
+    infectedJcrNodeIdentifier = StringUtils.substringBeforeLast(infectedJcrNodeIdentifier, infectedJcrNodePathSeparator);
+    return StringUtils.remove(infectedJcrNodeIdentifier, infectedJcrNodePathSeparator);
 
   }
 
   private String getJcrNodeWorkspace(String infectedJcrNodePath) {
-    return StringUtils.substringBetween(infectedJcrNodePath, MalwareDetectionService.VALUES + MalwareDetectionService.getJcrNodePathSeparator(infectedJcrNodePath), PORTAL_CONTAINER);
+    return StringUtils.substringBetween(infectedJcrNodePath, VALUES + MalwareDetectionService.getPathSeparator(infectedJcrNodePath), PORTAL_CONTAINER);
   }
 }

--- a/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-connector-configuration.xml
+++ b/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-connector-configuration.xml
@@ -181,14 +181,14 @@
     </component-plugin>
   </external-component-plugins>
   
-<!-- Malware Detection Service Connector -->
+<!-- Malware Detection Jcr Connector -->
   <external-component-plugins>
     <target-component>org.exoplatform.social.service.malwareDetection.MalwareDetectionService</target-component>
     <component-plugin>
-      <name>MalwareDetectionServiceConnector</name>
+      <name>MalwareDetectionJcrConnector</name>
       <set-method>addConnector</set-method>
-      <type>org.exoplatform.ecm.connector.malwareDetection.JcrMalwareDetectionServiceConnector</type>
-      <description>Jcr Malware Detection Service Connector</description>
+      <type>org.exoplatform.ecm.connector.malwareDetection.MalwareDetectionJcrConnector</type>
+      <description>Malware Detection JCR Connector</description>
       <init-params>
         <properties-param>
           <name>constructor.params</name>
@@ -198,6 +198,6 @@
       </init-params>
     </component-plugin>
   </external-component-plugins>
-<!-- Malware Detection Service Connector -->  
+<!-- Malware Detection Jcr Connector -->  
 
 </configuration>

--- a/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-connector-configuration.xml
+++ b/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-connector-configuration.xml
@@ -180,5 +180,24 @@
       </init-params>
     </component-plugin>
   </external-component-plugins>
+  
+<!-- Malware Detection Service Connector -->
+  <external-component-plugins>
+    <target-component>org.exoplatform.social.service.malwareDetection.MalwareDetectionService</target-component>
+    <component-plugin>
+      <name>MalwareDetectionServiceConnector</name>
+      <set-method>addConnector</set-method>
+      <type>org.exoplatform.ecm.connector.malwareDetection.JcrMalwareDetectionServiceConnector</type>
+      <description>Jcr Malware Detection Service Connector</description>
+      <init-params>
+        <properties-param>
+          <name>constructor.params</name>
+          <property name="enable" value="true"/>
+          <property name="type" value="jcr"/>
+        </properties-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+<!-- Malware Detection Service Connector -->  
 
 </configuration>


### PR DESCRIPTION
This PR implements JcrMalwareDetectionServiceConnector which allows to detect jcr nodes as malwares for example after uploading a document in File explorer, a FS file example is generated into /data/jcr/values/collaboration_portal/2/6/e/7/e/6/4/70a004b0127cfa3f996100298/26e7e6470a004b0127cfa3f9961002980 of the server,  the last part of the file path is the jcr:data property identifier the connector will detect this identifier, get the corresponding nt:file node using Jcr API then send the notification.