### PR TITLE
TASK-47771 Fix End Loading time of stream application

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoAttachments.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoAttachments.vue
@@ -471,7 +471,6 @@ export default {
     window.require(['SHARED/jquery'], function($) {
       $('#exoAttachmentsApp *[rel="tooltip"]').tooltip();
     });
-    this.$root.$applicationLoaded();
   },
   created(){
     this.addDefaultPath();


### PR DESCRIPTION
Prior to this change, the extension of Legacy attachment drawer was mounted with stream app, thus it emits an 'end loading' event that should be emitted by an application instead of extensions. This fix will delete triggering this event by the extension of composer.