### PR TITLE
48942: the comment for the versions is added to the activity of the initial document

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/wcm/core/NodetypeConstant.java
+++ b/core/services/src/main/java/org/exoplatform/services/wcm/core/NodetypeConstant.java
@@ -266,6 +266,8 @@ public class NodetypeConstant {
   public static final String SORT_BY_VERSIONABLE = "Versionable";
   public static final String SORT_BY_AUDITING = "Auditing";
   public static final String SHOW_OWNED_BY_USER_DOC = "OwnedByMe";
+
+  public static final String EOO_ONLYOFFICE_FILE = "eoo:onlyofficeFile";
   
 
 }

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/PasteManageComponent.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/PasteManageComponent.java
@@ -44,6 +44,7 @@ import org.exoplatform.services.cms.link.LinkUtils;
 import org.exoplatform.services.cms.relations.RelationsService;
 import org.exoplatform.services.cms.thumbnail.ThumbnailService;
 import org.exoplatform.services.jcr.access.PermissionType;
+import org.exoplatform.services.jcr.ext.ActivityTypeUtils;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
@@ -563,6 +564,14 @@ public class PasteManageComponent extends UIAbstractManagerComponent {
         pasteByCopy(destSession, srcWorkspace, srcPath, destPath);
         destNode = (Node) destSession.getItem(destPath);
         actionContainer.initiateObservation(destNode);
+
+        if(destNode.isNodeType(ActivityTypeUtils.EXO_ACTIVITY_INFO)) {
+          destNode.removeMixin(ActivityTypeUtils.EXO_ACTIVITY_INFO);
+        }
+        if(destNode.isNodeType(NodetypeConstant.EOO_ONLYOFFICE_FILE)) {
+          destNode.removeMixin(NodetypeConstant.EOO_ONLYOFFICE_FILE);
+        }
+
         // Set title
         if (title != null) {
           destNode.setProperty(Utils.EXO_TITLE, title);


### PR DESCRIPTION
Problem: The comment of the version of the documentY is added in the activity of the documentX
Fix: Version comment of documentY are added to the correct activity of documentY