### PR TITLE
TASK-46719: Implement change location for documents in snapshot page

### DIFF
--- a/apps/portlet-documents/src/main/webapp/js/attachmentService.js
+++ b/apps/portlet-documents/src/main/webapp/js/attachmentService.js
@@ -315,6 +315,8 @@ export function moveAttachmentToNewPath(newPathDrive, newPath, attachmentId, ent
   }).then((resp) => {
     if (!resp || !resp.ok) {
       throw new Error('Error moving attachment to the new destination path');
+    } else {
+      return resp.json();
     }
   });
 }

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
@@ -276,6 +276,7 @@ export default {
               this.linkUploadedAttachmentToEntity(file);
             } else {
               file.uploadId = '';
+              file.acl = uploadedFile.acl;
               this.uploadingCount--;
               this.processNextQueuedUpload();
             }
@@ -303,14 +304,20 @@ export default {
         pathDestinationFolder,
         movedFile.id,
         this.entityType,
-        this.entityId).then(() => {
+        this.entityId).then((updatedMovedFile) => {
         this.$root.$emit('entity-attachments-updated');
         document.dispatchEvent(new CustomEvent('entity-attachments-updated'));
+
         this.newUploadedFiles.filter(file => file.id === movedFile.id).map(file => {
           file.pathDestinationFolderForFile = folder;
           file.fileDrive = newDestinationPathDrive;
           file.pathDestinationFolderForFile = folder;
         });
+
+        const movedFileIndex = this.uploadedFiles.findIndex(file => file.id === movedFile.id);
+        this.uploadedFiles[movedFileIndex] = updatedMovedFile;
+        this.uploadedFiles[movedFileIndex].drive = folder;
+        this.uploadedFiles[movedFileIndex].date = updatedMovedFile.created;
       });
     },
     deleteDestinationPathForFile(folderId) {
@@ -466,6 +473,7 @@ export default {
       uploadedFile.id = uploadedFile.UUID;
       uploadedFile.size = file.size;
       uploadedFile.previewBreadcrumb = JSON.parse(uploadedFile.previewBreadcrumb);
+      uploadedFile.acl = JSON.parse(uploadedFile.acl);
       this.uploadedFiles.push(uploadedFile);
     },
     abortUploadingFiles() {

--- a/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentService.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentService.java
@@ -141,7 +141,7 @@ public interface AttachmentService {
    * @param entityId entity id
    * @throws IllegalAccessException when user is not allowed to access the entity
    */
-  void moveAttachmentToNewPath(long userIdentityId,
+  Attachment moveAttachmentToNewPath(long userIdentityId,
                                String attachmentId,
                                String newPathDrive,
                                String newPath,

--- a/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentServiceImpl.java
@@ -373,12 +373,12 @@ public class AttachmentServiceImpl implements AttachmentService {
   }
 
   @Override
-  public void moveAttachmentToNewPath(long userIdentityId,
-                                      String attachmentId,
-                                      String newPathDrive,
-                                      String newPath,
-                                      String entityType,
-                                      long entityId) throws IllegalAccessException {
+  public Attachment moveAttachmentToNewPath(long userIdentityId,
+                                            String attachmentId,
+                                            String newPathDrive,
+                                            String newPath,
+                                            String entityType,
+                                            long entityId) throws IllegalAccessException {
     if (userIdentityId <= 0) {
       throw new IllegalArgumentException("User identity must be positive");
     }
@@ -406,6 +406,12 @@ public class AttachmentServiceImpl implements AttachmentService {
       String destPath = destNode.getPath().concat("/").concat(attachmentNode.getName());
       session.move(attachmentNode.getPath(), destPath);
       session.save();
+      return EntityBuilder.fromAttachmentNode(repositoryService,
+                                              documentService,
+                                              linkManager,
+                                              Utils.getCurrentWorkspace(repositoryService),
+                                              session,
+                                              attachmentId);
     } catch (Exception e) {
       throw new IllegalStateException("Error while trying to move attachment node with id " + attachmentId + " to the new path "
           + newPath);

--- a/core/services/src/main/java/org/exoplatform/services/rest/AttachmentsRestService.java
+++ b/core/services/src/main/java/org/exoplatform/services/rest/AttachmentsRestService.java
@@ -337,6 +337,7 @@ public class AttachmentsRestService implements ResourceContainer {
   @POST
   @Path("/{attachmentId}/move")
   @Consumes("application/x-www-form-urlencoded")
+  @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed("users")
   @ApiOperation(value = "Move an attachment to a destination path", httpMethod = "POST", response = Response.class, consumes = "application/x-www-form-urlencoded", notes = "returns empty response")
   @ApiResponses(value = { @ApiResponse(code = HTTPStatus.NO_CONTENT, message = "Request fulfilled"),
@@ -359,12 +360,20 @@ public class AttachmentsRestService implements ResourceContainer {
 
     long userIdentityId = getCurrentUserIdentityId();
     try {
-      attachmentService.moveAttachmentToNewPath(userIdentityId, attachmentId, newPathDrive, newPath, entityType, entityId);
+      Attachment attachment = attachmentService.moveAttachmentToNewPath(userIdentityId,
+                                                                        attachmentId,
+                                                                        newPathDrive,
+                                                                        newPath,
+                                                                        entityType,
+                                                                        entityId);
+      return Response.ok(EntityBuilder.fromAttachment(identityManager, attachment)).build();
     } catch (Exception e) {
       LOG.error("Error when trying to move attachment with id {} to new destination path {} ", attachmentId, newPath, e);
-      return Response.serverError().entity("Error when trying to move attachment with id " + attachmentId + " to new destination path {} " + newPath).build();
+      return Response.serverError()
+                     .entity("Error when trying to move attachment with id " + attachmentId + " to new destination path {} "
+                         + newPath)
+                     .build();
     }
-    return Response.noContent().build();
   }
 
   public Identity getCurrentUserIdentity() {


### PR DESCRIPTION
The problem was that the file returned from the upload service doesn't include permission to allow to edit the file.
This should add permissions to the returned file and also fix the breadcrumb details after moving the file.