### PR TITLE
Suppress Cloud Drive warning logs and make them visible for debug mode

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/clouddrives/CloudDriveConnector.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/clouddrives/CloudDriveConnector.java
@@ -355,13 +355,16 @@ public abstract class CloudDriveConnector extends BaseComponentPlugin {
         connected.add(loadDrive(driveNode));
       } catch (CloudProviderException e) {
         // skip drives with provider errors
-        LOG.warn("Cannot load Cloud Drive associated with node " + driveNode.getPath() + " due to provider error. "
+        if (LOG.isDebugEnabled()) {
+          LOG.warn("Cannot load Cloud Drive associated with node " + driveNode.getPath() + " due to provider error. "
             + e.getMessage() + (e.getCause() != null ? ". " + e.getCause().getMessage() : "."), e);
+        }
       } catch (DriveTrashedException e) {
         // skip trashed drive and remove its node
-        LOG.warn("Node trashed " + driveNode.getPath() + ", it cannot be loaded as Cloud Drive and will be removed. "
+        if (LOG.isDebugEnabled()) {
+          LOG.warn("Node trashed " + driveNode.getPath() + ", it cannot be loaded as Cloud Drive and will be removed. "
             + e.getMessage());
-
+        }
         // Remove the node in another thread
         final String nodeUUID = driveNode.getUUID();
         final String nodePath = driveNode.getPath();


### PR DESCRIPTION
Each time the server is started, warning messages are displayed in the server logs for connecting to the cloud drive. Therefore, errors should be displayed to the client and not at startup. This workaround ensures that these logs are displayed when debugging mode is enabled.