### PR TITLE
Task-44674 DLP detect nothing for files

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDlpConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDlpConnector.java
@@ -106,15 +106,18 @@ public class FileDlpConnector extends DlpServiceConnector {
   
   private boolean itemExist(String entityId) {
     ExtendedSession session = null;
-    boolean result = false;
     try {
-      session = (ExtendedSession) WCMCoreUtils.getSystemSessionProvider().getSession(COLLABORATION_WS, repositoryService.getCurrentRepository());
-      result = session.itemExists(entityId);
-      if (result) {
-        LOGGER.debug("Item {} exists, path={}", entityId, session.getItem(entityId).getPath());
-      } else {
-        LOGGER.debug("Item {} not exists", entityId);
-      }
+      session =
+          (ExtendedSession) WCMCoreUtils.getSystemSessionProvider()
+                                        .getSession(COLLABORATION_WS, repositoryService.getCurrentRepository());
+      Item item = session.getNodeByIdentifier(entityId);
+      LOGGER.debug("Item {} exists, path={}", entityId, item.getPath());
+      return true;
+  
+    } catch (ItemNotFoundException e) {
+      LOGGER.debug("Item {} not exists", entityId);
+      return false;
+      
     } catch (RepositoryException e) {
       LOGGER.error("Error when reading repository",e);
     } finally {
@@ -122,7 +125,7 @@ public class FileDlpConnector extends DlpServiceConnector {
         session.logout();
       }
     }
-    return result;
+    return false;
   }
   
   private boolean isInTrash(String entityId) {


### PR DESCRIPTION
before this fix, the DLP system detect nothing even if you upload a document matching keyword
This is due to the fact that in FileDlpConnector, we check item existence byt using session.itemExists. But this function take in parameter a path, so it return always false when providing a node id.
This fix change the way we check item existence, by using session.getNodeByIdentifier