### PR TITLE
MAINT-36446: Display i18n drives labels in drives selector of the file attachment drawer

### DIFF
--- a/apps/portlet-documents/src/main/resources/locale/portlet/documents_en.properties
+++ b/apps/portlet-documents/src/main/resources/locale/portlet/documents_en.properties
@@ -44,6 +44,22 @@ Drives.label.DataProtection=Data Protection
 Drives.label.Guests=Guests
 Drives.label.Management=Management
 
+Folder.label.Music=Music
+Folder.label.Documents=Documents
+Folder.label.Videos=Videos
+Folder.label.Pictures=Pictures
+Folder.label.Favorites=Favorites
+Folder.label.Public=Public
+Folder.label.Private=Private
+Folder.label.Users=Users
+Folder.label.Groups=Groups
+Folder.label.DigitalAssets=Digital Assets
+Folder.label.ApplicationData=Application Data
+Folder.label.tags=Tags
+Folder.label.sites=Sites
+Folder.label.shared=Shared
+Folder.label.newfolder=New Folder
+
 documents.label.download=Download
 documents.label.downloadAll=Download all
 documents.label.new=New

--- a/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoAttachments.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoAttachments.vue
@@ -79,20 +79,26 @@
                   <div class="item"><span class="colorText"><hr class="rightLine"></span></div>
                 </div>
                 <div class="lastContent">
-                  <a
-                    title="Select on server"
-                    class="uploadButton"
-                    href="#"
-                    rel="tooltip"
-                    data-placement="bottom"
-                    @click="toggleServerFileSelector()">
-                    <i class="uiIcon32x32FolderDefault uiIcon32x32LightGray"></i>
-                    <v-icon
-                      color="#fff"
-                      x-small
-                      class="iconCloud">cloud</v-icon>
-                    <span class="text colorText">{{ $t('attachments.drawer.existingUploads') }}</span>
-                  </a>
+                  <v-tooltip bottom>
+                    <template v-slot:activator="{ on, attrs }">
+                      <a
+                        class="uploadButton"
+                        href="#"
+                        rel="tooltip"
+                        data-placement="bottom"
+                        v-bind="attrs"
+                        v-on="on"
+                        @click="toggleServerFileSelector()">
+                        <i class="uiIcon32x32FolderDefault uiIcon32x32LightGray"></i>
+                        <v-icon
+                          color="#fff"
+                          x-small
+                          class="iconCloud">cloud</v-icon>
+                        <span class="text colorText">{{ $t('attachments.drawer.existingUploads') }}</span>
+                      </a>
+                    </template>
+                    <span>{{ $t('attachments.drawer.existingUploads') }}</span>
+                  </v-tooltip>
                 </div>
               </div>
             </div>

--- a/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoFoldersFilesSelector.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoFoldersFilesSelector.vue
@@ -140,7 +140,7 @@
           </a>
           <div :class="folder.type === 'new_folder' ? 'boxOfTitle' :''">
             <a
-              :title="folder.title"
+              :title="getI18nTitle(folder.title, 'Folder')"
               href="javascript:void(0);"
               rel="tooltip"
               data-placement="bottom">
@@ -168,7 +168,7 @@
                 @blur="saveNewNameFolder()"
                 @keyup.enter="$event.target.blur()"
                 @keyup.esc="cancelRenameNewFolder($event)">
-              <div v-else class="selectionLabel center">{{ folder.title }}</div>
+              <div v-else class="selectionLabel center">{{ getI18nTitle(folder.title, 'Folder') }}</div>
             </a>
           </div>
         </div>
@@ -223,14 +223,14 @@
                 <div 
                   v-for="driver in group.drives" 
                   :key="driver.name" 
-                  :title="driver.title" 
+                  :title="getI18nTitle(driver.title, 'Drives')"
                   class="folderSelection"
                   @click="openDrive(driver, name)">
                   <a
                     :data-original-title="driver.title"
                     rel="tooltip"
                     data-placement="bottom">
-                    <i 
+                    <i
                       v-show="!drivesInProgress[driver.title]"
                       :class="driver.isCloudDrive ? driver.driveTypeCSSClass : `uiIconEcms24x24DriveGroup ${driver.driveTypeCSSClass}`"
                       class="uiIconEcmsLightGray selectionIcon center"></i>
@@ -249,7 +249,7 @@
                     </div>
                     <div 
                       :class="{ 'connectingDriveTitle': drivesInProgress[driver.title] >= 0 || drivesInProgress[driver.title] <= 100}"
-                      class="selectionLabel center">{{ driver.title }}</div>
+                      class="selectionLabel center">{{ getI18nTitle(driver.title, 'Drives') }}</div>
                   </a>
                 </div>
               </div>
@@ -501,6 +501,11 @@ export default {
     this.attachmentsComposerActions = getAttachmentsComposerExtensions();
   },
   methods: {
+    getI18nTitle(title, key) {
+      const label = `${key}.label.${title.replace(/\s+/g, '')}`;
+      const translation = this.$t(label);
+      return translation === label && title || translation;
+    },
     openFolder: function (folder) {
       if (this.selectedFolder.id && this.selectedFolder.canRemove){
         this.$refs.rename[0].focus();


### PR DESCRIPTION
…
ISSUE: The drives selector in the file attachment drawer was displaying the english default drives labels
FIX: Get the i18n drive label from the title and display it instead of the default one