### PR TITLE
TASK-49042: Differentiate between quarantined and private attachment.

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentService.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentService.java
@@ -56,9 +56,10 @@ public interface AttachmentService {
    * Get an attachment with its jcr uuid
    * 
    * @param attachmentId attachment jcr uuid
+   * @param userIdentityId user identity id
    * @return {@link Attachment}
    */
-  Attachment getAttachmentById(String attachmentId);
+  Attachment getAttachmentById(String attachmentId, long userIdentityId);
 
   /**
    * link an attachment with its jcr uuid to a given entity.

--- a/core/services/src/main/java/org/exoplatform/services/attachments/storage/AttachmentStorage.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/storage/AttachmentStorage.java
@@ -25,13 +25,14 @@ import java.util.List;
 public interface AttachmentStorage {
   void linkAttachmentToEntity(long entityId, String entityType, String attachmentsId);
 
-  List<Attachment> getAttachmentsByEntity(Session session, String workspace, long entityId, String entityType) throws Exception;
+  List<Attachment> getAttachmentsByEntity(Session session, String workspace, long entityId, String entityType, String UserIdentityId) throws Exception;
 
   Attachment getAttachmentItemByEntity(Session session,
                                        String workspace,
                                        long entityId,
                                        String entityType,
-                                       String attachmentId) throws Exception;
+                                       String attachmentId,
+                                       String UserIdentityId) throws Exception;
 
   void deleteAllEntityAttachments(AttachmentContextEntity attachmentContextEntity);
 

--- a/core/services/src/main/java/org/exoplatform/services/attachments/storage/AttachmentStorageImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/storage/AttachmentStorageImpl.java
@@ -29,6 +29,7 @@ import org.exoplatform.services.jcr.ext.app.SessionProviderService;
 import javax.jcr.Session;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class AttachmentStorageImpl implements AttachmentStorage {
@@ -71,7 +72,8 @@ public class AttachmentStorageImpl implements AttachmentStorage {
   public List<Attachment> getAttachmentsByEntity(Session session,
                                                  String workspace,
                                                  long entityId,
-                                                 String entityType) throws Exception {
+                                                 String entityType,
+                                                 String UserIdentityId) throws Exception {
     List<AttachmentContextEntity> attachmentsContextEntity = attachmentDAO.getAttachmentContextByEntity(entityId,
                                                                                                         entityType.toUpperCase());
     Utils.sortAttachmentsByDate(attachmentsContextEntity);
@@ -83,12 +85,13 @@ public class AttachmentStorageImpl implements AttachmentStorage {
                                                                  linkManager,
                                                                  workspace,
                                                                  session,
-                                                                 attachmentContextEntity.getAttachmentId());
+                                                                 attachmentContextEntity.getAttachmentId(),
+                                                                 UserIdentityId);
         attachments.add(attachment);
       }
     }
     return attachments.stream()
-                      .filter((var attachment) -> !attachment.getPath().startsWith("/" + DLP_QUARANTINE_FOLDER + "/"))
+                      .filter(Objects::nonNull)
                       .collect(Collectors.toList());
   }
 
@@ -97,7 +100,8 @@ public class AttachmentStorageImpl implements AttachmentStorage {
                                               String workspace,
                                               long entityId,
                                               String entityType,
-                                              String attachmentId) throws Exception {
+                                              String attachmentId,
+                                              String UserIdentityId) throws Exception {
     AttachmentContextEntity attachmentEntity = attachmentDAO.getAttachmentItemByEntity(entityId,
                                                                                        entityType.toUpperCase(),
                                                                                        attachmentId);
@@ -107,7 +111,8 @@ public class AttachmentStorageImpl implements AttachmentStorage {
                                             linkManager,
                                             workspace,
                                             session,
-                                            attachmentEntity.getAttachmentId());
+                                            attachmentEntity.getAttachmentId(),
+                                            UserIdentityId);
   }
 
   @Override

--- a/core/services/src/main/java/org/exoplatform/services/attachments/utils/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/utils/Utils.java
@@ -74,6 +74,12 @@ public class Utils {
     return sessionProvider.getSession(getCurrentWorkspace(repositoryService), repositoryService.getCurrentRepository());
   }
 
+  public static Session getSystemSession(SessionProviderService sessionProviderService,
+                                   RepositoryService repositoryService) throws RepositoryException {
+    SessionProvider sessionProvider = sessionProviderService.getSystemSessionProvider(null);
+    return sessionProvider.getSession(getCurrentWorkspace(repositoryService), repositoryService.getCurrentRepository());
+  }
+
   public static String getCurrentWorkspace(RepositoryService repositoryService) throws RepositoryException {
     return repositoryService.getCurrentRepository().getConfiguration().getDefaultWorkspaceName();
   }

--- a/core/services/src/main/java/org/exoplatform/services/rest/AttachmentsRestService.java
+++ b/core/services/src/main/java/org/exoplatform/services/rest/AttachmentsRestService.java
@@ -220,8 +220,10 @@ public class AttachmentsRestService implements ResourceContainer {
     if (StringUtils.isBlank(attachmentId)) {
       return Response.status(Response.Status.BAD_REQUEST).entity("Attachment identifier is mandatory").build();
     }
+    long userIdentityId = getCurrentUserIdentityId();
+
     try {
-      Attachment attachment = attachmentService.getAttachmentById(attachmentId);
+      Attachment attachment = attachmentService.getAttachmentById(attachmentId, userIdentityId);
       if (attachment == null) {
         return Response.status(Status.NOT_FOUND).build();
       } else {

--- a/core/services/src/test/java/org/exoplatform/services/attachments/service/AttachmentServiceTest.java
+++ b/core/services/src/test/java/org/exoplatform/services/attachments/service/AttachmentServiceTest.java
@@ -141,6 +141,7 @@ public class AttachmentServiceTest extends BaseExoTestCase {
     }
 
     // when
+    lenient().when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
     lenient().when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
@@ -185,8 +186,8 @@ public class AttachmentServiceTest extends BaseExoTestCase {
     lenient().when(session.getWorkspace()).thenReturn(workSpace);
     lenient().when(node3.getSession()).thenReturn(session);
     lenient().when(node3.getProperty(anyString())).thenReturn(property3);
-    when(node3.getNode(anyString())).thenReturn(nodeContent3);
-    when(nodeContent3.getProperty(anyString())).thenReturn(property3);
+    lenient().when(node3.getNode(anyString())).thenReturn(nodeContent3);
+    lenient().when(nodeContent3.getProperty(anyString())).thenReturn(property3);
     lenient().when(property3.getDate()).thenReturn(Calendar.getInstance());
     lenient().when(property3.getLong()).thenReturn((long) 3);
     lenient().when(node3.getPath()).thenReturn("/collaboration/");


### PR DESCRIPTION
The problem was that we can't know the path of a private file to differentiate with quarantined one.
This fix uses a system session only in case of retrieving the attachment list.