### PR TITLE
TASK-41656: Implement new Attachments App rest endpoints

### DIFF
--- a/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-connector-configuration.xml
+++ b/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-connector-configuration.xml
@@ -80,18 +80,6 @@
     <type>org.exoplatform.wcm.connector.collaboration.DocumentEditorsRESTService</type>
   </component>
   <component>
-    <type>org.exoplatform.services.attachments.dao.AttachmentsDAO</type>
-  </component>
-  <component>
-    <key>org.exoplatform.services.attachments.service.AttachmentsService</key>
-    <type>org.exoplatform.services.attachments.service.AttachmentsServiceImpl</type>
-  </component>
-  <component>
-    <key>org.exoplatform.services.attachments.storage.AttachmentsStorage</key>
-    <type>org.exoplatform.services.attachments.storage.AttachmentsStorageImpl</type>
-  </component>
-  
-  <component>
     <type>org.exoplatform.wcm.connector.fckeditor.DriverConnector</type>
     <init-params>
       <value-param>
@@ -211,20 +199,5 @@
   </external-component-plugins>
 <!-- Malware Detection Jcr Connector -->  
 
-  <external-component-plugins>
-    <target-component>org.exoplatform.commons.api.persistence.DataInitializer</target-component>
-    <component-plugin>
-      <name>AttachmentsContextRDBMSChangeLogsPlugin</name>
-      <set-method>addChangeLogsPlugin</set-method>
-      <type>org.exoplatform.commons.persistence.impl.ChangeLogsPlugin</type>
-      <init-params>
-        <values-param>
-          <name>changelogs</name>
-          <description>Change logs of Attachments Context RDBMS</description>
-          <value>db/changelog/attachments-context-rdbms.db.changelog.xml</value>
-        </values-param>
-      </init-params>
-    </component-plugin>
-  </external-component-plugins>
 
 </configuration>

--- a/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-connector-configuration.xml
+++ b/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-connector-configuration.xml
@@ -79,6 +79,17 @@
   <component>
     <type>org.exoplatform.wcm.connector.collaboration.DocumentEditorsRESTService</type>
   </component>
+  <component>
+    <type>org.exoplatform.services.attachments.dao.AttachmentsDAO</type>
+  </component>
+  <component>
+    <key>org.exoplatform.services.attachments.service.AttachmentsService</key>
+    <type>org.exoplatform.services.attachments.service.AttachmentsServiceImpl</type>
+  </component>
+  <component>
+    <key>org.exoplatform.services.attachments.storage.AttachmentsStorage</key>
+    <type>org.exoplatform.services.attachments.storage.AttachmentsStorageImpl</type>
+  </component>
   
   <component>
     <type>org.exoplatform.wcm.connector.fckeditor.DriverConnector</type>
@@ -199,5 +210,21 @@
     </component-plugin>
   </external-component-plugins>
 <!-- Malware Detection Jcr Connector -->  
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.api.persistence.DataInitializer</target-component>
+    <component-plugin>
+      <name>AttachmentsContextRDBMSChangeLogsPlugin</name>
+      <set-method>addChangeLogsPlugin</set-method>
+      <type>org.exoplatform.commons.persistence.impl.ChangeLogsPlugin</type>
+      <init-params>
+        <values-param>
+          <name>changelogs</name>
+          <description>Change logs of Attachments Context RDBMS</description>
+          <value>db/changelog/attachments-context-rdbms.db.changelog.xml</value>
+        </values-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
 
 </configuration>

--- a/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/db/changelog/attachments-context-rdbms.db.changelog.xml
+++ b/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/db/changelog/attachments-context-rdbms.db.changelog.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (C) 2003-2018 eXo Platform SAS. This is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1 of the License, or (at your option) any later version. This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public 
+  License for more details. You should have received a copy of the GNU Lesser General Public License along with this software; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF site: http://www.fsf.org. -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+  <!-- Managing both DB that use sequences and db that use auto increment -->
+  <property name="autoIncrement" value="true" dbms="mysql,mssql,h2,sybase,db2,hsqldb" />
+  <property name="autoIncrement" value="false" dbms="oracle,postgresql" />
+
+  <changeSet author="attachments" id="1.0.0-0" dbms="oracle,postgresql">
+    <createSequence sequenceName="SEQ_ATTACHMENTS_CONTEXT_ID" startValue="1" />
+  </changeSet>
+
+  <changeSet author="attachments" id="1.0.0-1">
+    <createTable tableName="EXO_ATTACHMENTS_CONTEXT">
+      <column name="ATTACHMENTS_CONTEXT_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="PK_ATTACHMENTS_CONTEXT" />
+      </column>
+      <column name="ATTACHMENT_IDS" type="NVARCHAR(1000)"/>
+      <column name="ENTITY_ID" type="BIGINT" />
+      <column name="ENTITY_TYPE" type="NVARCHAR(35)" />
+    </createTable>
+    <modifySql dbms="mysql">
+      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+    </modifySql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/core/services/pom.xml
+++ b/core/services/pom.xml
@@ -11,6 +11,7 @@
   <description>eXo CMS Service</description>
   <properties>
     <exo.test.coverage.ratio>0.34</exo.test.coverage.ratio>
+    <org.lombok.version>1.18.2</org.lombok.version>
   </properties>
   <dependencies>
     <dependency>
@@ -294,6 +295,12 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>${org.lombok.version}</version>
+      <scope>provided</scope>
     </dependency>
     <!-- for tests -->
     <!-- dependency>

--- a/core/services/pom.xml
+++ b/core/services/pom.xml
@@ -302,6 +302,16 @@
       <version>${org.lombok.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
     <!-- for tests -->
     <!-- dependency>
       <groupId>org.slf4j</groupId>

--- a/core/services/src/main/java/org/exoplatform/services/attachments/dao/AttachmentsDAO.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/dao/AttachmentsDAO.java
@@ -1,0 +1,22 @@
+package org.exoplatform.services.attachments.dao;
+
+import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
+import org.exoplatform.services.attachments.model.AttachmentsContextEntity;
+
+import javax.persistence.NoResultException;
+import javax.persistence.TypedQuery;
+
+public class AttachmentsDAO extends GenericDAOJPAImpl<AttachmentsContextEntity, Long> {
+
+  public AttachmentsContextEntity getAttachmentContextByEntity(long entityId, String entityType) {
+    TypedQuery<AttachmentsContextEntity> query = getEntityManager().createNamedQuery("AttachmentsContext.getAttachmentContextByEntity",
+            AttachmentsContextEntity.class);
+    query.setParameter("entityId", entityId);
+    query.setParameter("entityType", entityType);
+    try {
+      return query.getSingleResult();
+    } catch (NoResultException e) {
+      return null;
+    }
+  }
+}

--- a/core/services/src/main/java/org/exoplatform/services/attachments/model/Attachment.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/model/Attachment.java
@@ -1,0 +1,37 @@
+package org.exoplatform.services.attachments.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Attachment implements Cloneable {
+  private String id;
+  private String title;
+  private long size;
+  private String mimetype;
+  private String path;
+  private Boolean isPublic;
+  private Permission acl;
+  private long creatorId;
+  private String created;
+  private String updater;
+  private String updated;
+
+  @Override
+  public Attachment clone() { // NOSONAR
+    return new Attachment(id,
+            title,
+            size,
+            mimetype,
+            path,
+            isPublic,
+            acl,
+            creatorId,
+            created,
+            updater,
+            updated);
+  }
+}

--- a/core/services/src/main/java/org/exoplatform/services/attachments/model/AttachmentsContextEntity.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/model/AttachmentsContextEntity.java
@@ -1,0 +1,65 @@
+package org.exoplatform.services.attachments.model;
+
+import org.exoplatform.commons.api.persistence.ExoEntity;
+import javax.persistence.*;
+
+@Entity(name = "AttachmentsContext")
+@ExoEntity
+@Table(name = "EXO_ATTACHMENTS_CONTEXT")
+@NamedQueries(
+  {
+    @NamedQuery(
+      name = "AttachmentsContext.getAttachmentContextByEntity",
+      query = "SELECT ac FROM AttachmentsContext ac WHERE ac.entityId = :entityId AND ac.entityType = :entityType"
+    )
+  }
+)
+public class AttachmentsContextEntity {
+
+  @Id
+  @SequenceGenerator(name = "SEQ_ATTACHMENTS_CONTEXT_ID", sequenceName = "SEQ_ATTACHMENTS_CONTEXT_ID")
+  @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_ATTACHMENTS_CONTEXT_ID")
+  @Column(name = "ATTACHMENTS_CONTEXT_ID")
+  private Long id;
+
+  @Column(name = "ATTACHMENT_IDS")
+  private String attachmentIds;
+
+  @Column(name = "ENTITY_ID")
+  private Long entityId;
+
+  @Column(name = "ENTITY_TYPE")
+  private String entityType;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getAttachmentIds() {
+    return attachmentIds;
+  }
+
+  public void setAttachmentIds(String attachmentIds) {
+    this.attachmentIds = attachmentIds;
+  }
+
+  public Long getEntityId() {
+    return entityId;
+  }
+
+  public void setEntityId(Long entityId) {
+    this.entityId = entityId;
+  }
+
+  public String getEntityType() {
+    return entityType;
+  }
+
+  public void setEntityType(String entityType) {
+    this.entityType = entityType;
+  }
+}

--- a/core/services/src/main/java/org/exoplatform/services/attachments/model/AttachmentsContextEntity.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/model/AttachmentsContextEntity.java
@@ -2,6 +2,7 @@ package org.exoplatform.services.attachments.model;
 
 import org.exoplatform.commons.api.persistence.ExoEntity;
 import javax.persistence.*;
+import java.io.Serializable;
 
 @Entity(name = "AttachmentsContext")
 @ExoEntity
@@ -14,7 +15,9 @@ import javax.persistence.*;
     )
   }
 )
-public class AttachmentsContextEntity {
+public class AttachmentsContextEntity implements Serializable {
+
+  private static final long         serialVersionUID = -6445215481619188461L;
 
   @Id
   @SequenceGenerator(name = "SEQ_ATTACHMENTS_CONTEXT_ID", sequenceName = "SEQ_ATTACHMENTS_CONTEXT_ID")

--- a/core/services/src/main/java/org/exoplatform/services/attachments/model/AttachmentsEntityType.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/model/AttachmentsEntityType.java
@@ -1,0 +1,5 @@
+package org.exoplatform.services.attachments.model;
+
+public enum AttachmentsEntityType {
+  WIKI, EVENT, TASK;
+}

--- a/core/services/src/main/java/org/exoplatform/services/attachments/model/Permission.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/model/Permission.java
@@ -1,0 +1,24 @@
+package org.exoplatform.services.attachments.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Permission implements Cloneable, Serializable {
+
+  private static final long serialVersionUID = 3495355054244658657L;
+
+  private boolean           canEdit;
+
+  private boolean           canRemove;
+
+  @Override
+  public Permission clone() { // NOSONAR
+    return new Permission(canEdit, canRemove);
+  }
+}

--- a/core/services/src/main/java/org/exoplatform/services/attachments/rest/model/AttachmentEntity.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/rest/model/AttachmentEntity.java
@@ -1,0 +1,40 @@
+package org.exoplatform.services.attachments.rest.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.exoplatform.services.attachments.model.Permission;
+import org.exoplatform.social.rest.entity.IdentityEntity;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AttachmentEntity {
+  private String id;
+  private String title;
+  private long size;
+  private String mimetype;
+  private String path;
+  private Boolean isPublic;
+  private Permission acl;
+  private IdentityEntity creator;
+  private String created;
+  private IdentityEntity updater;
+  private String updated;
+
+  @Override
+  public AttachmentEntity clone() { // NOSONAR
+    return new AttachmentEntity(id,
+            title,
+            size,
+            mimetype,
+            path,
+            isPublic,
+            acl,
+            creator,
+            created,
+            updater,
+            updated);
+  }
+
+}

--- a/core/services/src/main/java/org/exoplatform/services/attachments/rest/model/AttachmentsContext.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/rest/model/AttachmentsContext.java
@@ -1,0 +1,25 @@
+package org.exoplatform.services.attachments.rest.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.exoplatform.services.attachments.model.AttachmentsEntityType;
+import java.io.Serializable;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AttachmentsContext  implements Serializable, Cloneable{
+  private static final long serialVersionUID = -8173593686976273638L;
+  private long id;
+  private List<String> attachmentIds;
+  private long entityId;
+  private AttachmentsEntityType attachmentsEntityType;
+
+  @Override
+  public AttachmentsContext clone() {// NOSONAR
+    return new AttachmentsContext(id, attachmentIds, entityId, attachmentsEntityType);
+  }
+
+}

--- a/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentsService.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentsService.java
@@ -1,0 +1,12 @@
+package org.exoplatform.services.attachments.service;
+
+import org.exoplatform.services.attachments.model.Attachment;
+import org.exoplatform.services.attachments.rest.model.AttachmentsContext;
+import java.util.List;
+
+public interface AttachmentsService {
+
+  void linkAttachmentsToContext(AttachmentsContext attachmentsContext);
+
+  List<Attachment> getAttachmentsByEntity(long entityId, String entityType) throws Exception;
+}

--- a/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentsServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentsServiceImpl.java
@@ -1,0 +1,155 @@
+package org.exoplatform.services.attachments.service;
+
+import org.apache.commons.lang.StringUtils;
+import org.exoplatform.services.attachments.model.Permission;
+import org.exoplatform.services.attachments.model.Attachment;
+import org.exoplatform.services.attachments.model.AttachmentsContextEntity;
+import org.exoplatform.services.attachments.rest.model.AttachmentsContext;
+import org.exoplatform.services.attachments.storage.AttachmentsStorage;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.access.PermissionType;
+import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.wcm.utils.WCMCoreUtils;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AttachmentsServiceImpl implements AttachmentsService {
+  private static final Log LOG = ExoLogger.getLogger(AttachmentsServiceImpl.class.getName());
+
+  AttachmentsStorage attachmentsStorage;
+
+  public AttachmentsServiceImpl(AttachmentsStorage attachmentsStorage) {
+    this.attachmentsStorage = attachmentsStorage;
+  }
+
+  @Override
+  public void linkAttachmentsToContext(AttachmentsContext attachmentsContext) {
+    if (attachmentsContext == null) {
+      throw new IllegalArgumentException("attachmentsContext object is mandatory");
+    }
+
+    if (attachmentsContext.getAttachmentIds() == null || attachmentsContext.getAttachmentIds().size() <= 0) {
+      throw new IllegalArgumentException("attachmentsIds must not be empty");
+    }
+
+    if (attachmentsContext.getEntityId() <= 0) {
+      throw new IllegalArgumentException("Entity Id must be positive");
+    }
+
+    if (attachmentsContext.getAttachmentsEntityType() == null) {
+      throw new IllegalArgumentException("Entity type is mandatory");
+    }
+    long entityId = attachmentsContext.getEntityId();
+    String entityType = attachmentsContext.getAttachmentsEntityType().toString();
+    AttachmentsContextEntity attachmentsContextEntity = attachmentsStorage.getAttachmentContextByEntity(entityId, entityType);
+
+    if(attachmentsContextEntity == null) {
+      attachmentsContextEntity = new AttachmentsContextEntity();
+    }
+
+    attachmentsContextEntity.setEntityId(entityId);
+    attachmentsContextEntity.setEntityType(entityType);
+    List<String> attachmentIds = attachmentsContext.getAttachmentIds();
+    attachmentsContextEntity.setAttachmentIds(attachmentIds.stream().map(Object::toString).collect(Collectors.joining(",")));
+
+    attachmentsStorage.linkAttachmentsToContext(attachmentsContextEntity);
+  }
+
+  @Override
+  public List<Attachment> getAttachmentsByEntity(long entityId, String entityType) throws Exception {
+    if (entityId <= 0) {
+      throw new IllegalArgumentException("Entity Id should be positive");
+    }
+    if (StringUtils.isEmpty(entityType)) {
+      throw new IllegalArgumentException("Entity type is mandatory");
+    }
+
+    AttachmentsContextEntity attachmentsContext = attachmentsStorage.getAttachmentContextByEntity(entityId, entityType);
+    List<Attachment> attachments = new ArrayList<>();
+    if (attachmentsContext != null && StringUtils.isNotEmpty(attachmentsContext.getAttachmentIds())) {
+      List<String> attachmentsIds = new ArrayList<>(Arrays.asList(
+              attachmentsContext.getAttachmentIds().split(",")
+      ));
+      String currentWorkspaceName = getCurrentWorkspaceName();
+      Session session = getSession(currentWorkspaceName);
+      attachmentsIds.forEach(attachmentId -> {
+        try {
+          Node attachmentNode = session.getNodeByUUID(attachmentId);
+          Attachment attachment = new Attachment();
+          attachment.setId(attachmentNode.getUUID());
+          attachment.setTitle(getStringProperty(attachmentNode, "exo:title"));
+          attachment.setPath(attachmentNode.getPath());
+          attachment.setCreated(getStringProperty(attachmentNode, "exo:dateCreated"));
+          //attachment.setCreatorId(Long.parseLong(getStringProperty(attachmentNode, "exo:owner")));
+          if (attachmentNode.hasProperty("exo:dateModified")) {
+            attachment.setUpdated(getStringProperty(attachmentNode, "exo:dateModified"));
+          } else {
+            attachment.setUpdated(null);
+          }
+          if (attachmentNode.hasProperty("exo:lastModifier")) {
+            attachment.setUpdater(getStringProperty(attachmentNode, "exo:lastModifier"));
+          } else {
+            attachment.setUpdater(null);
+          }
+          attachment.setMimetype(getStringProperty(attachmentNode, "jcr:primaryType"));
+
+          boolean canRemove = true;
+          try {
+            session.checkPermission(attachmentNode.getPath(), PermissionType.REMOVE);
+          } catch (Exception e) {
+            canRemove = false;
+          }
+
+          boolean canEdit = true;
+          try {
+            session.checkPermission(attachmentNode.getPath(), PermissionType.SET_PROPERTY);
+          } catch (Exception e) {
+            canEdit = false;
+          }
+
+          Permission permission = new Permission(canEdit, canRemove);
+          attachment.setAcl(permission);
+          long size = attachmentNode.getNode("jcr:content").getProperty("jcr:data").getLength();
+          attachment.setSize(size);
+          attachments.add(attachment);
+        } catch (Exception e) {
+          LOG.error("Cannot get attachment with id " + attachmentId + " of entity " + entityType + " with id " + entityId, e);
+        }
+      });
+    }
+    return attachments;
+  }
+
+  private String getCurrentWorkspaceName() throws RepositoryException {
+    RepositoryService repositoryService = WCMCoreUtils.getService(RepositoryService.class);
+    return repositoryService.getCurrentRepository().getConfiguration().getDefaultWorkspaceName();
+  }
+
+  private Session getSession(String workspaceName) throws Exception {
+    SessionProvider sessionProvider = WCMCoreUtils.getUserSessionProvider();
+    ManageableRepository manageableRepository = getCurrentRepository();
+    return sessionProvider.getSession(workspaceName, manageableRepository);
+  }
+
+  private ManageableRepository getCurrentRepository() throws RepositoryException {
+    RepositoryService repositoryService = WCMCoreUtils.getService(RepositoryService.class);
+    return repositoryService.getCurrentRepository();
+  }
+
+  private String getStringProperty(Node node, String propertyName) throws RepositoryException {
+    if (node.hasProperty(propertyName)) {
+      return node.getProperty(propertyName).getString();
+    }
+    return "";
+  }
+
+}

--- a/core/services/src/main/java/org/exoplatform/services/attachments/storage/AttachmentsStorage.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/storage/AttachmentsStorage.java
@@ -1,0 +1,9 @@
+package org.exoplatform.services.attachments.storage;
+
+import org.exoplatform.services.attachments.model.AttachmentsContextEntity;
+
+public interface AttachmentsStorage {
+  void linkAttachmentsToContext(AttachmentsContextEntity attachmentsContextEntity);
+
+  AttachmentsContextEntity getAttachmentContextByEntity(long entityId, String entityType);
+}

--- a/core/services/src/main/java/org/exoplatform/services/attachments/storage/AttachmentsStorageImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/storage/AttachmentsStorageImpl.java
@@ -1,0 +1,27 @@
+package org.exoplatform.services.attachments.storage;
+
+import org.exoplatform.services.attachments.dao.AttachmentsDAO;
+import org.exoplatform.services.attachments.model.AttachmentsContextEntity;
+
+public class AttachmentsStorageImpl implements AttachmentsStorage {
+
+  AttachmentsDAO attachmentsDAO;
+
+  public AttachmentsStorageImpl(AttachmentsDAO attachmentsDAO) {
+    this.attachmentsDAO = attachmentsDAO;
+  }
+  @Override
+  public void linkAttachmentsToContext(AttachmentsContextEntity attachmentsContextEntity) {
+    if (attachmentsContextEntity.getId() == null) {
+      attachmentsDAO.create(attachmentsContextEntity);
+    } else {
+      attachmentsDAO.update(attachmentsContextEntity);
+    }
+  }
+
+  @Override
+  public AttachmentsContextEntity getAttachmentContextByEntity(long entityId, String entityType) {
+    return attachmentsDAO.getAttachmentContextByEntity(entityId, entityType);
+  }
+
+}

--- a/core/services/src/main/java/org/exoplatform/services/attachments/utils/EntityBuilder.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/utils/EntityBuilder.java
@@ -1,0 +1,42 @@
+package org.exoplatform.services.attachments.utils;
+
+import org.exoplatform.services.attachments.model.Attachment;
+import org.exoplatform.services.attachments.rest.model.AttachmentEntity;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.rest.entity.IdentityEntity;
+
+public class EntityBuilder {
+
+  private static final String IDENTITIES_REST_PATH = "/v1/social/identities"; // NOSONAR
+
+  private static final String IDENTITIES_EXPAND = "all";
+
+  public static final AttachmentEntity fromAttachment(IdentityManager identityManager, Attachment attachment) {
+    return new AttachmentEntity(attachment.getId(),
+            attachment.getTitle(),
+            attachment.getSize(),
+            attachment.getMimetype(),
+            attachment.getPath(),
+            attachment.getIsPublic(),
+            attachment.getAcl(),
+            null,
+            attachment.getCreated(),
+            getIdentityEntity(identityManager, attachment.getUpdater()),
+            attachment.getUpdated()
+    );
+  }
+
+  private static IdentityEntity getIdentityEntity(IdentityManager identityManager, String ownerId) {
+    Identity identity = getIdentity(identityManager, ownerId);
+    if (identity == null) {
+      return null;
+    }
+    return org.exoplatform.social.rest.api.EntityBuilder.buildEntityIdentity(identity, IDENTITIES_REST_PATH, IDENTITIES_EXPAND);
+  }
+
+  private static final Identity getIdentity(IdentityManager identityManager, String identityId) {
+    return  identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, identityId);
+  }
+}

--- a/core/services/src/main/resources/META-INF/persistence.xml
+++ b/core/services/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,13 @@
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+             version="2.0">
+
+  <persistence-unit name="exo-pu" transaction-type="RESOURCE_LOCAL">
+    <provider>org.hibernate.ejb.HibernatePersistence</provider>
+    <non-jta-data-source>java:/comp/env/exo-jpa_portal</non-jta-data-source>
+    <properties>
+      <property name="persistenceUnitName" value="exo-pu"></property>
+    </properties>
+  </persistence-unit>
+</persistence>

--- a/core/services/src/main/resources/META-INF/services/org.hibernate.integrator.spi.Integrator
+++ b/core/services/src/main/resources/META-INF/services/org.hibernate.integrator.spi.Integrator
@@ -1,0 +1,2 @@
+# Define integrators that should be instantiated by the ServiceLoader
+org.exoplatform.commons.persistence.impl.ExoEntityScanner

--- a/core/services/src/main/resources/changelog/attachments-context-rdbms.db.changelog.xml
+++ b/core/services/src/main/resources/changelog/attachments-context-rdbms.db.changelog.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (C) 2003-2018 eXo Platform SAS. This is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1 of the License, or (at your option) any later version. This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public 
+  License for more details. You should have received a copy of the GNU Lesser General Public License along with this software; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF site: http://www.fsf.org. -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+  <!-- Managing both DB that use sequences and db that use auto increment -->
+  <property name="autoIncrement" value="true" dbms="mysql,mssql,h2,sybase,db2,hsqldb" />
+  <property name="autoIncrement" value="false" dbms="oracle,postgresql" />
+
+  <changeSet author="attachments" id="1.0.0-0" dbms="oracle,postgresql">
+    <createSequence sequenceName="SEQ_ATTACHMENTS_CONTEXT_ID" startValue="1" />
+  </changeSet>
+
+  <changeSet author="attachments" id="1.0.0-1">
+    <createTable tableName="EXO_ATTACHMENTS_CONTEXT">
+      <column name="ATTACHMENTS_CONTEXT_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="PK_ATTACHMENTS_CONTEXT" />
+      </column>
+      <column name="ATTACHMENT_IDS" type="NVARCHAR(1000)"/>
+      <column name="ENTITY_ID" type="BIGINT" />
+      <column name="ENTITY_TYPE" type="NVARCHAR(35)" />
+    </createTable>
+    <modifySql dbms="mysql">
+      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
+    </modifySql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/core/services/src/main/resources/conf/portal/configuration.xml
+++ b/core/services/src/main/resources/conf/portal/configuration.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (C) 2018 eXo Platform SAS. This is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1 of the License, or (at your option) any later version. This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License 
+  for more details. You should have received a copy of the GNU Lesser General Public License along with this software; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF site: http://www.fsf.org. -->
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd" xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+
+  <component>
+    <type>org.exoplatform.services.attachments.dao.AttachmentsDAO</type>
+  </component>
+  <component>
+    <key>org.exoplatform.services.attachments.service.AttachmentsService</key>
+    <type>org.exoplatform.services.attachments.service.AttachmentsServiceImpl</type>
+  </component>
+  <component>
+    <key>org.exoplatform.services.attachments.storage.AttachmentsStorage</key>
+    <type>org.exoplatform.services.attachments.storage.AttachmentsStorageImpl</type>
+  </component>
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.api.persistence.DataInitializer</target-component>
+    <component-plugin>
+      <name>AttachmentsContextRDBMSChangeLogsPlugin</name>
+      <set-method>addChangeLogsPlugin</set-method>
+      <type>org.exoplatform.commons.persistence.impl.ChangeLogsPlugin</type>
+      <init-params>
+        <values-param>
+          <name>changelogs</name>
+          <description>Change logs of Attachments Context RDBMS</description>
+          <value>changelog/attachments-context-rdbms.db.changelog.xml</value>
+        </values-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+</configuration>

--- a/core/services/src/test/java/org/exoplatform/services/attachments/service/AttachmentsServiceTest.java
+++ b/core/services/src/test/java/org/exoplatform/services/attachments/service/AttachmentsServiceTest.java
@@ -1,0 +1,207 @@
+package org.exoplatform.services.attachments.service;
+
+import org.exoplatform.commons.testing.BaseExoTestCase;
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.component.test.ConfigurationUnit;
+import org.exoplatform.component.test.ConfiguredBy;
+import org.exoplatform.component.test.ContainerScope;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.exoplatform.services.attachments.model.Attachment;
+import org.exoplatform.services.attachments.model.AttachmentsEntityType;
+import org.exoplatform.services.attachments.rest.model.AttachmentsContext;
+import org.exoplatform.services.attachments.storage.AttachmentsStorage;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.config.RepositoryEntry;
+import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.jcr.ext.app.SessionProviderService;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.Session;
+import javax.jcr.Workspace;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+
+@ConfiguredBy({
+        @ConfigurationUnit(scope = ContainerScope.ROOT, path = "conf/configuration.xml"),
+        @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/exo.portal.component.portal-configuration.xml"),
+        @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/exo.portal.component.identity-configuration.xml"),
+        @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/attachments/attachments-test-configuration.xml")})
+@RunWith(MockitoJUnitRunner.class)
+public class AttachmentsServiceTest extends BaseExoTestCase {
+
+  protected AttachmentsService attachmentsService;
+
+  AttachmentsStorage attachmentsStorage;
+
+  @Mock
+  RepositoryService repositoryService;
+
+  @Mock
+  SessionProviderService sessionProviderService;
+
+  @Mock
+  ManageableRepository repository;
+
+  @Mock
+  RepositoryEntry repositoryEntry;
+
+  @Mock
+  SessionProvider sessionProvider;
+
+  @Mock
+  Session session;
+
+  @Before
+  public void setUp() throws Exception {
+    begin();
+    attachmentsStorage = CommonsUtils.getService(AttachmentsStorage.class);
+    attachmentsService = new AttachmentsServiceImpl(attachmentsStorage, repositoryService, sessionProviderService);
+  }
+
+  @After
+  public void teardown() throws Exception {
+    super.tearDown();
+  }
+
+  @Test
+  public void testLinkAttachmentsToContext() throws Exception { // NOSONAR
+
+    try {
+      attachmentsService.linkAttachmentsToContext(null);
+      fail();
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+
+    try {
+      AttachmentsContext attachmentsContext = new AttachmentsContext();
+      attachmentsContext.setAttachmentIds(null);
+      attachmentsService.linkAttachmentsToContext(attachmentsContext);
+      fail();
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+
+    try {
+      AttachmentsContext attachmentsContext = new AttachmentsContext();
+      List<String> attachmentsIds = new ArrayList<>();
+      attachmentsContext.setAttachmentIds(attachmentsIds);
+      attachmentsService.linkAttachmentsToContext(attachmentsContext);
+      fail();
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+
+    try {
+      AttachmentsContext attachmentsContext = new AttachmentsContext();
+      List<String> attachmentsIds = new ArrayList<>();
+      attachmentsIds.add("1");
+      attachmentsIds.add("2");
+      attachmentsIds.add("3");
+      attachmentsContext.setAttachmentIds(attachmentsIds);
+      attachmentsContext.setEntityId(0);
+      attachmentsService.linkAttachmentsToContext(attachmentsContext);
+      fail();
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+
+    try {
+      AttachmentsContext attachmentsContext = new AttachmentsContext();
+      List<String> attachmentsIds = new ArrayList<>();
+      attachmentsIds.add("1");
+      attachmentsIds.add("2");
+      attachmentsIds.add("3");
+      attachmentsContext.setAttachmentIds(attachmentsIds);
+      attachmentsContext.setEntityId(5);
+      attachmentsContext.setAttachmentsEntityType(null);
+      attachmentsService.linkAttachmentsToContext(attachmentsContext);
+      fail();
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+
+    //when
+    when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
+    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
+    when(repositoryService.getCurrentRepository()).thenReturn(repository);
+    when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
+    when(sessionProvider.getSession(any(), any())).thenReturn(session);
+
+    ManageableRepository manageableRepository = repositoryService.getRepository("repository");
+    Mockito.when(repositoryService.getRepository(Mockito.anyString())).thenReturn(manageableRepository);
+    Node node1 = mock(Node.class);
+    Node nodeContent1 = mock(Node.class);
+    Property property = mock(Property.class);
+    when(session.getNodeByUUID(anyString())).thenReturn(node1);
+    Workspace workSpace = mock(Workspace.class);
+    when(session.getWorkspace()).thenReturn(workSpace);
+    when(node1.getSession()).thenReturn(session);
+    when(node1.getProperty(anyString())).thenReturn(property);
+    when(node1.getNode(anyString())).thenReturn(nodeContent1);
+    when(nodeContent1.getProperty(anyString())).thenReturn(property);
+    when(property.getDate()).thenReturn(Calendar.getInstance());
+    when(property.getLong()).thenReturn((long) 1);
+    Mockito.when(session.getNodeByUUID(String.valueOf(1))).thenReturn(node1);
+
+    Node node2 = mock(Node.class);
+    Node nodeContent2 = mock(Node.class);
+    Property property2 = mock(Property.class);
+    when(session.getNodeByUUID(anyString())).thenReturn(node2);
+    when(session.getWorkspace()).thenReturn(workSpace);
+    when(node2.getSession()).thenReturn(session);
+    when(node2.getProperty(anyString())).thenReturn(property);
+    when(node2.getNode(anyString())).thenReturn(nodeContent2);
+    when(nodeContent2.getProperty(anyString())).thenReturn(property);
+    when(property2.getDate()).thenReturn(Calendar.getInstance());
+    when(property2.getLong()).thenReturn((long) 2);
+    Mockito.when(session.getNodeByUUID(String.valueOf(2))).thenReturn(node2);
+
+    Node node3 = mock(Node.class);
+    Node nodeContent3 = mock(Node.class);
+    Property property3 = mock(Property.class);
+    when(session.getNodeByUUID(anyString())).thenReturn(node3);
+    when(session.getWorkspace()).thenReturn(workSpace);
+    when(node3.getSession()).thenReturn(session);
+    when(node3.getProperty(anyString())).thenReturn(property);
+    when(node3.getNode(anyString())).thenReturn(nodeContent3);
+    when(nodeContent3.getProperty(anyString())).thenReturn(property);
+    when(property3.getDate()).thenReturn(Calendar.getInstance());
+    when(property3.getLong()).thenReturn((long) 3);
+    Mockito.when(session.getNodeByUUID(String.valueOf(3))).thenReturn(node3);
+
+    AttachmentsContext attachmentsContext = new AttachmentsContext();
+    List<String> attachmentsIds = new ArrayList<>();
+    attachmentsIds.add("1");
+    attachmentsIds.add("2");
+    attachmentsIds.add("3");
+    attachmentsContext.setAttachmentIds(attachmentsIds);
+    attachmentsContext.setEntityId(5);
+    attachmentsContext.setAttachmentsEntityType(AttachmentsEntityType.EVENT);
+
+    //when
+    attachmentsService.linkAttachmentsToContext(attachmentsContext);
+
+    //then
+    List<Attachment> attachmentsEntityStored = attachmentsService.getAttachmentsByEntity(5, String.valueOf(AttachmentsEntityType.EVENT));
+    assertNotNull(attachmentsEntityStored);
+    assertEquals(3, attachmentsEntityStored.size());
+  }
+
+}

--- a/core/services/src/test/java/org/exoplatform/services/wcm/BaseWCMTestSuite.java
+++ b/core/services/src/test/java/org/exoplatform/services/wcm/BaseWCMTestSuite.java
@@ -18,6 +18,7 @@ package org.exoplatform.services.wcm;
 
 import org.exoplatform.commons.testing.BaseExoContainerTestSuite;
 import org.exoplatform.commons.testing.ConfigTestCase;
+import org.exoplatform.services.attachments.service.AttachmentsServiceTest;
 import org.exoplatform.services.cms.clipboard.TestClipboardService;
 import org.exoplatform.services.cms.documents.TestCustomizeViewService;
 import org.exoplatform.services.cms.documents.TestDocumentService;
@@ -117,7 +118,8 @@ import org.junit.runners.Suite.SuiteClasses;
   TestDocumentsAppRedirectService.class,
   TestDocumentService.class,
   TestCustomizeViewService.class,
-  TestXSkinService.class
+  TestXSkinService.class,
+  AttachmentsServiceTest.class
 })
 @ConfigTestCase(BaseWCMTestCase.class)
 public class BaseWCMTestSuite extends BaseExoContainerTestSuite {

--- a/core/services/src/test/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
+++ b/core/services/src/test/resources/META-INF/services/javax.ws.rs.ext.RuntimeDelegate
@@ -1,1 +1,0 @@
-org.exoplatform.services.rest.impl.RuntimeDelegateImpl

--- a/core/services/src/test/resources/conf/attachments/attachments-test-configuration.xml
+++ b/core/services/src/test/resources/conf/attachments/attachments-test-configuration.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+This file is part of the Meeds project (https://meeds.io/).
+Copyright (C) 2020 Meeds Association
+contact@meeds.io
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 3 of the License, or (at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<configuration
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
+        xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+    <!-- Attachments components -->
+    <component>
+        <key>org.exoplatform.services.attachments.service.AttachmentsService</key>
+        <type>org.exoplatform.services.attachments.service.AttachmentsServiceImpl</type>
+    </component>
+
+    <component>
+        <key>org.exoplatform.services.attachments.storage.AttachmentsStorage</key>
+        <type>org.exoplatform.services.attachments.storage.AttachmentsStorageImpl</type>
+    </component>
+
+    <component>
+        <type>org.exoplatform.services.attachments.dao.AttachmentsDAO</type>
+    </component>
+
+    <external-component-plugins>
+        <target-component>org.exoplatform.commons.api.persistence.DataInitializer</target-component>
+        <component-plugin>
+            <name>GamificationManagementChangeLogsPlugin</name>
+            <set-method>addChangeLogsPlugin</set-method>
+            <type>org.exoplatform.commons.persistence.impl.ChangeLogsPlugin</type>
+            <init-params>
+                <values-param>
+                    <name>changelogs</name>
+                    <description>Change logs of Gamification</description>
+                    <value>changelog/attachments-context-rdbms.db.changelog.xml</value>
+                </values-param>
+            </init-params>
+        </component-plugin>
+    </external-component-plugins>
+
+</configuration>

--- a/core/services/src/test/resources/mockwebapp/gatein-resources.xml
+++ b/core/services/src/test/resources/mockwebapp/gatein-resources.xml
@@ -154,7 +154,7 @@
   </module>
 
   <module>
-    <name>text</name>
+    <name>text</name>PowerMockRunner
     <script>
       <path>/js/text.js</path>
     </script>


### PR DESCRIPTION
This implementation will allow to attach files **uploaded in JCR** to any context such as events, tasks, wikis, ... By calling the first endpoint `linkAttachmentsToContext` we will save the **attachment ids** and the **entity** linked to. So on, we can provide attachments to any context who request it via the second endpoint `getAttachmentsByEntity` if **ECMS addon** is installed.