### PR TITLE
Task-49273: Hide space navigation in mobile view and fix attachment drawer style

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoAttachmentItem.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoAttachmentItem.vue
@@ -7,7 +7,7 @@
       <div class="fileDetails1">
         <div
           v-sanitized-html="file.name"
-          class="fileNameLabel"
+          class="fileNameLabel text-truncate"
           data-toggle="tooltip"
           rel="tooltip"
           data-placement="top"></div>

--- a/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoAttachments.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoAttachments.vue
@@ -518,9 +518,12 @@ export default {
       this.showAttachmentsDrawer = !this.showAttachmentsDrawer;
       if (this.showAttachmentsDrawer){
         document.addEventListener('paste', this.onPaste, false);
+        $('.spaceButtomNavigation').addClass('hidden');
       } else {
         document.removeEventListener('paste', this.onPaste, false);
+        $('.spaceButtomNavigation').removeClass('hidden');
       }
+      this.$emit('HideAttachmentsDrawer', this.uploadingCount);
     },
     uploadFile: function() {
       this.$refs.uploadInput.click();

--- a/apps/resources-wcm/src/main/webapp/skin/less/ecms/portlets/attachments/attachmentsApp.less
+++ b/apps/resources-wcm/src/main/webapp/skin/less/ecms/portlets/attachments/attachmentsApp.less
@@ -475,11 +475,6 @@
       .contentOR {
         display: none;
       }
-
-      .contentDrop {
-        padding: 35px 1px 1px;
-      }
-
       .contentDrop {
         display: none;
       }
@@ -497,9 +492,6 @@
             padding-top: 0;
           }
 
-          .text {
-            padding: 8px;
-          }
         }
       }
 
@@ -519,6 +511,12 @@
 @media screen and (max-width: 1024px) {
   .attachments .content.serverFiles .serverFiles .contentBody .selectionBox .folderSelection {
     margin: 0 7px;
+  }
+}
+
+@media (max-width: 480px) {
+  .dropFileBox .dropMsg {
+    display: initial !important;
   }
 }
 


### PR DESCRIPTION
Prior to this change, some styles were added to attachment drawer footer. Due to those properties, the drawer in mobile view is not well displayed, so to solve this problem, we have removes those styles and we hide the spaceButtomNavigation when opening the drawer