### PR TITLE
Task-48221 : Download option is still displayed after suspend temporarily download documents on transfer rules page

### DIFF
--- a/apps/portlet-documents/src/main/webapp/js/transferRulesService.js
+++ b/apps/portlet-documents/src/main/webapp/js/transferRulesService.js
@@ -1,0 +1,17 @@
+export function getTransfertRulesDownloadDocumentStatus() {
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/transferRules/getTransfertRulesDocumentStatus`, {
+    method: 'GET',
+    credentials: 'include',
+  }).then((resp) => {
+    if (resp && resp.ok) {
+      return resp.json();
+    }
+    else {
+      throw new Error ('Error when getting transfer rules download documents status');
+    }
+  }).then(data => {
+    if (data) {
+      return data.downloadDocumentStatus !== 'true';
+    }
+  });
+}

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/extensions.js
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/extensions.js
@@ -54,30 +54,35 @@ export function installExtensions() {
     },
   };
 
-  extensionRegistry.registerExtension('activity', 'action', Object.assign({
-    id: 'download',
-    labelKey: 'documents.label.download',
-    isEnabled: activity => {
-      if (activity.templateParams) {
-        const docPaths = activity.templateParams.DOCPATH && activity.templateParams.DOCPATH.split('|@|')
-                          || (activity.templateParams.nodePath && [activity.templateParams.nodePath]);
-        return docPaths && docPaths.length === 1;
-      }
-    },
-    rank: 0,
-  }, downloadHandlerExtension));
+  Vue.prototype.$transferRulesService.getTransfertRulesDownloadDocumentStatus()
+    .then(data => {
+      if (data) {
+        extensionRegistry.registerExtension('activity', 'action', Object.assign({
+          id: 'download',
+          labelKey: 'documents.label.download',
+          isEnabled: activity => {
+            if (activity.templateParams) {
+              const docPaths = activity.templateParams.DOCPATH && activity.templateParams.DOCPATH.split('|@|')
+                              || (activity.templateParams.nodePath && [activity.templateParams.nodePath]);
+              return docPaths && docPaths.length === 1;
+            }
+          },
+          rank: 0,
+        }, downloadHandlerExtension));
 
-  extensionRegistry.registerExtension('activity', 'action', Object.assign({
-    id: 'downloadAll',
-    labelKey: 'documents.label.downloadAll',
-    isEnabled: activity => {
-      if (activity.templateParams) {
-        const docPaths = activity.templateParams.DOCPATH && activity.templateParams.DOCPATH.split('|@|')
-                          || (activity.templateParams.nodePath && [activity.templateParams.nodePath]);
-        return docPaths && docPaths.length > 1;
+        extensionRegistry.registerExtension('activity', 'action', Object.assign({
+          id: 'downloadAll',
+          labelKey: 'documents.label.downloadAll',
+          isEnabled: activity => {
+            if (activity.templateParams) {
+              const docPaths = activity.templateParams.DOCPATH && activity.templateParams.DOCPATH.split('|@|')
+                              || (activity.templateParams.nodePath && [activity.templateParams.nodePath]);
+              return docPaths && docPaths.length > 1;
+            }
+          },
+          rank: 0,
+        }, downloadHandlerExtension));
       }
-    },
-    rank: 0,
-  }, downloadHandlerExtension));
+    });
 
 }

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/initComponents.js
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/initComponents.js
@@ -43,3 +43,11 @@ if (!Vue.prototype.$attachmentService) {
     value: attachmentService,
   });
 }
+
+import * as transferRulesService from '../../js//transferRulesService.js';
+
+if (!Vue.prototype.$transferRulesService) {
+  window.Object.defineProperty(Vue.prototype, '$transferRulesService', {
+    value: transferRulesService,
+  });
+}


### PR DESCRIPTION
Issue: Before this fix, when suspending temporarily download documents on the transfer rules page, the download action (download or downloadAll)is still displayed on the activity stream (3 dots button).
Solution: Check the transfer rules download action status and filter enabled action according to this value, if suspend is enabled the download actions are displayed(download or downloadAll) otherwise isn't displayed.