### PR TITLE
TASK-52372: XSS in create document form. (#1601)

### DIFF
--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/documents/UINewDocumentForm.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/documents/UINewDocumentForm.java
@@ -32,6 +32,7 @@ import org.apache.commons.lang.StringUtils;
 
 import org.exoplatform.ecm.utils.text.Text;
 import org.exoplatform.ecm.webui.component.explorer.UIJCRExplorer;
+import org.exoplatform.ecm.webui.form.validator.XSSValidator;
 import org.exoplatform.ecm.webui.utils.JCRExceptionManager;
 import org.exoplatform.services.cms.documents.DocumentEditorProvider;
 import org.exoplatform.services.cms.documents.DocumentService;
@@ -83,10 +84,11 @@ public class UINewDocumentForm extends UIForm implements UIPopupComponent {
    * Constructor.
    *
    */
-  public UINewDocumentForm() {
+  public UINewDocumentForm() throws Exception{
     this.documentService = this.getApplicationComponent(DocumentService.class);
     // Title textbox
     UIFormStringInput titleTextBox = new UIFormStringInput(FIELD_TITLE_TEXT_BOX, FIELD_TITLE_TEXT_BOX, null);
+    titleTextBox.addValidator(XSSValidator.class);
     this.addUIFormInput(titleTextBox);
 
     List<NewDocumentTemplateProvider> templateProviders = documentService.getNewDocumentTemplateProviders();

--- a/core/webui/src/main/java/org/exoplatform/ecm/webui/form/validator/XSSValidator.java
+++ b/core/webui/src/main/java/org/exoplatform/ecm/webui/form/validator/XSSValidator.java
@@ -24,6 +24,9 @@ import org.exoplatform.webui.exception.MessageException;
 import org.exoplatform.webui.form.UIFormInput;
 import org.exoplatform.webui.form.validator.Validator;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
 /**
  * Created by The eXo Platform SAS Author : Tran Hung Phong
  * phongth@exoplatform.com Jul 24, 2012
@@ -36,7 +39,7 @@ public class XSSValidator implements Validator {
     if (inputValue == null || inputValue.trim().length() == 0) {
       return;
     }
-
+    inputValue = URLDecoder.decode(inputValue, StandardCharsets.UTF_8);
     inputValue = HTMLSanitizer.sanitize(inputValue);
     if (StringUtils.isEmpty(inputValue)) {
       String message = "UIActionForm.msg.xss-vulnerability-character";


### PR DESCRIPTION
ISSUES : XSS in create document form: Type a script in the document name when creating a new document, the script is executed and the alert popup displayed.
FIX : the problem fixed by adding a validator to the input text.