### PR TITLE
MAINT-48141: Fix Expand folder contents via the expand icon button in the left side explorer TreeNode when it's paginated

### DIFF
--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/sidebar/UITreeExplorer.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/sidebar/UITreeExplorer.java
@@ -438,6 +438,7 @@ public class UITreeExplorer extends UIContainer {
                                                                                           emptySet, 
                                                                                           emptySet, 
                                                                                           new TreeNodeDataCreater());
+        temp.setExpanded(isExpand);
         addTreeNodePageIteratorAsChild(temp.getPath(), pageList, subPath.toString(), path);
       } else temp.setChildren(jcrExplorer.getChildrenList(subPath.toString(), false));
     }


### PR DESCRIPTION
**ISSUE** : When a folder has more then 20 child sub nodes it doesn't being expanded when click on expand icon because when building the pageList the expand option is not set for the TreeNode..
**FIX** : Set the Expand option when building the pageList for the targeted TreeNode 