### PR TITLE
Task-42406: Fix latest news bloc display when deleting a space having a pinned news

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -33,6 +33,7 @@ import org.exoplatform.services.cms.thumbnail.ThumbnailService;
 import org.exoplatform.services.context.DocumentContext;
 import org.exoplatform.services.jcr.core.ExtendedNode;
 import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.jcr.ext.ActivityTypeUtils;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
@@ -464,11 +465,15 @@ public class Utils {
               synchronized (symlink) {
                 if (keepInTrash) {
                   trashService.moveToTrash(symlink, sessionProvider, 1);
-                }else {
+                } else {
+                  if (symlink.isNodeType(ActivityTypeUtils.EXO_ACTIVITY_INFO) && node.hasProperty(ActivityTypeUtils.EXO_ACTIVITY_ID)) {
+                    ListenerService listenerService =  WCMCoreUtils.getService(ListenerService.class);
+                    listenerService.broadcast(ActivityCommonService.FILE_REMOVE_ACTIVITY, null, symlink);
+                  }
+                  Session nodeSession = symlink.getSession();
                   symlink.remove();
+                  nodeSession.save();
                 }
-                ListenerService listenerService =  WCMCoreUtils.getService(ListenerService.class);
-                listenerService.broadcast(ActivityCommonService.FILE_REMOVE_ACTIVITY, null, symlink);
               }
             }
           } catch (Exception e) {

--- a/core/services/src/main/java/org/exoplatform/services/cms/listeners/NewGroupListener.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/listeners/NewGroupListener.java
@@ -28,6 +28,7 @@ import javax.jcr.Session;
 
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.cms.impl.Utils;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.access.PermissionType;
 import org.exoplatform.services.jcr.core.ExtendedNode;
@@ -94,10 +95,16 @@ public class NewGroupListener extends GroupEventListener
       String systemWorkspace = manageableRepository.getConfiguration().getDefaultWorkspaceName();
       Session session = manageableRepository.getSystemSession(systemWorkspace);
       Node groupNode = (Node)session.getItem(groupsPath_ + groupId);
-      groupNode.remove();
-      session.save();
-      session.logout();
-   }
+      try {
+        Utils.removeDeadSymlinks(groupNode);
+        groupNode.remove();
+        session.save();
+      } catch (Exception e) {
+        LOG.error("Error while deleting group node", e);
+      } finally {
+        session.logout();
+      }
+    }
 
    @SuppressWarnings("unchecked")
    private void buildGroupStructure(Group group) throws Exception

--- a/core/services/src/main/java/org/exoplatform/services/cms/listeners/NewGroupListener.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/listeners/NewGroupListener.java
@@ -96,7 +96,7 @@ public class NewGroupListener extends GroupEventListener
       Session session = manageableRepository.getSystemSession(systemWorkspace);
       Node groupNode = (Node)session.getItem(groupsPath_ + groupId);
       try {
-        Utils.removeDeadSymlinks(groupNode);
+        Utils.removeDeadSymlinks(groupNode, false);
         groupNode.remove();
         session.save();
       } catch (Exception e) {


### PR DESCRIPTION
Prior to this change, when we remove a space that has a related pinned news, the bloc latest news disappear. The problem consists of that when deleting the space, the space node is well deleted but not the symlinks of its sub-tree nodes.
To fix this problem, we have deleted all dead symlinks related to the deleted space.