### PR TITLE
TASK-46621: Delete attachments from entity when unselecting all in drives

### DIFF
--- a/apps/portlet-documents/src/main/webapp/js/attachmentService.js
+++ b/apps/portlet-documents/src/main/webapp/js/attachmentService.js
@@ -248,6 +248,17 @@ export function removeEntityAttachment(entityId, entityType, attachmentId) {
   });
 }
 
+export function removeAllAttachmentsFromEntity(entityId, entityType) {
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/attachments/${entityType}/${entityId}`, {
+    credentials: 'include',
+    method: 'DELETE',
+  }).then((resp) => {
+    if (!resp || !resp.ok) {
+      throw new Error('Error removing entity\'s linked attachment');
+    }
+  });
+}
+
 export function getEntityAttachments(entityType, entityId) {
   return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/attachments/${entityType}/${entityId}`, {
     credentials: 'include',

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
@@ -418,7 +418,25 @@ export default {
     },
     updateLinkedAttachmentsToEntity() {
       const attachmentIds = this.attachments.map(attachment => attachment.id);
-      return this.$attachmentService.updateLinkedAttachmentsToEntity(this.entityId, this.entityType, attachmentIds).then(() => {
+      if (attachmentIds.length === 0) {
+        return this.removeAllAttachmentsFromEntity(this.entityId, this.entityType);
+      } else {
+        return this.$attachmentService.updateLinkedAttachmentsToEntity(this.entityId, this.entityType, attachmentIds).then(() => {
+          this.$root.$emit('entity-attachments-updated');
+          document.dispatchEvent(new CustomEvent('entity-attachments-updated'));
+          this.displaySuccessMessage();
+        }).catch(e => {
+          console.error(e);
+          this.$refs.attachmentsAppDrawer.endLoading();
+          this.$root.$emit('attachments-notification-alert', {
+            message: this.$t('attachments.link.failed'),
+            type: 'error',
+          });
+        });
+      }
+    },
+    removeAllAttachmentsFromEntity(entityId, entityType) {
+      return this.$attachmentService.removeAllAttachmentsFromEntity(entityId, entityType).then(() => {
         this.$root.$emit('entity-attachments-updated');
         document.dispatchEvent(new CustomEvent('entity-attachments-updated'));
         this.displaySuccessMessage();


### PR DESCRIPTION
When un-selecting all attachment linked to an entity from the drives explorer drawer, we need to call the delete all rest service to remove all attachments ids related to an entity in DB.