### PR TITLE
Ensure that no element are added to queue when no keywords configured

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDLPAction.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDLPAction.java
@@ -4,6 +4,7 @@ import javax.jcr.observation.Event;
 
 import org.apache.commons.chain.Context;
 
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.api.settings.ExoFeatureService;
 import org.exoplatform.commons.dlp.processor.DlpOperationProcessor;
 import org.exoplatform.commons.dlp.queue.QueueDlpService;
@@ -33,6 +34,7 @@ public class FileDLPAction implements AdvancedAction {
   private QueueDlpService queueDlpService;
   
   private ExoFeatureService featureService;
+  private DlpOperationProcessor dlpOperationProcessor;
   
   private static final String EXO_EDITORS_RUNTIME_ID = "exo:editorsId";
 
@@ -44,11 +46,13 @@ public class FileDLPAction implements AdvancedAction {
     this.trashService = CommonsUtils.getService(TrashService.class);
     this.queueDlpService = CommonsUtils.getService(QueueDlpService.class);
     this.featureService = CommonsUtils.getService(ExoFeatureService.class);
+    this.dlpOperationProcessor = CommonsUtils.getService(DlpOperationProcessor.class);
   }
 
   @Override
   public boolean execute(Context context) throws Exception {
-    if (!featureService.isActiveFeature(DlpOperationProcessor.DLP_FEATURE)) {
+    if (!featureService.isActiveFeature(DlpOperationProcessor.DLP_FEATURE) ||
+        StringUtils.isBlank(dlpOperationProcessor.getKeywords())) {
       return false;
     }
     int eventType = (Integer) context.get(InvocationContext.EVENT);

--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDlpConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDlpConnector.java
@@ -235,7 +235,7 @@ public class FileDlpConnector extends DlpServiceConnector {
       Node node = session.getNodeByIdentifier(itemReference);
       return WCMCoreUtils.getLinkInDocumentsApplication(node.getPath());
     } catch (Exception e) {
-      LOGGER.error("Error while getting dlp item url", e);
+      LOGGER.error("Error while getting dlp item url, itemId={}", itemReference, e);
     }
     return null;
   }


### PR DESCRIPTION
Before this fix, when no keywords are configured, item are queued, and fill the queue for nothing
This fix add a check to verify if there is at least one keyword.