### PR TITLE
Task-45427 [DLP] Problem with symlink in trash

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDlpConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/dlp/FileDlpConnector.java
@@ -276,7 +276,7 @@ public class FileDlpConnector extends DlpServiceConnector {
       Node node = session.getNodeByIdentifier(itemReference);
 
       if (node != null && dlpQuarantineNode != null) {
-        Utils.removeDeadSymlinks(node);
+        Utils.removeDeadSymlinks(node,false);
         node.remove();
         dlpQuarantineNode.save();
       }


### PR DESCRIPTION
Before this fix, when a symlink exist for a node which is in quarantine and when the admin remove the item in quarantine, the symlink is send to trash, but as parent node is removed, the symlink broke the display of the trash
This commit change the way we handle symlink remove, by not sending it to trash