### PR TITLE
MAINT-52092: Fix links are not clickable in embedded pdf viewer

### DIFF
--- a/apps/resources-wcm/src/main/webapp/pdf.js/viewer.css
+++ b/apps/resources-wcm/src/main/webapp/pdf.js/viewer.css
@@ -1118,17 +1118,33 @@ canvas {
   background-color: #f8f8f8;
 }
 
-.page > a,
-.annotationLayer > a {
-  display: block;
+.annotationLayer section {
   position: absolute;
+  text-align: initial;
 }
 
-.page > a:hover,
-.annotationLayer > a:hover {
+.annotationLayer .linkAnnotation > a,
+.annotationLayer .buttonWidgetAnnotation.pushButton > a {
+  position: absolute;
+  font-size: 1em;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.annotationLayer .buttonWidgetAnnotation.pushButton > canvas {
+  position: relative;
+  top: 0;
+  left: 0;
+  z-index: -1;
+}
+
+.annotationLayer .linkAnnotation > a:hover,
+.annotationLayer .buttonWidgetAnnotation.pushButton > a:hover {
   opacity: 0.2;
-  background: #ff0;
-  box-shadow: 0px 2px 10px #ff0;
+  background: rgba(255, 255, 0, 1);
+  box-shadow: 0 2px 10px rgba(255, 255, 0, 1);
 }
 
 .loadingIcon {

--- a/apps/resources-wcm/src/main/webapp/pdf.js/viewer.js
+++ b/apps/resources-wcm/src/main/webapp/pdf.js/viewer.js
@@ -453,7 +453,7 @@ var DEFAULT_PREFERENCES = {
   disableFontFace: false,
   disableTextLayer: false,
   useOnlyCssZoom: false,
-  externalLinkTarget: 0,
+  externalLinkTarget: 2,
 };
 
 


### PR DESCRIPTION
**ISSUE**: The annotationLayer and its sections in the previewer were not well styled and positioned which made the links (internal and external) not clickable
**FIX**: Add styles for annotationLayer and its sections from official Pdf.js github repo, also allow opening external links in new tab by set externalLinkTarget = 2 (means target = blank)