### PR TITLE
Task-48908: folders icons not dispayed when adding special character to a space name

### DIFF
--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIJCRExplorerPortlet.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIJCRExplorerPortlet.java
@@ -209,7 +209,7 @@ public class UIJCRExplorerPortlet extends UIPortletApplication {
       .addScripts("multiUpload.setLocation('" + 
                uiExplorer.getWorkspaceName()  + "','" + 
                uiExplorer.getDriveData().getName()  + "','" +
-               uiTreeExplorer.getLabel()  + "','" +
+               uiTreeExplorer.getLabel().replaceAll("\'", "") + "','" +
                Text.escapeIllegalJcrChars(uiExplorer.getCurrentPath()) + "','" +
                org.exoplatform.services.cms.impl.Utils.getPersonalDrivePath(uiExplorer.getDriveData().getHomePath(),
                ConversationState.getCurrent().getIdentity().getUserId())+ "', '"+


### PR DESCRIPTION
when we add an apostrophe caracter in the name of the space we will get a JS error in the multiUpload.setLocation(...) method
because the input value of the uiTreeExplorer.getLabel() method does not ingone apostrophes so my solution skip this caracter