### PR TITLE
Refactor UserPopup Labels

### DIFF
--- a/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/versions/UIDiff.gtmpl
+++ b/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/versions/UIDiff.gtmpl
@@ -32,23 +32,7 @@
     def rcontext = _ctx.getRequestContext() ;
     def jm = rcontext.getJavascriptManager();
 
-    String statusTitle = StringEscapeUtils.escapeJavaScript(_ctx.appRes("UserProfilePopup.label.Loading"));
-    String connectLabel = StringEscapeUtils.escapeJavaScript(_ctx.appRes("UserProfilePopup.label.Connect"));
-    String confirmLabel = StringEscapeUtils.escapeJavaScript(_ctx.appRes("UserProfilePopup.label.Confirm"));
-    String cancelRequestLabel = StringEscapeUtils.escapeJavaScript(_ctx.appRes("UserProfilePopup.label.CancelRequest"));
-    String removeConnectionLabel = StringEscapeUtils.escapeJavaScript(_ctx.appRes("UserProfilePopup.label.RemoveConnection"));
-    String ignoreLabel = StringEscapeUtils.escapeJavaScript(_ctx.appRes("UserProfilePopup.label.Ignore"));
-
-    String labels = """ {
-      StatusTitle: '${statusTitle}',
-      Connect: '${connectLabel}',
-      Confirm: '${confirmLabel}',
-      CancelRequest: '${cancelRequestLabel}',
-      RemoveConnection: '${removeConnectionLabel}',
-      Ignore: '${ignoreLabel}'
-    } """;
-
-    jm.require("SHARED/UIVersionInfo", "uiVersionInfo").addScripts("uiVersionInfo.initUserProfilePopup($labels);");
+    jm.require("SHARED/UIVersionInfo", "uiVersionInfo").addScripts("uiVersionInfo.initUserProfilePopup();");
 %>
 <div class="uiDiff">
   <div class="headTitle">

--- a/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/versions/UIVersionInfo.gtmpl
+++ b/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/versions/UIVersionInfo.gtmpl
@@ -55,25 +55,9 @@ import java.util.Locale;
   	def context = _ctx.getRequestContext();
   	def jsManager = context.getJavascriptManager();
 
-    String statusTitle = StringEscapeUtils.escapeJavaScript(_ctx.appRes("UserProfilePopup.label.Loading"));
-    String connectLabel = StringEscapeUtils.escapeJavaScript(_ctx.appRes("UserProfilePopup.label.Connect"));
-    String confirmLabel = StringEscapeUtils.escapeJavaScript(_ctx.appRes("UserProfilePopup.label.Confirm"));
-    String cancelRequestLabel = StringEscapeUtils.escapeJavaScript(_ctx.appRes("UserProfilePopup.label.CancelRequest"));
-    String removeConnectionLabel = StringEscapeUtils.escapeJavaScript(_ctx.appRes("UserProfilePopup.label.RemoveConnection"));
-    String ignoreLabel = StringEscapeUtils.escapeJavaScript(_ctx.appRes("UserProfilePopup.label.Ignore"));
-
-    String labels = """ {
-    StatusTitle: '${statusTitle}',
-    Connect: '${connectLabel}',
-    Confirm: '${confirmLabel}',
-    CancelRequest: '${cancelRequestLabel}',
-    RemoveConnection: '${removeConnectionLabel}',
-    Ignore: '${ignoreLabel}'
-    } """;
-
     def actionCompareLink = StringUtils.getNestedString(uicomponent.event("CompareVersion"),"javascript:ajaxGet(\'","\')");
     jsManager.require("SHARED/UIVersionInfo", "uiVersionInfo").addScripts("uiVersionInfo.init(\""+uicomponent.id+"\");")
-           .addScripts("uiVersionInfo.initUserProfilePopup($labels);")
+           .addScripts("uiVersionInfo.initUserProfilePopup();")
            .addScripts("uiVersionInfo.compareEventUrl(\""+actionCompareLink+"\");");
     Locale currentLocale = Util.getPortalRequestContext().getLocale();
     DateFormat df = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT, currentLocale);

--- a/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/comment/view1.gtmpl
+++ b/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/dms-extension/dms/artifacts/templates/comment/view1.gtmpl
@@ -31,23 +31,8 @@ import org.exoplatform.web.application.Parameter ;
     }
     lastCommentLabel = lastCommentLabel.replace("{user}",user);
     lastCommentLabel = lastCommentLabel.replace("{time}",timeComment);
-	  String statusTitle = StringEscapeUtils.escapeJavaScript(_ctx.appRes("UserProfilePopup.label.Loading"));
-	  String connectLabel = StringEscapeUtils.escapeJavaScript(_ctx.appRes("UserProfilePopup.label.Connect"));
-	  String confirmLabel = StringEscapeUtils.escapeJavaScript(_ctx.appRes("UserProfilePopup.label.Confirm"));
-	  String cancelRequestLabel = StringEscapeUtils.escapeJavaScript(_ctx.appRes("UserProfilePopup.label.CancelRequest"));
-	  String removeConnectionLabel = StringEscapeUtils.escapeJavaScript(_ctx.appRes("UserProfilePopup.label.RemoveConnection"));
-	  String ignoreLabel = StringEscapeUtils.escapeJavaScript(_ctx.appRes("UserProfilePopup.label.Ignore"));
 
-	  String labels = """ {
-      StatusTitle: '${statusTitle}',
-      Connect: '${connectLabel}',
-      Confirm: '${confirmLabel}',
-      CancelRequest: '${cancelRequestLabel}',
-      RemoveConnection: '${removeConnectionLabel}',
-      Ignore: '${ignoreLabel}'
-    } """;
-
-	  jsManager.require("SHARED/uiCommentForm", "commentForm").addScripts("eXo.ecm.CommentForm.initUserProfilePopup($labels);");
+	  jsManager.require("SHARED/uiCommentForm", "commentForm").addScripts("eXo.ecm.CommentForm.initUserProfilePopup();");
 %>
   <style>
 		<% _ctx.include(uicomponent.getTemplateSkin("exo:comments", "Stylesheet")); %>


### PR DESCRIPTION
Before this fix, user popup labels are duplicated in a lot of properties files
This fix use the common userPopup labels and removed the non necessary ones