### PR TITLE
Task-52369: cannot upload a new version of a document when its name i…

### DIFF
--- a/apps/portlet-explorer/src/main/webapp/javascript/eXo/ecm/MultiUpload.js
+++ b/apps/portlet-explorer/src/main/webapp/javascript/eXo/ecm/MultiUpload.js
@@ -586,7 +586,7 @@
 		  var uri = eXo.ecm.MultiUpload.restContext + "/wcmDriver/uploadFile/checkExistence?" +
 		  "repositoryName=repository&workspaceName=" + eXo.ecm.MultiUpload.ws +
 		  "&driverName=" + eXo.ecm.MultiUpload.drive +
-		  "&currentFolder=" + eXo.ecm.MultiUpload.pathMap[id] +
+		  "&currentFolder=" + encodeURIComponent(eXo.ecm.MultiUpload.pathMap[id]) +
 		  "&currentPortal="+ eXo.ecm.MultiUpload.portalName +
 		  "&userId=" + eXo.ecm.MultiUpload.userId +
 		  "&fileName=" + cleanName(eXo.ecm.MultiUpload.uploadingFileIds[id].name) + 
@@ -817,7 +817,7 @@
 		  var uri = eXo.ecm.MultiUpload.restContext + "/wcmDriver/uploadFile/control?" +
 		  "repositoryName=repository&workspaceName=" + eXo.ecm.MultiUpload.ws +
 		  "&driverName=" + eXo.ecm.MultiUpload.drive +
-		  "&currentFolder=" + eXo.ecm.MultiUpload.pathMap[id] +
+		  "&currentFolder=" + encodeURIComponent(eXo.ecm.MultiUpload.pathMap[id]) +
 		  "&currentPortal="+ eXo.ecm.MultiUpload.portalName +
 		  "&userId=" + eXo.ecm.MultiUpload.userId +
 		  "&action=progress&uploadId=" + id;
@@ -905,7 +905,7 @@
 		    var uri = eXo.ecm.MultiUpload.restContext + "/wcmDriver/uploadFile/control?" +
 		    "repositoryName=repository&workspaceName=" + eXo.ecm.MultiUpload.ws +
 		    "&driverName=" + eXo.ecm.MultiUpload.drive +
-		    "&currentFolder=" + eXo.ecm.MultiUpload.pathMap[progressID] +
+		    "&currentFolder=" + encodeURIComponent(eXo.ecm.MultiUpload.pathMap[progressID]) +
 		    "&currentPortal="+ eXo.ecm.MultiUpload.portalName +
 		    "&userId=" + eXo.ecm.MultiUpload.userId +
 		    "&uploadId=" + progressID +

--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/fckeditor/DriverConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/fckeditor/DriverConnector.java
@@ -17,6 +17,7 @@
 package org.exoplatform.wcm.connector.fckeditor;
 
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -384,6 +385,7 @@ public class DriverConnector extends BaseConnector implements ResourceContainer 
       @QueryParam("language") String language,
       @QueryParam("fileName") String fileName) throws Exception {
     try {
+      currentFolder = URLDecoder.decode(currentFolder, StandardCharsets.UTF_8);
       // Check file existence
       Node currentFolderNode = getParentFolderNode(workspaceName,
                                                    Text.escapeIllegalJcrChars(driverName),
@@ -463,12 +465,12 @@ public class DriverConnector extends BaseConnector implements ResourceContainer 
         workspaceName = workspaceName != null ? workspaceName :
                                                 manageDriveService.getDriveByName(Text.escapeIllegalJcrChars(driverName))
                                                                   .getWorkspace();
-
+        currentFolder = URLDecoder.decode(currentFolder, StandardCharsets.UTF_8);
         Node currentFolderNode = getParentFolderNode(workspaceName,
                                                      Text.escapeIllegalJcrChars(driverName),
                                                      Text.escapeIllegalJcrChars(currentFolder));
         fileName = Text.escapeIllegalJcrChars(fileName);
-        fileName = URLDecoder.decode(fileName, "UTF-8");
+        fileName = URLDecoder.decode(fileName, StandardCharsets.UTF_8);
         return createProcessUploadResponse(workspaceName,
                                            currentFolderNode,
                                            currentPortal,


### PR DESCRIPTION
…ncludes the character "+". (#1588)

Problem: Before this fix, it was impossible to upload a new version of the document in file explorer if the filename contains a +. when checking the existence of the file, the field currentFolder contains the filename, and the + is read as a space.

Fix: This change use function encodeURIComponent for variable current folder, so that, the + is transformed to %2B and then in the rest service, we decode it with URLDecoder.decode, and we replace the parameter string "UTF-8" by StandardCharsets.UTF_8 to avoid errors in code smells, so that we are able to see the +.