### PR TITLE
Task-48707: 404 error on documents application page console.

### DIFF
--- a/apps/portlet-clouddrives/src/main/webapp/js/clouddrives.js
+++ b/apps/portlet-clouddrives/src/main/webapp/js/clouddrives.js
@@ -579,22 +579,24 @@
                 var path = contextNode.path;
                 var process = getDrive(workspace, path);
                 process.done(function(drive, status) {
-                    var provider = providers[drive.provider.id];
-                    if (provider) {
-                        provider.clientModule.done(function(client) {
-                            if (client) {
-                                // init context drive within the provider client
-                                if (client.initDrive && client.hasOwnProperty("initDrive")) {
-                                    client.initDrive(drive);
-                                }
-                                // init files by the client if applicable
-                                if (client.initFile && client.hasOwnProperty("initFile")) {
-                                    for (fpath in drive.files) {
-                                        client.initFile(drive.files[fpath]);
+                    if(drive) {
+                        var provider = providers[drive.provider.id];
+                        if (provider) {
+                            provider.clientModule.done(function(client) {
+                                if (client) {
+                                    // init context drive within the provider client
+                                    if (client.initDrive && client.hasOwnProperty("initDrive")) {
+                                        client.initDrive(drive);
+                                    }
+                                    // init files by the client if applicable
+                                    if (client.initFile && client.hasOwnProperty("initFile")) {
+                                        for (fpath in drive.files) {
+                                            client.initFile(drive.files[fpath]);
+                                        }
                                     }
                                 }
-                            }
-                        });
+                            });
+                        }
                     }
                     // use already cached files with new drive
                     if (contextDrive && contextDrive.path == drive.path) {

--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/clouddrives/DriveService.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/clouddrives/DriveService.java
@@ -275,7 +275,7 @@ public class DriveService implements ResourceContainer {
         if (LOG.isDebugEnabled()) {
           LOG.debug("Item " + workspace + ":" + path + " not a cloud file or drive not connected.");
         }
-        return Response.status(Status.NOT_FOUND).entity(ErrorEntiry.notCloudDrive("Not connected", workspace, path)).build();
+        return Response.status(Status.NO_CONTENT).entity(ErrorEntiry.notCloudDrive("Not connected", workspace, path)).build();    
       }
     } catch (LoginException e) {
       LOG.warn("Error login to read drive " + workspace + ":" + path + ". " + e.getMessage());


### PR DESCRIPTION
Problem: Before this fix, many errors, 404 related to cloud drive stay appeared in the console when the user open doc apps in his space, and those errors indicate that cannot find some paths if  user is not connected to one of provider's cloud drive.
Fix: the fix represented in change the response of DriveService.java from status not found (404) to no content (204) because the error is originally coming from the browser and not the app (browser behavior). On the other side in front, we add a  check on the existence of the object drive which contains all information about user connection to the drive.