### PR TITLE
Task-50207: Html tags in tooltip. (#1553)

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/common/components/ExoDocument.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/common/components/ExoDocument.vue
@@ -7,7 +7,7 @@
     </v-list-item-icon>
     <v-list-item-content>
       <v-list-item-title 
-        v-sanitized-html="document.title" 
+        v-sanitized-html="document.excerptTitle ? document.excerptTitle : document.title" 
         :title="document.title" 
         class="text-truncate" />
       <v-list-item-subtitle v-if="!hideTime || !hideDrive">

--- a/apps/portlet-documents/src/main/webapp/vue-app/files-search/components/FileSearchCard.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/files-search/components/FileSearchCard.vue
@@ -56,7 +56,7 @@ export default {
   mounted() {
     if (this.result && this.excerptTitle) {
       // eslint-disable-next-line vue/no-mutating-props
-      this.result.title = this.excerptTitle;
+      this.$set(this.result,'excerptTitle', this.excerptTitle);
     }
     this.computeEllipsis();
   },


### PR DESCRIPTION
Problem: pop up displays when hovering on the document indicating the name of the document contains html tags..
Fix: No html tags appear with a document name.