### PR TITLE
MAINT-36446: Fix sections labels are not i18n in file attachment drawer

### DIFF
--- a/apps/portlet-documents/src/main/resources/locale/portlet/documents_en.properties
+++ b/apps/portlet-documents/src/main/resources/locale/portlet/documents_en.properties
@@ -60,6 +60,10 @@ Folder.label.sites=Sites
 Folder.label.shared=Shared
 Folder.label.newfolder=New Folder
 
+Category.label.MyDrives=My Drives
+Category.label.MySpaces=My Spaces
+Category.label.Others=Others
+
 documents.label.download=Download
 documents.label.downloadAll=Download all
 documents.label.new=New

--- a/apps/portlet-documents/src/main/resources/locale/portlet/documents_fr.properties
+++ b/apps/portlet-documents/src/main/resources/locale/portlet/documents_fr.properties
@@ -44,6 +44,10 @@ Drives.label.DataProtection=Protection des donn\u00E9es
 Drives.label.Guests=Invit\u00E9s
 Drives.label.Management=Gestion
 
+Category.label.MyDrives=Mes lecteurs
+Category.label.MySpaces=Mes espaces
+Category.label.Others=Autres
+
 documents.label.download=T\u00E9l\u00E9charger
 documents.label.downloadAll=Tout t\u00E9l\u00E9charger
 documents.label.new=Nouveau

--- a/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoFoldersFilesSelector.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoFoldersFilesSelector.vue
@@ -22,13 +22,13 @@
           @click="openDrive(currentDrive)">
           <span class="uiIconArrowRight"></span>
           <a
-            :title="currentDrive.title"
+            :title="getI18nTitle(currentDrive.title, 'Drives')"
             :class="currentDrive.isSelected? 'active' : ''"
             class="currentDriveTitle"
             data-toggle="tooltip"
             rel="tooltip"
             data-placement="bottom">
-            {{ currentDrive.title }}
+            {{ getI18nTitle(currentDrive.title, 'Drives') }}
           </a>
         </div>
         <div class="foldersHistory">
@@ -216,7 +216,7 @@
               class="category"
               active-class="categoryActive">
               <template v-slot:activator>
-                <v-list-item-content class="categoryContent">{{ name }}</v-list-item-content>
+                <v-list-item-content class="categoryContent">{{ getI18nTitle(name, 'Category') }}</v-list-item-content>
               </template>
               <!-- Drives block -->
               <div class="selectionBox">


### PR DESCRIPTION
**ISSUE**: In the attachment drawer the section labels are not well translated because of missed keys and unhanded translation for their names
**FIX**: Add new keys for the section and get the i18n values when display these labels