### PR TITLE
MAINT-45781: Fix nodeType of a folder added from attachments drawer

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
@@ -338,15 +338,17 @@ public class ManageDocumentService implements ResourceContainer {
   public Response createFolder(@QueryParam("driveName") String driveName,
                                @QueryParam("workspaceName") String workspaceName,
                                @QueryParam("currentFolder") String currentFolder,
-                               @QueryParam("folderName") String folderName) throws Exception {
+                               @QueryParam("folderName") String folderName,
+                               @QueryParam("folderNodeType") @DefaultValue("nt:folder") String folderNodeType) throws Exception {
     try {
       Node node = getNode(driveName, workspaceName, currentFolder);
       // The name automatically determined from the title according to the current algorithm.
       String name = Text.escapeIllegalJcrChars(org.exoplatform.services.cms.impl.Utils.cleanString(folderName));
       // Set default name if new title contain no valid character
       name = (StringUtils.isEmpty(name)) ? DEFAULT_NAME : name;
-      Node newNode = node.addNode(name,
-                                  NodetypeConstant.NT_UNSTRUCTURED);
+
+      Node newNode = node.addNode(name, folderNodeType);
+
       if (!newNode.hasProperty("exo:title")) {
         newNode.addMixin("exo:rss-enable");
       }


### PR DESCRIPTION
ISSUE : when adding a folder via the attachments drawer the type of folder is nt:unstructure which is a super type node and not the same behavior when adding a folder via the explorer which the type is nt:folder these contradictions make it impossible to rearrange folders because it's impossible to put nt:unstructure folder inside an nt:folder.

Fix the nodeType of a folder added from attachments drawer by updating the rest endpoint to have the possibility of specifying the node type in the rest call to other future use and need or a default value will be assigned nt:folder.