### PR TITLE
MAINT-43884: Fix new_folder i18n value in file attachment drawer

### DIFF
--- a/apps/portlet-documents/src/main/resources/locale/portlet/documents_fr.properties
+++ b/apps/portlet-documents/src/main/resources/locale/portlet/documents_fr.properties
@@ -60,8 +60,8 @@ Folder.label.sites=Sites
 Folder.label.shared=Shared
 Folder.label.newfolder=Nouveau Dossier
 
-Category.label.MyDrives=My Drive
-Category.label.MySpaces=Mes Espaces
+Category.label.MyDrives=Mes lecteurs
+Category.label.MySpaces=Mes espaces
 Category.label.Others=Autres
 
 documents.label.download=T\u00E9l\u00E9charger

--- a/apps/portlet-documents/src/main/resources/locale/portlet/documents_fr.properties
+++ b/apps/portlet-documents/src/main/resources/locale/portlet/documents_fr.properties
@@ -58,7 +58,7 @@ Folder.label.ApplicationData=Application Data
 Folder.label.tags=Tags
 Folder.label.sites=Sites
 Folder.label.shared=Shared
-Folder.label.newfolder=Nouveau Dossier
+Folder.label.newfolder=Nouveau dossier
 
 Category.label.MyDrives=Mes lecteurs
 Category.label.MySpaces=Mes espaces

--- a/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoFoldersFilesSelector.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoFoldersFilesSelector.vue
@@ -502,7 +502,7 @@ export default {
   },
   methods: {
     getI18nTitle(title, key) {
-      const label = `${key}.label.${title.replace(/\s+/g, '')}`;
+      const label = `${key}.label.${title.replace(/\s+|_/g, '')}`;
       const translation = this.$t(label);
       return translation === label && title || translation;
     },


### PR DESCRIPTION
**ISSUE**: The `getI18nTitle` function wasn't take in consideration the title with underscore when building the key label in order to offer a translation for the title.
**FIX**: Update the used regex of label key building to support titles with underscore to allow translate the new_folder label