### PR TITLE
Task-48942: the comment for the versions is added to the activity of the initial document (copied/pasted)

### DIFF
--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIDocumentAutoVersionForm.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIDocumentAutoVersionForm.java
@@ -154,7 +154,7 @@ public class UIDocumentAutoVersionForm extends UIForm implements UIPopupComponen
           }else {
             int fileIndex = 0;
             String copyTitle = null;
-            if (isFolder) {
+            if(isFolder){
             Node existNode = uiExplorer.getNodeByPath(destPath, srcSession);
             fileIndex = 1;
             String newDestPath = "";
@@ -542,17 +542,21 @@ public class UIDocumentAutoVersionForm extends UIForm implements UIPopupComponen
           destNode = destNodeIterator.nextNode();
         }
 
-        if(destNode.isNodeType(ActivityTypeUtils.EXO_ACTIVITY_INFO)) {
-          destNode.removeMixin(ActivityTypeUtils.EXO_ACTIVITY_INFO);
+        if(destNode!=null) {
+          if (destNode.isNodeType(ActivityTypeUtils.EXO_ACTIVITY_INFO)) {
+            destNode.removeMixin(ActivityTypeUtils.EXO_ACTIVITY_INFO);
+          }
+          if (destNode.isNodeType(NodetypeConstant.EOO_ONLYOFFICE_FILE)) {
+            destNode.removeMixin(NodetypeConstant.EOO_ONLYOFFICE_FILE);
+          }
+          destNode.save();
         }
-        if(destNode.isNodeType(NodetypeConstant.EOO_ONLYOFFICE_FILE)) {
-          destNode.removeMixin(NodetypeConstant.EOO_ONLYOFFICE_FILE);
-        }
-        destNode.save();
 
-        if(copyTitle != null)
+        if(copyTitle != null) {
           destNode.setProperty("exo:title", copyTitle);
+        }
         Utils.removeReferences(destNode);
+
       }catch (ConstraintViolationException ce) {
       uiApp.addMessage(new ApplicationMessage("UIPopupMenu.msg.current-node-not-allow-paste", null,
               ApplicationMessage.WARNING));

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIDocumentAutoVersionForm.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIDocumentAutoVersionForm.java
@@ -154,6 +154,7 @@ public class UIDocumentAutoVersionForm extends UIForm implements UIPopupComponen
           }else {
             int fileIndex = 0;
             String copyTitle = null;
+            if (isFolder) {
             Node existNode = uiExplorer.getNodeByPath(destPath, srcSession);
             fileIndex = 1;
             String newDestPath = "";
@@ -162,6 +163,9 @@ public class UIDocumentAutoVersionForm extends UIForm implements UIPopupComponen
               newDestPath = destPath.substring(0, lastDotIndex) + "-" + (fileIndex + 1 ) + destPath.substring(lastDotIndex);
               existNode = uiExplorer.getNodeByPath(newDestPath, srcSession);
               fileIndex ++;
+            }
+            destPath = newDestPath;
+            copyTitle = destPath.substring(destPath.lastIndexOf("/") + 1, lastDotIndex) + "(" + (fileIndex + 1 ) + ")" + destPath.substring(lastDotIndex);
             }
 
             copyNode(destSession, autoVersionComponent.getSourceWorkspace(),
@@ -529,7 +533,14 @@ public class UIDocumentAutoVersionForm extends UIForm implements UIPopupComponen
     if (workspace.getName().equals(srcWorkspaceName)) {
       try {
         workspace.copy(srcPath, destPath);
-        Node destNode = (Node) session.getItem(destPath);
+        Node parentDestNode = session.getItem(destPath).getParent();
+        String destName = session.getItem(destPath).getName();
+        NodeIterator destNodeIterator = parentDestNode.getNodes(destName);
+        Node destNode = null;
+
+        while (destNodeIterator.hasNext()) {
+          destNode = destNodeIterator.nextNode();
+        }
 
         if(destNode.isNodeType(ActivityTypeUtils.EXO_ACTIVITY_INFO)) {
           destNode.removeMixin(ActivityTypeUtils.EXO_ACTIVITY_INFO);

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIDocumentAutoVersionForm.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIDocumentAutoVersionForm.java
@@ -550,12 +550,12 @@ public class UIDocumentAutoVersionForm extends UIForm implements UIPopupComponen
             destNode.removeMixin(NodetypeConstant.EOO_ONLYOFFICE_FILE);
           }
           destNode.save();
-        }
 
-        if(copyTitle != null) {
-          destNode.setProperty("exo:title", copyTitle);
+          if (copyTitle != null) {
+            destNode.setProperty("exo:title", copyTitle);
+          }
+          Utils.removeReferences(destNode);
         }
-        Utils.removeReferences(destNode);
 
       }catch (ConstraintViolationException ce) {
       uiApp.addMessage(new ApplicationMessage("UIPopupMenu.msg.current-node-not-allow-paste", null,


### PR DESCRIPTION
Problem: The comment of the version of the documentY is added in the activity of the documentX
Fix: Version comment of documentY are added to the correct activity of documentY