### PR TITLE
MAINT-51623: Fix the mail notification sender param in the watch document notification

### DIFF
--- a/core/webui-clouddrives/src/main/java/org/exoplatform/services/cms/clouddrives/webui/watch/EmailNotifyCloudDocumentListener.java
+++ b/core/webui-clouddrives/src/main/java/org/exoplatform/services/cms/clouddrives/webui/watch/EmailNotifyCloudDocumentListener.java
@@ -31,6 +31,7 @@ import javax.jcr.observation.EventIterator;
 import javax.jcr.observation.EventListener;
 import javax.portlet.PortletRequest;
 
+import org.exoplatform.commons.utils.MailUtils;
 import org.exoplatform.portal.application.PortalRequestContext;
 import org.exoplatform.portal.mop.SiteType;
 import org.exoplatform.portal.mop.user.UserNavigation;
@@ -110,6 +111,8 @@ public class EmailNotifyCloudDocumentListener implements EventListener {
     WatchCloudDocumentServiceImpl watchService =
                                                (WatchCloudDocumentServiceImpl) WCMCoreUtils.getService(WatchDocumentService.class);
     MessageConfig messageConfig = watchService.getMessageConfig();
+    String sender = MailUtils.getSenderName() + "<" + MailUtils.getSenderEmail() + ">";
+    messageConfig.setSender(sender);
     List<String> emailList = getEmailList(NodeLocation.getNodeByLocation(observedNode_));
     for (String receiver : emailList) {
       try {


### PR DESCRIPTION
…
**ISSUE**: The the sender property wasn't set in the mail notification plugin of watch documents and also doesn't take the value set in notification administrations
**FIX**: Set the value already set in the notification administration as  the sender value in the mail notification plugin