### PR TITLE
Task-36405: Fix versioning documents is not activated by default

### DIFF
--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/ECMSActivityFileStoragePlugin.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/ECMSActivityFileStoragePlugin.java
@@ -13,6 +13,7 @@ import javax.jcr.Session;
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.cms.BasePath;
+import org.exoplatform.services.cms.documents.AutoVersionService;
 import org.exoplatform.services.cms.impl.Utils;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.core.ManageableRepository;
@@ -49,18 +50,22 @@ public class ECMSActivityFileStoragePlugin extends ActivityFileStoragePlugin {
 
   private SessionProviderService sessionProviderService;
 
+  private AutoVersionService autoVersionService;
+
   public ECMSActivityFileStoragePlugin(SpaceService spaceService,
                                        NodeHierarchyCreator nodeHierarchyCreator,
                                        RepositoryService repositoryService,
                                        UploadService uploadService,
                                        SessionProviderService sessionProviderService,
-                                       InitParams initParams) {
+                                       InitParams initParams,
+                                       AutoVersionService autoVersionService) {
     super(initParams);
     this.spaceService = spaceService;
     this.nodeHierarchyCreator = nodeHierarchyCreator;
     this.repositoryService = repositoryService;
     this.uploadService = uploadService;
     this.sessionProviderService = sessionProviderService;
+    this.autoVersionService = autoVersionService;
   }
 
   @Override
@@ -144,7 +149,7 @@ public class ECMSActivityFileStoragePlugin extends ActivityFileStoragePlugin {
         session.save();
         node = (Node) session.getItem(node.getPath());
       }
-
+      autoVersionService.autoVersion(node);
       if (activity.getTemplateParams() == null) {
         activity.setTemplateParams(new HashMap<>());
       }

--- a/ecms-social-integration/src/test/java/org/exoplatform/wcm/ext/component/activity/ECMSActivityFileStoragePluginTest.java
+++ b/ecms-social-integration/src/test/java/org/exoplatform/wcm/ext/component/activity/ECMSActivityFileStoragePluginTest.java
@@ -2,6 +2,7 @@ package org.exoplatform.wcm.ext.component.activity;
 
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.services.cms.documents.AutoVersionService;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.config.RepositoryEntry;
 import org.exoplatform.services.jcr.core.ManageableRepository;
@@ -67,6 +68,8 @@ public class ECMSActivityFileStoragePluginTest {
   @Mock
   Session session;
 
+  @Mock
+  AutoVersionService autoVersionService;
 
   @Test
   public void storeAttachments() throws Exception {
@@ -81,7 +84,7 @@ public class ECMSActivityFileStoragePluginTest {
     priority.setValue("1");
     initParams.addParameter(datasource);
     initParams.addParameter(priority);
-    ECMSActivityFileStoragePlugin ecmsActivityFileStoragePlugin = new ECMSActivityFileStoragePlugin(spaceService,nodeHierarchyCreator,repositoryService,uploadService,sessionProviderService,initParams);
+    ECMSActivityFileStoragePlugin ecmsActivityFileStoragePlugin = new ECMSActivityFileStoragePlugin(spaceService,nodeHierarchyCreator,repositoryService,uploadService,sessionProviderService,initParams,autoVersionService);
     ExoSocialActivity activity = new ExoSocialActivityImpl();
     activity.setTitle("test");
     activity.setStreamOwner("root");
@@ -124,6 +127,7 @@ public class ECMSActivityFileStoragePluginTest {
     when(resourceNode.getProperty(any())).thenReturn(property);
     when(property.getString()).thenReturn("testProperty");
     when(node.isNodeType(any())).thenReturn(false);
+    when(autoVersionService.autoVersion(node)).thenReturn(any());
 
     // when
     ecmsActivityFileStoragePlugin.storeAttachments(activity,streamOwner,activityFile);
@@ -132,5 +136,6 @@ public class ECMSActivityFileStoragePluginTest {
     verify(uploadService, times(1)).removeUploadResource(any());
     verify(uploadService, times(1)).getUploadResource(any());
     verify(session, times(1)).save();
+    verify(autoVersionService, times(1)).autoVersion(any());
   }
 }


### PR DESCRIPTION
Problem: the autoversionning service wasn't used.
How it was solved: apply the autoversionning service to the used node. 