### PR TITLE
TASK-42087: fixed spaces accesibility when creating a symilink from drives application

### DIFF
--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps</artifactId>
   <packaging>pom</packaging>

--- a/apps/portlet-administration/pom.xml
+++ b/apps/portlet-administration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-administration</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-clouddrives/pom.xml
+++ b/apps/portlet-clouddrives/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-clouddrives</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-documents/pom.xml
+++ b/apps/portlet-documents/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-documents</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
@@ -127,96 +127,96 @@
           </div>
         </transition>
         <div class="contentBody">
-          <div v-if="currentDrive" class="selectionBox px-5 d-flex flex-wrap">
-            <div v-if="loadingFolders" class="VuetifyApp loader ma-auto">
-              <v-app class="VuetifyApp">
-                <v-progress-circular
-                  :size="30"
-                  :width="3"
-                  indeterminate
-                  class="loadingRing"
-                  color="#578dc9" />
-              </v-app>
+          <div v-if="currentDrive" class="selectionBox">
+            <div v-if="loadingFolders || driveExplorerInitializing" class="loader flex-column d-flex align-center">
+              <v-progress-circular
+                :size="30"
+                :width="3"
+                indeterminate
+                class="loadingRing"
+                color="#578dc9" />
             </div>
-            <div v-if="emptyFolder" class="emptyFolder my-10 mx-auto mx-auto flex-column d-flex align-center">
-              <i class="uiIconEmptyFolder"></i>
-              <p>{{ $t('attachments.drawer.destination.folder.empty') }}</p>
-            </div>
-            <div
-              v-for="folder in filteredFolders"
-              :id="folder.id"
-              :key="folder.id"
-              :title="folder.name"
-              :class="folder.type === 'new_folder' ? 'boxOfFolder d-flex flex-column' : ''"
-              class="folderSelection ma-2"
-              @click="openFolder(folder)"
-              @contextmenu="openFolderActionsMenu(folder, $event)">
-              <a
-                v-if="folder.type === 'new_folder'"
-                href="javascript:void(0);"
-                class="closeIcon pt-1 pr-1 align-self-end"
-                @mousedown="cancelCreatingNewFolder($event)">
-                <span>x</span>
-              </a>
-              <div :class="folder.type === 'new_folder' ? 'boxOfTitle px-1' :''">
-                <a
-                  :title="folder.title"
-                  href="javascript:void(0);"
-                  rel="tooltip"
-                  class="folderTitle d-flex flex-column v-messages"
-                  data-placement="bottom">
-                  <i
-                    :class="folder.folderTypeCSSClass"
-                    class="uiIcon24x24FolderDefault uiIconEcmsLightGray selectionIcon center"></i>
-                  <i
-                    v-show="folder.isCloudDrive"
-                    :class="getFolderIcon(folder)"
-                    class="uiIcon-clouddrive"></i>
-                  <input
-                    v-if="folder.type === 'new_folder'"
-                    :ref="folder.ref"
-                    v-model="newFolderName"
-                    type="text"
-                    class="newFolderInput  ignore-vuetify-classes"
-                    @blur="createNewFolder($event)"
-                    @keyup.enter="$event.target.blur()"
-                    @keyup.esc="cancelCreatingNewFolder($event)">
-                  <input
-                    v-else-if="renameFolderAction && folder.id === selectedFolder.id"
-                    :id="folder.id"
-                    ref="rename"
-                    v-model="newName"
-                    type="text"
-                    class="newFolderInput  ignore-vuetify-classes"
-                    @blur="saveNewNameFolder()"
-                    @keyup.enter="$event.target.blur()"
-                    @keyup.esc="cancelRenameNewFolder($event)">
-                  <div v-else class="selectionLabel text-truncate text-color center">{{ folder.title }}</div>
-                </a>
+            <div v-else class="content-explorer px-5 d-flex flex-wrap">
+              <div v-if="emptyFolder" class="emptyFolder my-10 mx-auto flex-column d-flex align-center">
+                <i class="uiIconEmptyFolder"></i>
+                <p>{{ $t('attachments.drawer.destination.folder.empty') }}</p>
               </div>
-            </div>
-            <attachments-folder-actions-menu
-              ref="folderActionsMenu"
-              :folder-actions-menu-left="folderActionsMenuLeft"
-              :folder-actions-menu-top="folderActionsMenuTop"
-              :selected-folder="selectedFolder"
-              @renameFolder="renameFolder()"
-              @deleteFolder="deleteFolder"
-              @closeMenu="closeFolderActionsMenu" />
-            <div v-if="emptyFolderForSelectDestination && modeFolderSelection && !emptyFolder" class="emptyFolder d-flex flex-column align-center mx-auto mt-10">
-              <i class="uiIconEmptyFolder"></i>
-              <p>{{ $t('attachments.drawer.destination.subfolder.empty') }}</p>
-            </div>
-            <div
-              v-for="file in filteredFiles"
-              v-show="!modeFolderSelection"
-              :id="file.idAttribute"
-              :key="file.id"
-              :title="file.idAttribute"
-              :class="file.isSelected? 'selected' : ''"
-              class="fileSelection"
-              @click="selectFile(file)">
-              <attachments-drive-explorer-file-item :file="file" />
+              <div
+                v-for="folder in filteredFolders"
+                :id="folder.id"
+                :key="folder.id"
+                :title="folder.name"
+                :class="folder.type === 'new_folder' ? 'boxOfFolder d-flex flex-column' : ''"
+                class="folderSelection ma-2"
+                @click="openFolder(folder)"
+                @contextmenu="openFolderActionsMenu(folder, $event)">
+                <a
+                  v-if="folder.type === 'new_folder'"
+                  href="javascript:void(0);"
+                  class="closeIcon pt-1 pr-1 align-self-end"
+                  @mousedown="cancelCreatingNewFolder($event)">
+                  <span>x</span>
+                </a>
+                <div :class="folder.type === 'new_folder' ? 'boxOfTitle px-1' :''">
+                  <a
+                    :title="folder.title"
+                    href="javascript:void(0);"
+                    rel="tooltip"
+                    class="folderTitle d-flex flex-column v-messages"
+                    data-placement="bottom">
+                    <i
+                      :class="folder.folderTypeCSSClass"
+                      class="uiIcon24x24FolderDefault uiIconEcmsLightGray selectionIcon center"></i>
+                    <i
+                      v-show="folder.isCloudDrive"
+                      :class="getFolderIcon(folder)"
+                      class="uiIcon-clouddrive"></i>
+                    <input
+                      v-if="folder.type === 'new_folder'"
+                      :ref="folder.ref"
+                      v-model="newFolderName"
+                      type="text"
+                      class="newFolderInput  ignore-vuetify-classes"
+                      @blur="createNewFolder($event)"
+                      @keyup.enter="$event.target.blur()"
+                      @keyup.esc="cancelCreatingNewFolder($event)">
+                    <input
+                      v-else-if="renameFolderAction && folder.id === selectedFolder.id"
+                      :id="folder.id"
+                      ref="rename"
+                      v-model="newName"
+                      type="text"
+                      class="newFolderInput  ignore-vuetify-classes"
+                      @blur="saveNewNameFolder()"
+                      @keyup.enter="$event.target.blur()"
+                      @keyup.esc="cancelRenameNewFolder($event)">
+                    <div v-else class="selectionLabel text-truncate text-color center">{{ folder.title }}</div>
+                  </a>
+                </div>
+              </div>
+              <attachments-folder-actions-menu
+                ref="folderActionsMenu"
+                :folder-actions-menu-left="folderActionsMenuLeft"
+                :folder-actions-menu-top="folderActionsMenuTop"
+                :selected-folder="selectedFolder"
+                @renameFolder="renameFolder()"
+                @deleteFolder="deleteFolder"
+                @closeMenu="closeFolderActionsMenu" />
+              <div v-if="emptyFolderForSelectDestination && modeFolderSelection && !emptyFolder" class="emptyFolder d-flex flex-column align-center mx-auto mt-10">
+                <i class="uiIconEmptyFolder"></i>
+                <p>{{ $t('attachments.drawer.destination.subfolder.empty') }}</p>
+              </div>
+              <div
+                v-for="file in filteredFiles"
+                v-show="!modeFolderSelection"
+                :id="file.idAttribute"
+                :key="file.id"
+                :title="file.idAttribute"
+                :class="file.isSelected? 'selected' : ''"
+                class="fileSelection"
+                @click="selectFile(file)">
+                <attachments-drive-explorer-file-item :file="file" />
+              </div>
             </div>
           </div>
           <div v-else class="categorizedDrives">
@@ -413,6 +413,7 @@ export default {
       modeFolderSelection: true,
       modeFolderSelectionForFile: false,
       movedFile: {},
+      driveExplorerInitializing: false,
     };
   },
   computed: {
@@ -559,6 +560,7 @@ export default {
       //if default drive exist
       if (this.defaultDrive && this.defaultDrive.name) {
         const self = this;
+        this.driveExplorerInitializing = true;
         //open it to generate the path
         this.openDrive(this.defaultDrive).then(() => {
           const defaultFolder = self.folders.find(folder => folder.title === self.defaultFolder);
@@ -575,6 +577,7 @@ export default {
           if (defaultFolder) {
             this.openFolder(defaultFolder).then(() => {
               this.$root.$emit('attachments-default-folder-path-initialized', this.getRelativePath(self.selectedFolderPath), this.schemaFolder);
+              this.driveExplorerInitializing = false;
             });
             //else if no default folder
           } else {
@@ -1005,11 +1008,11 @@ export default {
             this.createNewFolder().then((newFolder) => {
               this.openFolder(newFolder).then(() => {
                 this.$root.$emit('attachments-default-folder-path-initialized', this.getRelativePath(this.selectedFolderPath), this.schemaFolder);
+              }).finally(() => {
+                this.driveExplorerInitializing = false;
               });
             });
           });
-        }).finally(() => {
-          this.creatingNewFolder = false;
         });
       } else { //if entityType (tasks, event, ..) folder exist, we create directly entityId folder
         this.openFolder(defaultFolder).then(() => {
@@ -1020,11 +1023,15 @@ export default {
             this.createNewFolder().then((newFolder) => {
               this.openFolder(newFolder).then(() => {
                 this.$root.$emit('attachments-default-folder-path-initialized', this.getRelativePath(this.selectedFolderPath), this.schemaFolder);
+              }).finally(() => {
+                this.driveExplorerInitializing = false;
               });
             });
           } else {
             this.openFolder(defaultFolder).then(() => {
               this.$root.$emit('attachments-default-folder-path-initialized', this.getRelativePath(this.selectedFolderPath), this.schemaFolder);
+            }).finally(() => {
+              this.driveExplorerInitializing = false;
             });
           }
         });

--- a/apps/portlet-editors/pom.xml
+++ b/apps/portlet-editors/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-editors</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-explorer/pom.xml
+++ b/apps/portlet-explorer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-explorer</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-presentation/pom.xml
+++ b/apps/portlet-presentation/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-presentation</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-search/pom.xml
+++ b/apps/portlet-search/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-search</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-seo/pom.xml
+++ b/apps/portlet-seo/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-seo</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-transferrules/pom.xml
+++ b/apps/portlet-transferrules/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-transferrules</artifactId>
   <packaging>war</packaging>

--- a/apps/resources-wcm/pom.xml
+++ b/apps/resources-wcm/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-resources-wcm</artifactId>
   <packaging>war</packaging>

--- a/core/connector/pom.xml
+++ b/core/connector/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-connector</artifactId>
   <packaging>jar</packaging>

--- a/core/core-configuration/pom.xml
+++ b/core/core-configuration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webapp</artifactId>
   <packaging>war</packaging>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core</artifactId>
   <packaging>pom</packaging>

--- a/core/publication-plugins/pom.xml
+++ b/core/publication-plugins/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-publication-plugins</artifactId>
   <packaging>jar</packaging>

--- a/core/publication/pom.xml
+++ b/core/publication/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-publication</artifactId>
   <packaging>jar</packaging>

--- a/core/search/pom.xml
+++ b/core/search/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-search</artifactId>
   <name>eXo PLF:: WCM Search Service</name>

--- a/core/services/pom.xml
+++ b/core/services/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-services</artifactId>
   <name>eXo PLF:: CMS Service</name>

--- a/core/viewer/pom.xml
+++ b/core/viewer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-viewer</artifactId>
   <name>eXo PLF:: DMS Document Viewer</name>

--- a/core/webui-administration/pom.xml
+++ b/core/webui-administration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webui-administration</artifactId>
   <packaging>jar</packaging>

--- a/core/webui-clouddrives/pom.xml
+++ b/core/webui-clouddrives/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webui-clouddrives</artifactId>
   <packaging>jar</packaging>

--- a/core/webui-explorer/pom.xml
+++ b/core/webui-explorer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webui-explorer</artifactId>
   <packaging>jar</packaging>

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/sidebar/UITreeExplorer.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/sidebar/UITreeExplorer.java
@@ -49,6 +49,7 @@ import org.exoplatform.ecm.webui.component.explorer.UIJCRExplorerPortlet;
 import org.exoplatform.ecm.webui.component.explorer.UIWorkingArea;
 import org.exoplatform.ecm.webui.component.explorer.UIDocumentInfo;
 import org.exoplatform.ecm.webui.utils.JCRExceptionManager;
+import org.exoplatform.services.cms.BasePath;
 import org.exoplatform.services.cms.clipboard.ClipboardService;
 import org.exoplatform.services.cms.clouddrives.CloudDrive;
 import org.exoplatform.services.cms.clouddrives.CloudDriveService;
@@ -61,6 +62,7 @@ import org.exoplatform.services.cms.link.LinkUtils;
 import org.exoplatform.services.cms.link.NodeFinder;
 import org.exoplatform.services.cms.templates.TemplateService;
 import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.OrganizationService;
@@ -216,14 +218,14 @@ public class UITreeExplorer extends UIContainer {
               return cloudDrives.getTitle();
             } else {
               try {
-                RepositoryService repoService = WCMCoreUtils.getService(RepositoryService.class);
-                Node groupNode = (Node) WCMCoreUtils.getSystemSessionProvider()
-                                                    .getSession(repoService.getCurrentRepository()
-                                                                           .getConfiguration()
-                                                                           .getDefaultWorkspaceName(),
-                                                                repoService.getCurrentRepository())
-                                                    .getItem(path);
-                return groupNode.getProperty(NodetypeConstant.EXO_LABEL).getString();
+                RepositoryService repoService = CommonsUtils.getService(RepositoryService.class);
+                NodeHierarchyCreator nodeHierarchyCreator = CommonsUtils.getService(NodeHierarchyCreator.class);
+                String groupPath = nodeHierarchyCreator.getJcrPath(BasePath.CMS_GROUPS_PATH);
+                Node groupNode = (Node) WCMCoreUtils.getSystemSessionProvider().getSession(
+                        repoService.getCurrentRepository().getConfiguration().getDefaultWorkspaceName(),
+                        repoService.getCurrentRepository()).getItem(
+                        groupPath + driveData.getName().replace(".", "/"));
+                return groupNode.getParent().getName() + " / " + groupNode.getProperty(NodetypeConstant.EXO_LABEL).getString();
               } catch (Exception e) {
                 return id.replace(".", " / ");
               }

--- a/core/webui-fcc/pom.xml
+++ b/core/webui-fcc/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webui-fcc</artifactId>
   <name>eXo PLF:: Fast Content Creator webui component</name>

--- a/core/webui-presentation/pom.xml
+++ b/core/webui-presentation/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webui-presentation</artifactId>
   <packaging>jar</packaging>

--- a/core/webui-seo/pom.xml
+++ b/core/webui-seo/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webui-seo</artifactId>
   <packaging>jar</packaging>

--- a/core/webui/pom.xml
+++ b/core/webui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webui</artifactId>
   <name>eXo PLF:: DMS webui component</name>

--- a/ecm-wcm-extension/pom.xml
+++ b/ecm-wcm-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecm-wcm-extension</artifactId>
   <packaging>war</packaging>

--- a/ecms-packaging/pom.xml
+++ b/ecms-packaging/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.exoplatform.ecms</groupId>
     <artifactId>ecms</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-packaging</artifactId>
   <packaging>pom</packaging>

--- a/ecms-social-integration/pom.xml
+++ b/ecms-social-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.ecms</groupId>
     <artifactId>ecms</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-social-integration</artifactId>
   <packaging>jar</packaging>

--- a/ext/authoring/apps/pom.xml
+++ b/ext/authoring/apps/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-ext-authoring</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext-authoring-apps</artifactId>
   <packaging>war</packaging>

--- a/ext/authoring/pom.xml
+++ b/ext/authoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-ext</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext-authoring</artifactId>
   <packaging>pom</packaging>

--- a/ext/authoring/services/pom.xml
+++ b/ext/authoring/services/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-ext-authoring</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext-authoring-services</artifactId>
   <packaging>jar</packaging>

--- a/ext/authoring/webui/pom.xml
+++ b/ext/authoring/webui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-ext-authoring</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext-authoring-webui</artifactId>
   <packaging>jar</packaging>

--- a/ext/clouddrives-gdrive/pom.xml
+++ b/ext/clouddrives-gdrive/pom.xml
@@ -25,7 +25,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   <parent>
     <groupId>org.exoplatform.ecms</groupId>
     <artifactId>ecms-ext</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>ecms-ext-gdrive</artifactId>

--- a/ext/clouddrives-gdrive/services/pom.xml
+++ b/ext/clouddrives-gdrive/services/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.ecms</groupId>
     <artifactId>ecms-ext-gdrive</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>ecms-ext-gdrive-services</artifactId>

--- a/ext/clouddrives-gdrive/webapp/pom.xml
+++ b/ext/clouddrives-gdrive/webapp/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.exoplatform.ecms</groupId>
     <artifactId>ecms-ext-gdrive</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>ecms-ext-gdrive-webapp</artifactId>

--- a/ext/clouddrives-onedrive/pom.xml
+++ b/ext/clouddrives-onedrive/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>ecms-ext</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/ext/clouddrives-onedrive/services/pom.xml
+++ b/ext/clouddrives-onedrive/services/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.exoplatform.ecms</groupId>
     <artifactId>ecms-ext-onedrive</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
 
   <artifactId>ecms-ext-onedrive-services</artifactId>

--- a/ext/clouddrives-onedrive/webapp/pom.xml
+++ b/ext/clouddrives-onedrive/webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.ecms</groupId>
     <artifactId>ecms-ext-onedrive</artifactId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/ext/fastcontentcreator/pom.xml
+++ b/ext/fastcontentcreator/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-ext</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext-fastcontentcreator</artifactId>
   <packaging>pom</packaging>

--- a/ext/fastcontentcreator/portlet/pom.xml
+++ b/ext/fastcontentcreator/portlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-ext-fastcontentcreator</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext-fastcontentcreator-portlet</artifactId>
   <packaging>war</packaging>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext</artifactId>
   <packaging>pom</packaging>

--- a/ext/webui/pom.xml
+++ b/ext/webui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-ext</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext-webui</artifactId>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.exoplatform.ecms</groupId>
   <artifactId>ecms</artifactId>
-  <version>6.3.x-SNAPSHOT</version>
+  <version>6.3.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo PLF:: ECM Suite</name>
   <description>eXo Entreprise Content Management Suite</description>
@@ -40,9 +40,9 @@
     <!-- **************************************** -->
     <!-- Project Dependencies                     -->
     <!-- **************************************** -->
-    <org.exoplatform.social.version>6.3.x-SNAPSHOT</org.exoplatform.social.version>
-    <addon.exo.jcr.version>6.3.x-SNAPSHOT</addon.exo.jcr.version>
-    <org.exoplatform.platform-ui.version>6.3.x-SNAPSHOT</org.exoplatform.platform-ui.version>
+    <org.exoplatform.social.version>6.3.x-maintenance-SNAPSHOT</org.exoplatform.social.version>
+    <addon.exo.jcr.version>6.3.x-maintenance-SNAPSHOT</addon.exo.jcr.version>
+    <org.exoplatform.platform-ui.version>6.3.x-maintenance-SNAPSHOT</org.exoplatform.platform-ui.version>
     <!-- **************************************** -->
     <!-- Google API -->
     <!-- **************************************** -->

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-testsuite</artifactId>
   <packaging>pom</packaging>

--- a/testsuite/test/pom.xml
+++ b/testsuite/test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-testsuite</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.3.x-SNAPSHOT</version>
+    <version>6.3.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-testsuite-test</artifactId>
   <name>eXo PLF:: ECMS Testing</name>


### PR DESCRIPTION
Before this fix , when creating a symilink from drives application , an administrator has full access to application spaces even the ones which he is not a member of . So i fixed this by filtering the tree entries when selecting "spaces" from the symilink creation popup in order to keep only the spaces where the administrator is a member.