### PR TITLE
TASK-44543: Display edit button in preview of document not belonging to an activity

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
@@ -465,6 +465,7 @@ export default {
       file.id = uploadedFile.UUID;
       uploadedFile.drive = file.fileDrive.title;
       uploadedFile.id = uploadedFile.UUID;
+      uploadedFile.size = file.size;
       uploadedFile.previewBreadcrumb = JSON.parse(uploadedFile.previewBreadcrumb);
       this.uploadedFiles.push(uploadedFile);
     },

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
@@ -237,7 +237,8 @@ export default {
             downloadUrl: self.attachment.downloadUrl,
             openUrl: self.attachment.url || self.attachment.openUrl,
             breadCrumb: self.attachment.previewBreadcrumb,
-            fileInfo: self.fileInfo()
+            fileInfo: self.fileInfo(),
+            size: self.attachment.size
           },
           version: {
             number: self.attachment.version

--- a/apps/portlet-documents/src/main/webapp/vue-app/common/components/ExoDocument.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/common/components/ExoDocument.vue
@@ -116,7 +116,8 @@ export default {
           downloadUrl: this.document.downloadUrl,
           openUrl: this.document.url || this.document.openUrl,
           breadCrumb: this.document.previewBreadcrumb,
-          fileInfo: this.fileInfo()
+          fileInfo: this.fileInfo(),
+          size: this.document.size,
         },
         version: {                                                                 
           number: this.document.version 

--- a/ecm-wcm-extension/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/ecm-wcm-extension/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -56,8 +56,8 @@
 
       this.settings = $.extend(this.defaultSettings, docPreviewSettings);
 
+      var promises = [];
       if(this.settings.showComments) {
-        var promises = [];
 
         // if we miss author information, let's fetch them
         if(this.settings.author.username != null
@@ -80,29 +80,24 @@
         if(this.settings.activity.id != null && (this.settings.activity.postTime == null || this.settings.activity.status == null)) {
           promises.push(this.fetchActivity());
         }
-
-        var self = this;
-
-        if(ES6Promise && !window.Promise ) {
-          ES6Promise.polyfill();
-        }
-
-       promises.push(this.checkDownloadDocumentStatus());
-
-        // wait for all users info fetches to be complete before rendering the component
-        Promise.all(promises).then(function() {
-          self.render();
-          self.show();
-          if(!$('.commentsLoaded').length) {
-            self.loadComments();
-          }
-        }, function(err) {
-          // error occurred
-        });
-      } else {
-        this.render();
-        this.show();
       }
+
+      if(ES6Promise && !window.Promise ) {
+        ES6Promise.polyfill();
+      }
+      var self = this;
+      promises.push(this.checkDownloadDocumentStatus());
+
+      // wait for all users info fetches to be complete before rendering the component
+      Promise.all(promises).then(function() {
+        self.render();
+        self.show();
+        if(!$('.commentsLoaded').length && self.settings.showComments) {
+          self.loadComments();
+        }
+      }, function(err) {
+        console.error('An error occurred when trying to load document preview details: ',err);
+      });
     },
 
     fetchUserInformation: function(callback) {


### PR DESCRIPTION
The `checkDownloadDocumentStatus` was only called when the attachment is belonging to an activity. 
This fix make the check done every time the init of the preview is called. It will also fix the display of download button.