### PR TITLE
Task-48226 : Make folder icon clickable on upload documents drawer

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadedFiles.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadedFiles.vue
@@ -153,7 +153,7 @@ export default {
   },
   computed: {
     displayMessageDestinationFolder() {
-      return !this.attachments.length || !this.attachments.some(val => val.uploadId != null && val.uploadId !== '');
+      return !this.attachments.length || this.attachments.some(val => val.uploadId != null && val.uploadId !== '');
     },
     allowToDetach() {
       return !!this.entityId && !!this.entityType;


### PR DESCRIPTION
Issue: Before this fix the folder icon on the upload documents drawer is disabled, The select folder drawer isn't displayed.
Solution: Modify the condition on displayMessageDestinationFolder method to display the select folder drawer if some of the uploaded documents (documents) aren't null.