### PR TITLE
Task-45155 : When uploading a file with combining char in filename, t…

### DIFF
--- a/apps/portlet-explorer/src/main/webapp/javascript/eXo/ecm/MultiUpload.js
+++ b/apps/portlet-explorer/src/main/webapp/javascript/eXo/ecm/MultiUpload.js
@@ -285,6 +285,7 @@
 		if (!oldName || oldName==null ||oldName==undefined) return oldName;
 		specialChar = "[]/'\":;";
 		var ret = "";
+		oldName=oldName.normalize();
 		for (var i = 0; i < oldName.length; i++) {
 			if (specialChar.indexOf(oldName[i]) > -1) {
 				ret += "-";


### PR DESCRIPTION
…he name is not correctly read

Before this fix, when a filename contains combining chararacters, the filename is not correctly interpreted
This fix use normalize js function to remove theses combining characters so that we can interpret the filename