### PR TITLE
TASK-42100 : fixed erroned path redirection when opening two different documents in two different tabs

### DIFF
--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/UIAddressBar.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/UIAddressBar.java
@@ -158,7 +158,10 @@ public class UIAddressBar extends UIForm {
           uiExplorer.setIsViewTag(false) ;
           uiExplorer.setSelectNode(uiExplorer.getCurrentStatePath()) ;
         } else {
-          String previousNodePath = uiExplorer.rewind() ;
+          // Retrieve previous node path by refactoring current path and adding the RootPath
+          String CurrentPath =  Text.escapeIllegalJcrChars(uiAddressBar.getUIStringInput(FIELD_ADDRESS).getValue());
+          String RootPath = uiExplorer.getRootPath();
+          String previousNodePath = RootPath + CurrentPath.substring(0,CurrentPath.lastIndexOf('/')) ;
           String previousWs = uiExplorer.previousWsName();
           uiExplorer.setBackNodePath(previousWs, previousNodePath);
           if (uiExplorer.hasPaginator(previousNodePath, previousWs)) {


### PR DESCRIPTION
before this fix , when opening 2 documents from 2 different folders in 2 different tabs , the redirection from one document leads to the the other file parent folder instead of his own parent folder due to the fact that the object storing the current path depends on the session object so it returns the folder of the last file being opened . i fixed this by retrieving the previous path depending on the value of the current path Input from the UI.  