### PR TITLE
MAINT-28272: Fix snapshot myWork documents portlet listing order update

### DIFF
--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/FileSearchRestService.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/FileSearchRestService.java
@@ -150,9 +150,9 @@ public class FileSearchRestService implements ResourceContainer {
   private ElasticSearchFilter filterMyWorkingDocuments() {
     String userId = ConversationState.getCurrent().getIdentity().getUserId();
     StringBuilder recentFilter = new StringBuilder();
-    recentFilter.append("{\n \"term\" : { \"author\" : \"" + userId + "\" }\n }");
-    recentFilter.append(",{\n \"term\" : { \"lastModifier\" : \"" + userId + "\" }\n }");
-    return new ElasticSearchFilter(ElasticSearchFilterType.FILTER_CUSTOM, "", recentFilter.toString());
+    recentFilter.append("\"should\" : {\n \"term\" : { \"author\" : \"" + userId + "\" }\n },\n");
+    recentFilter.append("\"must\" : {\n \"term\" : { \"lastModifier\" : \"" + userId + "\" }\n }");
+    return new ElasticSearchFilter(ElasticSearchFilterType.FILTER_MY_WORK_DOCS, "", recentFilter.toString());
   }
 
   private Node getUserPrivateNode() throws Exception {


### PR DESCRIPTION
Additional PR for https://github.com/Meeds-io/commons/pull/232
**ISSUE**: The elasticsearch query for retieving documents wasn't musting the modifiedBy field to be only the user who modified the document, 
So, when someone else updates the documents which im the owner, it goes on up the list of myWork docs as that i'm the modifier while it's not the case.
**FIX**: Correct the elasticSearch filter by using the bool query must cluase instead of should in this particular case.
