### PR TITLE
TASK-43174: Create a new system session provider to avoid using it after being closed

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -306,7 +306,7 @@ public class Utils {
   }
 
   public static String getPersonalDrivePath(String parameterizedDrivePath, String userId) throws Exception {
-    SessionProvider sessionProvider = WCMCoreUtils.getSystemSessionProvider();
+    SessionProvider sessionProvider = SessionProvider.createSystemProvider();
     NodeHierarchyCreator nodeHierarchyCreator = WCMCoreUtils.getService(NodeHierarchyCreator.class);
     Node userNode = nodeHierarchyCreator.getUserNode(sessionProvider, userId);
     return StringUtils.replaceOnce(parameterizedDrivePath,

--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -308,10 +308,14 @@ public class Utils {
   public static String getPersonalDrivePath(String parameterizedDrivePath, String userId) throws Exception {
     SessionProvider sessionProvider = SessionProvider.createSystemProvider();
     NodeHierarchyCreator nodeHierarchyCreator = WCMCoreUtils.getService(NodeHierarchyCreator.class);
-    Node userNode = nodeHierarchyCreator.getUserNode(sessionProvider, userId);
-    return StringUtils.replaceOnce(parameterizedDrivePath,
-                                   nodeHierarchyCreator.getJcrPath(BasePath.CMS_USERS_PATH) + "/${userId}",
-                                   userNode.getPath());
+    try{
+      Node userNode = nodeHierarchyCreator.getUserNode(sessionProvider, userId);
+      return StringUtils.replaceOnce(parameterizedDrivePath,
+        nodeHierarchyCreator.getJcrPath(BasePath.CMS_USERS_PATH) + "/${userId}",
+        userNode.getPath());
+    } finally {
+      sessionProvider.close();
+    }
   }
 
   public static List<PropertyDefinition> getProperties(Node node) throws Exception {


### PR DESCRIPTION
The problem was that the `UIJCRExplorerPortlet` was not able to get the current node to refresh the page because the session was closed.
This fix creates a new system session provider to be always sure we can instantiate a new session.