### PR TITLE
Task-48539 : Display info message when changing folder destination

### DIFF
--- a/apps/portlet-documents/src/main/resources/locale/portlet/attachments_en.properties
+++ b/apps/portlet-documents/src/main/resources/locale/portlet/attachments_en.properties
@@ -83,3 +83,4 @@ attachments.errorAccessingFile=Error accessing file
 attachment.notAccessible.title=Document not accessible
 attachment.notAccessible.tooltip=This document is not accessible due to restricted access
 attachment.detach=Detach file
+attachment.alert.drive.confirm=These files will be available for your connections once you post them.

--- a/apps/portlet-documents/src/main/resources/locale/portlet/attachments_fr.properties
+++ b/apps/portlet-documents/src/main/resources/locale/portlet/attachments_fr.properties
@@ -83,3 +83,4 @@ attachments.errorAccessingFile=Erreur lors de l'acc\u00E8s au fichier
 attachment.notAccessible.title=Document non accessible
 attachment.notAccessible.tooltip=Ce document n'est pas accessible en raison d'un acc\u00E8s restreint
 attachment.detach=D\u00E9tacher le fichier
+attachment.alert.drive.confirm=Ces fichiers seront disponibles pour vos connexions une fois que vous les aurez post\u00E9s.

--- a/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoAttachments.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoAttachments.vue
@@ -43,6 +43,9 @@
             </b>
             {{ $t('attachments.alert.sharing.availableFor') }} <b>{{ spaceGroupId }}</b> {{ $t('attachments.alert.sharing.members') }}
           </div>
+          <div v-show="attachmentConfirmInfo" class="alert alert-info attachmentsAlert">
+            <span>{{ $t('attachments.alert.sharing.attachedFrom') }} <b>{{ selectedFolder }}</b> {{ $t('attachment.alert.drive.confirm') }}</span>
+          </div>
         </div>
         <div v-show="!showDocumentSelector" class="attachmentsContent">
           <div class="multiploadFilesSelector">
@@ -370,6 +373,7 @@ export default {
     return {
       showDestinationFolder: false,
       message: '',
+      selectedFolder: '',
       uploadingFilesQueue: [],
       uploadingCount: 0,
       maxUploadInProgressCount: 2,
@@ -398,6 +402,7 @@ export default {
       spaceGroupId: '',
       drivesInProgress: {},
       attachmentInfo: false,
+      attachmentConfirmInfo: false,
       isCloudDriveEnabled: false,
     };
   },
@@ -420,6 +425,11 @@ export default {
     attachmentInfo: function () {
       if (this.attachmentInfo) {
         setTimeout(() => this.attachmentInfo = false, this.MESSAGES_DISPLAY_TIME);
+      }
+    },
+    attachmentConfirmInfo: function () {
+      if (this.attachmentConfirmInfo) {
+        setTimeout(() => this.attachmentConfirmInfo = false, this.MESSAGES_DISPLAY_TIME);
       }
     },
     value: {
@@ -654,6 +664,8 @@ export default {
         this.showDestinationFolderForFile = false;
       }
       this.modeFolderSelectionForFile = false;
+      this.attachmentConfirmInfo = true;
+      this.selectedFolder = folder;
     },
     toggleServerFileSelector(selectedFiles){
       if (selectedFiles) {


### PR DESCRIPTION
Issue: No info message is displayed when the user selects a folder destination on the destination drawer.
Solution: The following message will be displayed after selecting a destination folder "ou attached files from ***Destination***, These files will be available for your connections once you post them" 