### PR TITLE
TASK-49082 Fix Blank Activity generated right after creating the document

### DIFF
--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/ActivityListener.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/ActivityListener.java
@@ -125,8 +125,6 @@ public class ActivityListener extends ActivityListenerPlugin {
       }
       } catch (RepositoryException e) {
         LOG.warn("Error while getting session for sharing files to the space: " + targetSpace.getGroupId(), e);
-      } finally {
-        sessionProvider.close();
       }
     }
   }


### PR DESCRIPTION
Prior to this change, a newly created document in space generates an empty activity without attached files. This is due to the fact that the shared SessionProvider has been manually closed before the ActivityAttachmentProcessor access to the JCR Session. This fix will ensure to log an exception when such a case is remarked (not throwing one to not impact existing behavior) and to delete an old code that closed manually the session provider.