### PR TITLE
MAINT-48084: Fix sharedfiles activity attachments processing

### DIFF
--- a/ecms-social-integration/src/main/java/org/exoplatform/ecms/activity/processor/ActivityAttachmentProcessor.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/ecms/activity/processor/ActivityAttachmentProcessor.java
@@ -52,7 +52,8 @@ public class ActivityAttachmentProcessor extends BaseActivityProcessorPlugin {
   @Override
   public void processActivity(ExoSocialActivity activity) {
     Map<String, String> activityParams = activity.getTemplateParams();
-    if (activityParams == null || activityParams.isEmpty() || !activityParams.containsKey(WORKSPACE)) {
+    if (activityParams == null || activityParams.isEmpty() ||
+            (!activityParams.containsKey(WORKSPACE) && !activityParams.containsKey(WORKSPACE.toLowerCase()))) {
       return;
     }
 

--- a/ecms-social-integration/src/test/java/org/exoplatform/ecms/activity/processor/ActivityAttachmentProcessorTest.java
+++ b/ecms-social-integration/src/test/java/org/exoplatform/ecms/activity/processor/ActivityAttachmentProcessorTest.java
@@ -1,0 +1,53 @@
+package org.exoplatform.ecms.activity.processor;
+
+import org.exoplatform.services.wcm.core.NodeLocation;
+import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.activity.model.ExoSocialActivityImpl;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.jcr.Node;
+import java.util.HashMap;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(NodeLocation.class)
+public class ActivityAttachmentProcessorTest {
+
+    @Mock
+    private ActivityAttachmentProcessor activityAttachmentProcessor;
+
+    @Test
+    public void processActivity() {
+        ExoSocialActivity activity = new ExoSocialActivityImpl();
+        activity.setType("sharefiles:spaces");
+        HashMap<String, String> templateParams = new HashMap<>();
+        templateParams.put("workspace", "collaboration");
+        templateParams.put("author", "root");
+        templateParams.put("permission", "read");
+        templateParams.put("nodePath", "/Groups/spaces/new/Documents/Shared/sample.pdf");
+        templateParams.put("docTitle", "sample.pdf");
+        templateParams.put("mimeType", "application/pdf");
+        templateParams.put("message", "");
+        templateParams.put("repository", "repository");
+        templateParams.put("contentName", "sample.pdf");
+        templateParams.put("nodeUUID", "736ec0d07f0001015e91bad4c1d582e1");
+        templateParams.put("id", "736ec0d07f0001015e91bad4c1d582e1");
+        activity.setTemplateParams(templateParams);
+        NodeLocation nodeLocation = new NodeLocation(templateParams.get("repository"), templateParams.get("workspace"),
+                templateParams.get("nodePath"), templateParams.get("nodeUUID"), true);
+        Node currentNode = mock(Node.class);
+        doCallRealMethod().when(activityAttachmentProcessor).processActivity(activity);
+        PowerMockito.mockStatic(NodeLocation.class);
+        when(NodeLocation.getNodeByLocation(ArgumentMatchers.refEq(nodeLocation))).thenReturn(currentNode);
+        activityAttachmentProcessor.processActivity(activity);
+        assertEquals(1, activity.getFiles().size());
+    }
+}


### PR DESCRIPTION
**ISSUE** : the sharedfiles activity attachments weren't processed as the condition of the `processActivity merhod` wasn't well satisfied because the workspace template param is saved in lowercase for this type of activity. 
**Fix** : Adjust the condition to get process method working properly 