### PR TITLE
TASK-47558 Retrieve the list of Activity Attached files by system provider instead of anonymous

### DIFF
--- a/ecms-social-integration/src/main/java/org/exoplatform/ecms/activity/processor/ActivityAttachmentProcessor.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/ecms/activity/processor/ActivityAttachmentProcessor.java
@@ -94,7 +94,7 @@ public class ActivityAttachmentProcessor extends BaseActivityProcessorPlugin {
         fileAttachment.setMimeType(mimeType);
         activity.getFiles().add(fileAttachment);
 
-        NodeLocation nodeLocation = new NodeLocation(repository, workspace, docPath, nodeUUID);
+        NodeLocation nodeLocation = new NodeLocation(repository, workspace, docPath, nodeUUID, true);
         Node contentNode = NodeLocation.getNodeByLocation(nodeLocation);
         if (contentNode == null || !contentNode.isNodeType(NodetypeConstant.MIX_REFERENCEABLE)) {
           fileAttachment.setDeleted(true);


### PR DESCRIPTION
Prior to this change, when accessing to an Activity through a batch process (no authenticated user), building the attached file activity is compromised and return an empty list of attachments. This fix will simply change to use the system provider all time and let Activity Management Caches all the files of the activity independently from used JCR Session