### PR TITLE
MAINT-52371: Return 404 error code instead of 401 from download connector rest endpoint when the user has no the right permissions

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/DownloadConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/DownloadConnector.java
@@ -86,7 +86,7 @@ public class DownloadConnector implements ResourceContainer{
     }catch (PathNotFoundException pne) {
       return Response.status(HTTPStatus.NOT_FOUND).build();
     } catch (AccessDeniedException ade) {
-      return Response.status(HTTPStatus.UNAUTHORIZED).build();
+      return Response.status(HTTPStatus.NOT_FOUND).build();
     }
     if (node.isNodeType("nt:file") || (node.isNodeType("nt:frozenNode")) && node.getProperty("jcr:frozenPrimaryType").getValue().getString().equals("nt:file")) {
       mimeType = node.getNode("jcr:content").getProperty("jcr:mimeType").getString();


### PR DESCRIPTION
…
**ISSUE**: When the user uses the download rest url he can knows if the file exists or not even if he has not enough permissions because of the returned 401 error code
**FIX**: This PR for a security purpose will return 404 http error code if the user has no the right permissions on the file to prevent him to detect the existence of the file