### PR TITLE
MAINT-50212: Prevent the trigger of keyboard press  actions on PDF viewer when typing a message on the chat composer

### DIFF
--- a/apps/resources-wcm/src/main/webapp/pdf.js/viewer.js
+++ b/apps/resources-wcm/src/main/webapp/pdf.js/viewer.js
@@ -7741,7 +7741,7 @@ window.addEventListener('click', function click(evt) {
 }, false);
 
 window.addEventListener('keydown', function keydown(evt) {
-  if (OverlayManager.active) {
+  if (OverlayManager.active || evt.target.isContentEditable) {
     return;
   }
 


### PR DESCRIPTION
**ISSUE**: When opening the PDF viewer and the try to type a message on chat drawer composer some keys such as n,p,k and j triggers an action on the PDF viewer without being typed in the composer.
**FIX**: Add a check on the target element of the key-down event to avoid the action on the viewer