### PR TITLE
Task-45155 : When uploading a file with combining char in filename, t…

### DIFF
--- a/apps/portlet-explorer/src/main/webapp/javascript/eXo/ecm/MultiUpload.js
+++ b/apps/portlet-explorer/src/main/webapp/javascript/eXo/ecm/MultiUpload.js
@@ -434,7 +434,7 @@
 		//add file name div
 		var info = eXo.ecm.MultiUpload.document.createElement("div");
 		info.id = "file" + fileID;
-		info.innerHTML = file.name;
+		info.innerHTML = file.name.normalize();
 		info.className = "fileName pull-left";
 		if (eXo.ecm.MultiUpload.pathMap[fileID] != undefined) {
 			info.title = eXo.ecm.MultiUpload.IN + " " + eXo.ecm.MultiUpload.driveTitle + (eXo.ecm.MultiUpload.pathMap[fileID].indexOf("/") == 0 ? "" : "/") + 
@@ -909,7 +909,7 @@
 		    "&currentPortal="+ eXo.ecm.MultiUpload.portalName +
 		    "&userId=" + eXo.ecm.MultiUpload.userId +
 		    "&uploadId=" + progressID +
-		    "&fileName=" + encodeURIComponent(file.name) + 
+		    "&fileName=" + encodeURIComponent(file.name.normalize()) +
 		    "&language=" + eXo.ecm.MultiUpload.userLanguage +
 		    "&existenceAction=" + eXo.ecm.MultiUpload.existingBehavior[progressID] +
 			"&action=save";
@@ -960,7 +960,7 @@
 		  	  //change uploaded files value
 		  	  eXo.ecm.MultiUpload.changeStatusValue(eXo.ecm.MultiUpload.UPLOADED, 1);
 		  	  //load image thumbnail
-			  var fileName = encodeURIComponent(file.name);
+			  var fileName = encodeURIComponent(file.name.normalize());
 			  var uri = eXo.ecm.MultiUpload.restContext + "/wcmDriver/uploadFile/cleanName?" + "fileName=" + fileName;
 			  gj.ajax({url: uri, 
 			    async: false, //blocks window close


### PR DESCRIPTION
…he name is not correctly read (#1297)

Before this fix, when a filename contains combining chararacters, the filename is not correctly interpreted
This fix use normalize js function to remove theses combining characters so that we can interpret the filename
It complete the precedent commit which miss some points