### PR TITLE
TASK-48947: Import missing documents translation file

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
@@ -615,8 +615,6 @@ export default {
       this.foldersHistory = [];
       this.resetExplorer();
       this.fromSpace = group === 'My Spaces' ? {title: drive.title, name: drive.name} : {};
-      const driveTitle = drive.title.replace('.', '').replace(' ', '');
-      drive.title = drive.name.includes('space') ? drive.title : this.$t(`Drives.label.${driveTitle}`);
       this.currentDrive = {
         name: drive.name,
         title: drive.title,
@@ -788,9 +786,11 @@ export default {
             const driveTypeCSSClass = isCloudDrive
               ? `uiIconEcmsDrive-${fetchedDrivers[j].getAttribute('cloudProvider')}`
               : `${name.replace(/\s/g, '')} ${driverTypeClass}`;
+            const driveLabel = fetchedDrivers[j].getAttribute('label')
+              .replace('.', '').replace(' ', '');
             this.drivers.push({
               name: name,
-              title: fetchedDrivers[j].getAttribute('label'),
+              title: name.includes('space') ? driveLabel : this.$t(`Drives.label.${driveLabel}`),
               path: fetchedDrivers[j].getAttribute('path'),
               css: fetchedDrivers[j].getAttribute('nodeTypeCssClass'),
               type: 'drive',

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/main.js
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/main.js
@@ -10,7 +10,8 @@ const lang = typeof eXo !== 'undefined' ? eXo.env.portal.language : 'en';
 
 // should expose the locale resources as REST API
 
-const url = `/portal/rest/i18n/bundle/locale.portlet.attachments-${lang}.json`;
+const url = [`/portal/rest/i18n/bundle/locale.portlet.attachments-${lang}.json`,
+  `/portal/rest/i18n/bundle/locale.portlet.documents-${lang}.json`];
 
 // get overridden components if exist
 if (extensionRegistry) {


### PR DESCRIPTION
The problem was that the documents translation file was missing and the displayed drives title in drives explorer was static in english.
This should initialize the drives `title` attribut with its translation.