### PR TITLE
MAINT-44337: fix edit  short message activity when it contains a link with preview plus an attached file

### DIFF
--- a/ecm-wcm-extension/src/main/webapp/groovy/ecm/social-integration/plugin/space/FileUIActivity.gtmpl
+++ b/ecm-wcm-extension/src/main/webapp/groovy/ecm/social-integration/plugin/space/FileUIActivity.gtmpl
@@ -60,6 +60,7 @@ import static org.exoplatform.social.webui.activity.BaseUIActivity.TEMPLATE_PARA
     def labelEdit = _ctx.appRes("UIActivity.label.Edit");
     def labelDelete = _ctx.appRes("UIActivity.label.Delete");
     def activity = uicomponent.getActivity();
+    def activityMessage = uicomponent.getMessage();
     def activityContentTitle = Text.unescapeIllegalJcrChars(activity.title);
     def linkExistsClassName = uicomponent.getLinkSource() ? "linkExists" : "";
 
@@ -105,7 +106,7 @@ import static org.exoplatform.social.webui.activity.BaseUIActivity.TEMPLATE_PARA
     //params for init UIActivity javascript object
     def params = """ {
       activityId: '${activity.id}',
-      activityBody: `${activity.title}`,
+      activityBody: `${activityMessage}`,
       placeholderComment: '${placeholder}',
       inputWriteAComment: '$inputWriteAComment',
       commentMinCharactersAllowed: '${uicomponent.getCommentMinCharactersAllowed()}',

--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/FileUIActivity.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/FileUIActivity.java
@@ -133,9 +133,9 @@ public class FileUIActivity extends BaseUIActivity{
 
   public static final String  CONTENT_LINK        = "contenLink";
 
-  public static final String  MESSAGE             = "message";
+  public static final String  MESSAGE             = "MESSAGE";
 
-  public static final String  ACTIVITY_STATUS     = "MESSAGE";
+  public static final String  ACTIVITY_STATUS     = "description";
 
   public static final String  IMAGE_PATH          = "imagePath";
 

--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/FileUIActivityBuilder.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/FileUIActivityBuilder.java
@@ -76,8 +76,8 @@ public class FileUIActivityBuilder extends BaseUIActivityBuilder {
     // org.exoplatform.social.plugin.doc.UIDocActivityComposer.docActivityTitle.
     // So we couldn't set activity.getTitle() all the time, see INTEG-486
     if (activity.getTemplateParams() != null
-        && StringUtils.isNotBlank(templateParams.get(UILinkActivity.COMMENT_PARAM))) {
-      fileActivity.setMessage(templateParams.get(UILinkActivity.COMMENT_PARAM));
+        && StringUtils.isNotBlank(templateParams.get(FileUIActivity.MESSAGE))) {
+      fileActivity.setMessage(templateParams.get(FileUIActivity.MESSAGE));
     } else if (activity.getTemplateParams() != null
         && StringUtils.isNotBlank(activity.getTemplateParams().get(FileUIActivity.ACTIVITY_STATUS))
         || (!patternLink.matcher(activity.getTitle()).find())) {

--- a/ecms-social-integration/src/test/java/org/exoplatform/wcm/ext/component/activity/FileUIActivityTest.java
+++ b/ecms-social-integration/src/test/java/org/exoplatform/wcm/ext/component/activity/FileUIActivityTest.java
@@ -47,9 +47,9 @@ public class FileUIActivityTest {
     activity.setTemplateParams(activityParameters);
     activityBuilder.extendUIActivity(fileUIActivity, activity);
 
-    assertTrue(StringUtils.isBlank(fileUIActivity.getMessage()));
+    assertTrue(StringUtils.isNotBlank(fileUIActivity.getMessage()));
 
-    activityParameters.put(FileUIActivity.ACTIVITY_STATUS, activityTitle);
+    activityParameters.put(FileUIActivity.MESSAGE, activityTitle);
     activityBuilder.extendUIActivity(fileUIActivity, activity);
 
     assertEquals(activityTitle, fileUIActivity.getMessage());


### PR DESCRIPTION
Additional PR to update and adapt the File activity template and the UI template to use the MESSAGE param instead of the title to fix the conflicts when the activity contains an attached file plus link preview (means a files:space activity and in the same time it's a Link Activity)