### PR TITLE
Task-42330 : [DLP] Some items are stuck in the queue

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDlpConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDlpConnector.java
@@ -105,7 +105,7 @@ public class FileDlpConnector extends DlpServiceConnector {
   }
   
   private boolean itemExist(String entityId) {
-    ExtendedSession session;
+    ExtendedSession session = null;
     boolean result = false;
     try {
       session = (ExtendedSession) WCMCoreUtils.getSystemSessionProvider().getSession(COLLABORATION_WS, repositoryService.getCurrentRepository());
@@ -117,6 +117,10 @@ public class FileDlpConnector extends DlpServiceConnector {
       }
     } catch (RepositoryException e) {
       LOGGER.error("Error when reading repository",e);
+    } finally {
+      if (session != null) {
+        session.logout();
+      }
     }
     return result;
   }
@@ -131,6 +135,10 @@ public class FileDlpConnector extends DlpServiceConnector {
       return result;
     } catch (Exception e) {
       LOGGER.error("Error when check if node {} is in trash", entityId, e);
+    } finally {
+      if (session != null) {
+        session.logout();
+      }
     }
     return false;
   }
@@ -156,6 +164,10 @@ public class FileDlpConnector extends DlpServiceConnector {
                   totalTime);
     } catch (Exception e) {
       LOGGER.error("Error while treating file dlp connector item", e);
+    } finally {
+      if (session != null) {
+        session.logout();
+      }
     }
   }
 
@@ -218,6 +230,10 @@ public class FileDlpConnector extends DlpServiceConnector {
       }
     } catch (Exception e) {
       LOGGER.error("Error while treating file dlp connector item", e);
+    } finally {
+      if (session != null) {
+        session.logout();
+      }
     }
   }
 
@@ -263,6 +279,10 @@ public class FileDlpConnector extends DlpServiceConnector {
       }
     } catch (Exception e) {
       LOGGER.error("Error while deleting dlp file item", e);
+    } finally {
+      if (session != null) {
+        session.logout();
+      }
     }
   }
 
@@ -284,6 +304,10 @@ public class FileDlpConnector extends DlpServiceConnector {
       return WCMCoreUtils.getLinkInDocumentsApplication(node.getPath());
     } catch (Exception e) {
       LOGGER.error("Error while getting dlp item url, itemId={}", itemReference, e);
+    } finally {
+      if (session != null) {
+        session.logout();
+      }
     }
     return null;
   }

--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDlpConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDlpConnector.java
@@ -91,7 +91,7 @@ public class FileDlpConnector extends DlpServiceConnector {
   @Override
   public boolean processItem(String entityId) {
     LOGGER.debug("Process item {}",entityId);
-    if (isInTrash(entityId)) {
+    if (!itemExist(entityId) || isInTrash(entityId)) {
       //if a document is in trash, we cannot check it because it is not indexed.
       //so we return true to remove it from the queue
       return true;
@@ -102,6 +102,23 @@ public class FileDlpConnector extends DlpServiceConnector {
       checkMatchKeywordAndTreatItem(entityId);
     }
     return true;
+  }
+  
+  private boolean itemExist(String entityId) {
+    ExtendedSession session;
+    boolean result = false;
+    try {
+      session = (ExtendedSession) WCMCoreUtils.getSystemSessionProvider().getSession(COLLABORATION_WS, repositoryService.getCurrentRepository());
+      result = session.itemExists(entityId);
+      if (result) {
+        LOGGER.debug("Item {} exists, path={}", entityId, session.getItem(entityId).getPath());
+      } else {
+        LOGGER.debug("Item {} not exists", entityId);
+      }
+    } catch (RepositoryException e) {
+      LOGGER.error("Error when reading repository",e);
+    }
+    return result;
   }
   
   private boolean isInTrash(String entityId) {

--- a/core/connector/src/test/java/org/exoplatform/ecm/connector/dlp/TestFileDlpConnector.java
+++ b/core/connector/src/test/java/org/exoplatform/ecm/connector/dlp/TestFileDlpConnector.java
@@ -112,6 +112,8 @@ public class TestFileDlpConnector {
     ExtendedSession session = mock(ExtendedSession.class);
     when(session.getWorkspace()).thenReturn(workspace);
     when(session.getNodeByIdentifier(uuid)).thenReturn(node);
+    when(session.itemExists(uuid)).thenReturn(true);
+    when(session.getItem(uuid)).thenReturn(node);
     when(session.getItem("/" + FileDlpConnector.DLP_QUARANTINE_FOLDER)).thenReturn(dlpQuarantineNode);
 
     PowerMockito.mockStatic(WCMCoreUtils.class);
@@ -165,6 +167,10 @@ public class TestFileDlpConnector {
     ExtendedSession session = mock(ExtendedSession.class);
     when(session.getWorkspace()).thenReturn(workspace);
     when(session.getNodeByIdentifier(uuid)).thenReturn(node);
+    when(session.itemExists(uuid)).thenReturn(true);
+    when(session.getItem(uuid)).thenReturn(node);
+  
+  
     when(session.getItem("/" + FileDlpConnector.DLP_QUARANTINE_FOLDER)).thenReturn(dlpQuarantineNode);
 
     PowerMockito.mockStatic(WCMCoreUtils.class);


### PR DESCRIPTION
Before this commit, items which no more exists (not only in trash but completly removed) throw an error, so that they are not removed from queue
This commit add a test to check if an item exists, if not, it is removed from the queue.
In addition this commit add a debug to display the path of an entityId (we need that for other items stucks in the queue)