### PR TITLE
Override eslint rule

### DIFF
--- a/ecm-wcm-extension/.eslintrc.json
+++ b/ecm-wcm-extension/.eslintrc.json
@@ -53,6 +53,7 @@
         "no-process-env": ["error"],
         "no-process-exit": ["error"],
         "no-proto": ["error"],
+        "no-restricted-imports": ["warn", "axios"],
         "no-self-compare": ["error"],
         "no-sequences": ["error"],
         "no-shadow-restricted-names": ["error"],


### PR DESCRIPTION
We add a rule at upper level to prevent the use of axios. The upper rule have error level, and fails the build
As we still use axios in ecms, we override the rule, to change the level to warn, waiting for change
When change applied in ecms, we will able to remove this override