### PR TITLE
Task-50193: Remove the web contributor group and publisher role from ECMS

### DIFF
--- a/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/wcm-extension/wcm/wcm-organization-configuration.xml
+++ b/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/wcm-extension/wcm/wcm-organization-configuration.xml
@@ -161,50 +161,6 @@
                     </field>
                   </object>
                 </value>
-                <value>
-                  <object type="org.exoplatform.services.organization.OrganizationConfig$MembershipType">
-                    <field name="type">
-                      <string>publisher</string>
-                    </field>
-                    <field name="description">
-                      <string>publisher membership type</string>
-                    </field>
-                  </object>
-                </value>
-              </collection>
-            </field>
-            <field name="group">
-              <collection type="java.util.ArrayList">
-                <value>
-                  <object type="org.exoplatform.services.organization.OrganizationConfig$Group">
-                    <field name="name">
-                      <string>web-contributors</string>
-                    </field>
-                    <field name="parentId">
-                      <string>/platform</string>
-                    </field>
-                    <field name="description">
-                      <string>the /platform/web-contributors group</string>
-                    </field>
-                    <field name="label">
-                      <string>Content Management</string>
-                    </field>
-                  </object>
-                </value>
-              </collection>
-            </field>
-            <field name="user">
-              <collection type="java.util.ArrayList">
-                <value>
-                  <object type="org.exoplatform.services.organization.OrganizationConfig$User">
-                    <field name="userName">
-                      <string>${exo.super.user}</string>
-                    </field>
-                    <field name="groups">
-                      <string>*:/platform/web-contributors</string>
-                    </field>
-                  </object>
-                </value>
               </collection>
             </field>
           </object>


### PR DESCRIPTION
Prior to this change, web contributor group and publisher role are configured on ecms thus not created on Meeds, after this change since web contributor group and publisher role will be created on Meeds within social
in order to allows publisher on web contributor group to write a post on a redactional space, web contributor group and publisher role are removed from ECMS