### PR TITLE
TASK-46918: Decode Attachment title

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
@@ -22,8 +22,8 @@
       </div>
     </v-list-item-avatar>
     <v-list-item-content @click="openPreview()">
-      <v-list-item-title class="uploadedFileTitle">
-        {{ attachment.name || notAccessibleAttachmentTitle }}
+      <v-list-item-title class="uploadedFileTitle" :title="attachmentTitle">
+        {{ attachmentTitle || notAccessibleAttachmentTitle }}
       </v-list-item-title>
       <v-list-item-subtitle v-if="canMoveAttachment" class="d-flex v-messages uploadedFileSubTitle">
         <v-chip
@@ -196,6 +196,9 @@ export default {
     },
     attachmentInProgress() {
       return this.attachment.uploadProgress < 100;
+    },
+    attachmentTitle() {
+      return this.attachment && this.attachment.name && unescape(this.attachment.name);
     },
   },
   methods: {


### PR DESCRIPTION
The attachment title saved in DB is encoded. We need to unescape the title in order to well display it.