### PR TITLE
MAINT-43744: Fix webcontent restoring from recent version

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/documents/VersionHistoryUtils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/documents/VersionHistoryUtils.java
@@ -39,6 +39,7 @@ public class VersionHistoryUtils {
 
   public static final String NT_FILE          = "nt:file";
   public static final String MIX_VERSIONABLE  = "mix:versionable";
+  public static final String WEB_CONTENT      = "exo:webContent";
 
   //Mixin used to store display version Name added after remove base version
   public static  final String MIX_DISPLAY_VERSION_NAME = "mix:versionDisplayName";
@@ -74,7 +75,7 @@ public class VersionHistoryUtils {
    * @param nodeVersioning
    */
   public static Version createVersion(Node nodeVersioning) throws Exception {
-    if(!nodeVersioning.isNodeType(NT_FILE)) {
+    if(!nodeVersioning.isNodeType(NT_FILE) && !nodeVersioning.isNodeType(WEB_CONTENT)) {
       if(log.isDebugEnabled()){
         log.debug("Version history is not impact with non-nt:file documents, there'is not any version created.");
       }


### PR DESCRIPTION
**ISSUE**: Creating version from versionhisotry wasn't working properly because of incorrect check in the `VersionHistoryUtils.createVerion()` method which was preventing the version creation for a node of type **exo:webContent**.
**FIX**: Correct the check condition the affected function to make it possible to create a version for a wrebContent form versions history.