### PR TITLE
MAINT-40548 : Fix the display of shared folder in the activity with attached files in a space

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/link/LinkManager.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/link/LinkManager.java
@@ -192,5 +192,16 @@ public interface LinkManager {
    * @throws Exception
    */
   public void updateSymlink(Node link) throws Exception;
-  
+
+  /**
+   * get the link of the document inside the folder
+   *
+   * @param contentUUID Jcr uuid of the file
+   * @param folderPath path of the target folder
+   * @param workspace target workspace
+   */
+  default List<Node> getNodeSymlinksUnderFolder(String contentUUID, String folderPath, String workspace) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
 }

--- a/core/services/src/main/java/org/exoplatform/services/cms/link/impl/LinkManagerImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/link/impl/LinkManagerImpl.java
@@ -444,4 +444,31 @@ public class LinkManagerImpl implements LinkManager {
     }
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public List<Node> getNodeSymlinksUnderFolder(String contentUUID, String folderPath, String workspace) {
+    List<Node> nodeSymlinks =  new ArrayList<Node>();
+    ManageableRepository repository = WCMCoreUtils.getRepository();
+    SessionProviderService sessionProviderService = CommonsUtils.getService(SessionProviderService.class);
+    SessionProvider sessionProvider = sessionProviderService.getSystemSessionProvider(null);
+    try {
+      Session session = sessionProvider.getSession(workspace, repository);
+      QueryManager queryManager = session.getWorkspace().getQueryManager();
+      String queryString = new StringBuilder("select * from exo:symlink ").append(" where exo:uuid = '").
+              append(contentUUID).append("' AND jcr:path like '%").
+              append(folderPath).append("/%' order by exo:dateCreated DESC").toString();
+      Query query = queryManager.createQuery(queryString, Query.SQL);
+      QueryResult queryResult = query.execute();
+      NodeIterator iterator = queryResult.getNodes();
+      while (iterator.hasNext()) {
+        nodeSymlinks.add(iterator.nextNode());
+      }
+      return nodeSymlinks;
+    } catch (Exception e) {
+      LOG.error("Error while trying to get the Node Link", e);
+      return null;
+    }
+  }
 }

--- a/core/services/src/main/java/org/exoplatform/services/wcm/core/NodetypeConstant.java
+++ b/core/services/src/main/java/org/exoplatform/services/wcm/core/NodetypeConstant.java
@@ -243,6 +243,7 @@ public class NodetypeConstant {
   public static final String EXO_NAME = "exo:name";
   
   public static final String JCR_UUID = "jcr:uuid";
+  public static final String EXO_UUID = "exo:uuid";
   // public static final String PUBLICATION_STATE_AND_VERSION_BASED_PUBLICATION
   // = "publication:stateAndVersionBasedPublication";
   

--- a/core/services/src/test/java/org/exoplatform/services/cms/documents/TestDocumentService.java
+++ b/core/services/src/test/java/org/exoplatform/services/cms/documents/TestDocumentService.java
@@ -3,22 +3,38 @@ package org.exoplatform.services.cms.documents;
 import java.util.List;
 
 import javax.jcr.Node;
+import javax.jcr.Session;
 
+import org.exoplatform.services.cms.BasePath;
 import org.exoplatform.services.cms.documents.model.Document;
 import org.exoplatform.services.cms.impl.Utils;
+import org.exoplatform.services.cms.link.LinkManager;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.jcr.ext.app.SessionProviderService;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
 import org.exoplatform.services.wcm.BaseWCMTestCase;
 import org.exoplatform.services.wcm.core.NodetypeConstant;
+import org.exoplatform.social.core.space.SpaceUtils;
+import org.exoplatform.social.core.space.model.Space;
 
 public class TestDocumentService extends BaseWCMTestCase {
 
   private DocumentService documentService;
   private NodeHierarchyCreator nodeHierarchyCreator;
+  private SessionProviderService sessionProviderService;
+  private RepositoryService repoService;
+
+
 
   public void setUp() throws Exception {
     super.setUp();
+    System.setProperty("gatein.email.domain.url", "http://localhost:8080");
     documentService = container.getComponentInstanceOfType(DocumentService.class);
     nodeHierarchyCreator = container.getComponentInstanceOfType(NodeHierarchyCreator.class);
+    sessionProviderService = container.getComponentInstanceOfType(SessionProviderService.class);
+    repoService = container.getComponentInstanceOfType(RepositoryService.class);
   }
 
   public void testCreateDocumentFromEmptyTemplate() throws Exception {
@@ -63,7 +79,36 @@ public class TestDocumentService extends BaseWCMTestCase {
     assertNotNull("documents wasn't created", documents);
     assertEquals(0, documents.size());
   }
-  
+
+  public void testGetDocumentUrlInSpaceDocuments() throws Exception {
+    Space space = new Space();
+    space.setDisplayName("testSpace");
+    space.setApp("documents");
+    space.setPrettyName(space.getDisplayName());
+    String shortName = SpaceUtils.cleanString(space.getPrettyName());
+    space.setGroupId("/spaces/" + shortName);
+    String spaceId = space.getGroupId();
+
+    Node rootNode = null;
+    SessionProvider sessionProvider = sessionProviderService.getSystemSessionProvider(null);
+    ManageableRepository repository = repoService.getCurrentRepository();
+    Session session = sessionProvider.getSession(repository.getConfiguration().getDefaultWorkspaceName(), repository);
+
+    nodeHierarchyCreator.getJcrPath(BasePath.CMS_GROUPS_PATH);
+    session.getRootNode().getNode("Groups").addNode("spaces").addNode(spaceId.split("/")[2]);
+    rootNode = (Node) session.getItem(nodeHierarchyCreator.getJcrPath(BasePath.CMS_GROUPS_PATH) + spaceId);
+    Node spaceDocumentNode = rootNode.addNode("Documents");
+    Node ActivityNode = spaceDocumentNode.addNode("Activity Stream Documents");
+    Node sharedNode = spaceDocumentNode.addNode("Shared");
+
+    Node currentNode = ActivityNode.addNode("testdoc.txt", "nt:file");
+
+    String sharedLink = documentService.getDocumentUrlInSpaceDocuments(currentNode, spaceId);
+    assertNotNull(sharedLink);
+    assertFalse(sharedNode.hasNode("testdoc.txt"));
+    assertTrue(ActivityNode.hasNode("testdoc.txt"));
+  }
+
 //  public void testGetMyWorkDocuments() throws Exception {
 //    String userId = "root";
 //    applyUserSession(userId, "gtn", COLLABORATION_WS);


### PR DESCRIPTION
**ISSUE** : When create an activity with attached files in a space  the `DocumetService.getDocumentUrlInPersonalDocuments` is called inside the UI template and also in the plugin notification template which invoke  the sub `getSharedLink` method which verify the existing of the shared folder and and searching the file inside it and if it's not exist its create it inside the shared folder : `linkManager.createLink(shared, currentNode);`
This happens after storing the file inside the activity stream folder, and the link value is transmitted to the template.
And this is not the expected behavior, the shared folder should include only the shared files in the current space.
**Solution** : 
- Replace the create of the symlink inside the shared folder by searching it in Activity Stream folder and sends its link.
- **Fix a discovered issue** inside the `ActivityListener` which wasn't working properly (this has no relation with the initial issue)
      - The Activity files received when calling `activity.getFiles();` has a `null id` which throws an **NPE** while getting their nodes 
       ` session.getNodeByUUID(fileToShare.getId());`
      
