### PR TITLE
Task-43577: Share document: comment zone not accessible

### DIFF
--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/wcm/frontoffice/public/ShareContent.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/wcm/frontoffice/public/ShareContent.js
@@ -95,12 +95,8 @@
   }
 
   ShareContent.prototype.doShare = function(){
-    gj(".uiShareDocuments.resizable #textAreaInput").exoMentions('val', function(value) {
-      value = value.replace(/<br\/?>/gi, '\n').replace(/&lt;/gi, '<').replace(/&gt;/gi, '>');
-      gj(".uiShareDocuments.resizable #textAreaInput").val(value);
-      gj(".PopupContent .uiActionBorder .btn-primary").attr("disabled","disabled");
-      gj("#shareActionBtn").trigger("click");
-    });
+    gj(".PopupContent .uiActionBorder .btn-primary").attr("disabled","disabled");
+    gj("#shareActionBtn").trigger("click");
   }
 
   /**


### PR DESCRIPTION
Problem: The comment zone is not clickable and you can’t write. (you have to click on the text in the comment zone several times to be editable)
Fix: Add a comment by clicking on comment zone (like the case when you open the document and select share from the top menu, you can add your comment normally)