### PR TITLE
Task-40615: Fix activity generated and displayed on the Activity Stream once creating or updating a web-content by a web-contributor

### DIFF
--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/Utils.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/Utils.java
@@ -304,7 +304,7 @@ public class Utils {
       return null;
     }
     ActivityManager activityManager = CommonsUtils.getService(ActivityManager.class);
-    activityType = StringUtils.isNotEmpty(activityType) ? activityType : FILE_SPACES;
+    activityType = StringUtils.isNotEmpty(activityType) ? activityType : CONTENT_SPACES;
     if(! activityManager.isActivityTypeEnabled(activityType)) {
       return null;
     }


### PR DESCRIPTION
Problem: the activity stream was generated once creating a web content, because the property of generating activity is enabled.
How it was solved : disable the property of generating activity from entreprise-configuration.properties.