### PR TITLE
Task-41418: Update MalwareDetectionService addMalwareDetectionItemConnector configuration method

### DIFF
--- a/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-connector-configuration.xml
+++ b/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-connector-configuration.xml
@@ -186,7 +186,7 @@
     <target-component>org.exoplatform.social.service.malwareDetection.MalwareDetectionService</target-component>
     <component-plugin>
       <name>MalwareDetectionJcrConnector</name>
-      <set-method>addConnector</set-method>
+      <set-method>addMalwareDetectionItemConnector</set-method>
       <type>org.exoplatform.ecm.connector.malwareDetection.MalwareDetectionJcrConnector</type>
       <description>Malware Detection JCR Connector</description>
       <init-params>


### PR DESCRIPTION
Since MalwareDetectionItemConnector is defined for detection item type connectors and a new method addMalwareDetectionItemConnector is added for MalwareDetectionService, this PR modifies the configuration of MalwareDetectionJcrConnector in order to use the addMalwareDetectionItemConnector  method