### PR TITLE
Task-48655 : empty doc / docx file attached to the post disappears

### DIFF
--- a/apps/portlet-documents/src/main/resources/locale/portlet/attachments_en.properties
+++ b/apps/portlet-documents/src/main/resources/locale/portlet/attachments_en.properties
@@ -13,6 +13,7 @@ attachments.drawer.maxFileSize=Maximum file size : {0} MB
 attachments.drawer.maxFileCountLeft=Max files left: {0}
 attachments.drawer.maxFileCount=Max files: {0}
 attachments.drawer.maxFileSize.error=You can\u2019t upload files larger than {0} MB
+attachments.drawer.nullFileSize.error=You can't attach an empty file
 attachments.drawer.maxFileCount.error=You can't upload more than {0} files
 attachments.drawer.sameFile.error=The file {0} is already attached to the post
 attachments.drawer.title=Attachments

--- a/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoAttachments.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoAttachments.vue
@@ -113,6 +113,12 @@
               </div>
             </transition>
             <transition name="fade">
+              <div v-show="fileSizeNullError" class="sizeExceeded alert alert-error">
+                <i class="uiIconError"></i>
+                {{ $t('attachments.drawer.nullFileSize.error') }}
+              </div>
+            </transition>
+            <transition name="fade">
               <div v-show="filesCountLimitError" class="countExceeded alert alert-error">
                 <i class="uiIconError"></i>
                 {{ $t('attachments.drawer.maxFileCount.error').replace('{0}', maxFilesCount) }}
@@ -380,6 +386,7 @@ export default {
       maxProgress: 100,
       showDocumentSelector: false,
       fileSizeLimitError: false,
+      fileSizeNullError: false,
       filesCountLimitError: false,
       sameFileError: false,
       sameFileErrorMessage: `${this.$t('attachments.drawer.sameFile.error')}`,
@@ -565,6 +572,13 @@ export default {
         this.fileSizeLimitError = true;
         return;
       }
+
+      if (fileSizeInMb === 0) {
+        this.fileSizeNullError = true;
+        window.setTimeout(() => this.fileSizeNullError = false, 2000);
+        return;
+      }
+
       const fileExists = this.value.some(f => f.name === file.name);
       if (fileExists) {
         this.sameFileErrorMessage = this.sameFileErrorMessage.replace('{0}', file.name);


### PR DESCRIPTION
Prior this change, when upload a file with size 0 (rare case) and then post, the file disappears and the log display errors.
We decide to limit the upload process by preventing the user from uploading a file with size 0 and by informing him by alert message.