### PR TITLE
MAINT-52280: Add potx file mimetype to the officeDocumentThumbnailPlugin

### DIFF
--- a/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/dms-extension/dms/dms-thumbnail-configuration.xml
+++ b/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/dms-extension/dms/dms-thumbnail-configuration.xml
@@ -98,8 +98,8 @@
                                 <value><string>application/vnd.openxmlformats-officedocument.presentationml.presentation</string></value>
                                 <value><string>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</string></value>
                                 <value><string>application/vnd.openxmlformats-officedocument.wordprocessingml.document</string></value>
-								<value><string>application/vnd.openxmlformats-officedocument.presentationml.template</string></value>
-								<value><string>application/vnd.sun.xml.impress</string></value>
+				<value><string>application/vnd.openxmlformats-officedocument.presentationml.template</string></value>
+				<value><string>application/vnd.sun.xml.impress</string></value>
                                 <value><string>application/vnd.sun.xml.writer</string></value>
                                 <value><string>application/wordperfect</string></value>
                                 <value><string>application/xls</string></value>

--- a/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/dms-extension/dms/dms-thumbnail-configuration.xml
+++ b/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/dms-extension/dms/dms-thumbnail-configuration.xml
@@ -98,7 +98,8 @@
                                 <value><string>application/vnd.openxmlformats-officedocument.presentationml.presentation</string></value>
                                 <value><string>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</string></value>
                                 <value><string>application/vnd.openxmlformats-officedocument.wordprocessingml.document</string></value>
-                                <value><string>application/vnd.sun.xml.impress</string></value>
+								<value><string>application/vnd.openxmlformats-officedocument.presentationml.template</string></value>
+								<value><string>application/vnd.sun.xml.impress</string></value>
                                 <value><string>application/vnd.sun.xml.writer</string></value>
                                 <value><string>application/wordperfect</string></value>
                                 <value><string>application/xls</string></value>


### PR DESCRIPTION
ISSUE: The files with potx type have the default presentation thaumbnail in the documents app workplace while it's possible to create correct thumbnail of this type.
FIX: This PR should add the potx file mimetype to the officeDocumentThumbnailPlugin to allow creating thumbnails for this type of files.