### PR TITLE
TASK-47580 Improve performance loading of Images

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityAttachment.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityAttachment.vue
@@ -12,14 +12,12 @@
       class="activity-attachment overflow-hidden d-flex flex-column border-box-sizing"
       @click="openPreview">
       <v-card-text class="activity-attachment-thumbnail d-flex flex-grow-1 pa-0">
-        <v-img
+        <img
           v-if="image"
           :src="attachment.image"
-          max-height="152px"
-          max-width="250px"
-          contain
-          eager
-          @error="image = null" />
+          :style="{maxHeight: previewHeight, maxWidth: previewWidth, height: 'fit-content'}"
+          class="ma-auto"
+          @error="image = null">
         <v-icon
           v-else
           :class="attachment.icon"
@@ -79,6 +77,14 @@ export default {
     count: {
       type: Number,
       default: 0,
+    },
+    previewHeight: {
+      type: String,
+      default: () => '152px',
+    },
+    previewWidth: {
+      type: Number,
+      default: () => '250px',
     },
   },
   data: () => ({

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityAttachments.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityAttachments.vue
@@ -7,6 +7,8 @@
       :index="index"
       :count="attachmentsCount"
       :attachment="attachment"
+      :preview-width="previewWidth"
+      :preview-height="previewHeight"
       class="activity-file-item" />
   </card-carousel>
 </template>
@@ -17,6 +19,14 @@ export default {
     activity: {
       type: Object,
       default: null,
+    },
+    previewHeight: {
+      type: String,
+      default: () => '152px',
+    },
+    previewWidth: {
+      type: Number,
+      default: () => '250px',
     },
   },
   computed: {


### PR DESCRIPTION
Using v-img when displaying principal content can lead to lazily loads image and thus offers a bad UX and performances for images loading. Thus here the images loading is made using a simple img tag