### PR TITLE
Task-48155: Cancel button is badly displayed in Confirmation popup

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoDropdownMenu.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoDropdownMenu.vue
@@ -8,16 +8,18 @@
     @blur="closeMenu">
     <li
       :class="!selectedFolder.canRemove ? 'disabled' : ''"
-      class="folderActionsMenuItem btn delete"
+      class="folderActionsMenuItem delete"
       @click="deleteFolder()">
-      <i class="uiIconTrash"></i>{{ $t('attachments.filesFoldersSelector.action.delete') }}
+      <i class="uiIconTrash"></i>
+      <span>{{ $t('attachments.filesFoldersSelector.action.delete') }}</span>
     </li>
     <li
       :class="!selectedFolder.canRemove ? 'disabled' : ''"
-      class="folderActionsMenuItem btn rename"
+      class="folderActionsMenuItem rename"
       @click="renameFolder()">
       <i
-        class="uiIconEdit"></i>{{ $t('attachments.filesFoldersSelector.action.rename') }}
+        class="uiIconEdit"></i>
+      <span>{{ $t('attachments.filesFoldersSelector.action.rename') }}</span>
     </li>
   </ul>
 </template>

--- a/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoFoldersFilesSelector.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoFoldersFilesSelector.vue
@@ -813,7 +813,7 @@ export default {
         this.$refs.confirmDialog.open();
         this.titleLabel = this.$t('attachments.filesFoldersSelector.action.delete.popup.title');
         this.okLabel = this.$t('attachments.filesFoldersSelector.action.delete.popup.button.ok');
-        this.cancelLabel = this.$t('attachments.filesFoldersSelector.action.delete.popup.button.cancel');
+        this.cancelLabel = this.$t('attachments.cancel');
         this.okAction = true;
         this.popupBodyMessage = `${this.$t('attachments.filesFoldersSelector.action.delete.popup.bodyMessage')}`;
       }

--- a/apps/resources-wcm/src/main/webapp/skin/less/ecms/portlets/attachments/legacyComposerAttachments.less
+++ b/apps/resources-wcm/src/main/webapp/skin/less/ecms/portlets/attachments/legacyComposerAttachments.less
@@ -911,14 +911,11 @@
                   margin-left: 5px ~'; /** orientation=rt */ ';
                   width: 20px;
                 }
-
-                &:hover {
-                  background: #578dc9;
-                  color: #fff;
-
-                  i {
-                    color: #fff;
+                &:hover{
+                  i,span {
+                    color: #ffffff;
                   }
+                  background-image: linear-gradient(to bottom, @primaryColor, @primaryColor);
                 }
 
                 &.disabled {


### PR DESCRIPTION
Problem: the cancel popup button label description didn't exist in the .properties file and the css hover button properties.
How it was solved: use the cancel label that exit in .properties and fix css hover problem.