### PR TITLE
MAINT-52375: Avoid sql/injection in document service

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImpl.java
@@ -784,6 +784,7 @@ public class DocumentServiceImpl implements DocumentService {
  public List<Document> getDocumentsByFolder(String folder, String condition, long limit) throws Exception {
    List<Document> documents = new ArrayList<Document>();
    if (folder != null) {
+     folder = escapeSQLString(folder);
      String query = "select * from nt:base where jcr:path like '" + folder + "/%' "
          + "and (exo:primaryType = 'nt:file' or jcr:primaryType = 'nt:file') "
          + "and (exo:fileType like '%pdf%' "
@@ -799,7 +800,54 @@ public class DocumentServiceImpl implements DocumentService {
    }
    return documents;
  }
-  
+
+  private static String escapeSQLString(String value){
+    int length = value.length();
+    int newLength = length;
+    // first check for characters that might
+    // be dangerous and calculate a length
+    // of the string that has escapes.
+    for (int i=0; i<length; i++){
+      char c = value.charAt(i);
+      switch(c){
+        case '\\':
+        case '\"':
+        case '\'':
+        case '\0':{
+          newLength += 1;
+        } break;
+        default:
+          break;
+      }
+    }
+    if (length == newLength){
+      // nothing to escape in the string
+      return value;
+    }
+    StringBuilder sb = new StringBuilder(newLength);
+    for (int i=0; i<length; i++){
+      char c = value.charAt(i);
+      switch(c){
+        case '\\':{
+          sb.append("\\\\");
+        } break;
+        case '\"':{
+          sb.append("\\\"");
+        } break;
+        case '\'':{
+          sb.append("\\\'");
+        } break;
+        case '\0':{
+          sb.append("\\0");
+        } break;
+        default: {
+          sb.append(c);
+        }
+      }
+    }
+    return sb.toString();
+  }
+
   /**
    * {@inheritDoc}
    */


### PR DESCRIPTION
ISSUE: When calling rest service /portal/rest/documents/folder?folder=value, The user can forge his own query to acces other documents.
even As jcr sql is readonly, and that the returned data is checked with ACLs, there is no risk for data modification or exposure;but it is better to clean the variable folder before using it.
FIX: This PR should escape the injected string to prevent any dangerous chars that can cheat the sql interpreter