### PR TITLE
Task-48393 : Folders drive is badly displayed in Attach files drawer

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoFoldersFilesSelector.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoFoldersFilesSelector.vue
@@ -234,7 +234,7 @@
                       v-show="!drivesInProgress[driver.title]"
                       :class="driver.isCloudDrive ? driver.driveTypeCSSClass : `uiIconEcms24x24DriveGroup ${driver.driveTypeCSSClass}`"
                       class="uiIconEcmsLightGray selectionIcon center"></i>
-                    <div class="text-center ma-12 connectingDrive">
+                    <div class="text-center connectingDrive">
                       <!-- show circular progress if cloud drive is connecting -->
                       <v-progress-circular
                         v-show="drivesInProgress[driver.title] >= 0 || drivesInProgress[driver.title] <= 100"


### PR DESCRIPTION
Prio this change , the drive folders in the attach files drawer is badly displayed with an extra space between drive icon and title.
Fix : remove extra spacing.