### PR TITLE
Task-53091: Received Email notification doesn't redirect to the shared document when clicking on "Open".

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImpl.java
@@ -220,9 +220,10 @@ public class DocumentServiceImpl implements DocumentService {
   public String getDocumentUrlInPersonalDocuments(Node currentNode, String username) throws Exception {
     Node rootNode = null;
     SessionProvider sessionProvider = sessionProviderService.getSystemSessionProvider(null);
+    Session session = null;
     try {
       ManageableRepository repository = repoService.getCurrentRepository();
-      Session session = sessionProvider.getSession(repository.getConfiguration().getDefaultWorkspaceName(), repository);
+      session = sessionProvider.getSession(repository.getConfiguration().getDefaultWorkspaceName(), repository);
       //add symlink to user folder destination
       nodeHierarchyCreator.getJcrPath(BasePath.CMS_USERS_PATH);
       rootNode = (Node) session.getItem(nodeHierarchyCreator.getJcrPath(BasePath.CMS_USERS_PATH) + getPrivatePath(username));
@@ -232,8 +233,11 @@ public class DocumentServiceImpl implements DocumentService {
       LOG.error(e.getMessage(), e);
       return "";
     } finally {
-      sessionProvider.close();
-    }
+        if(session != null)
+        {
+          session.logout();
+        }
+      }
   }
 
   /**


### PR DESCRIPTION
Problem: Before this fix, it was impossible to share documents in space with multiple users even they receive an email notification just the first tagged user who has permission and can get a shared document when he clicks on open button in the email but the others cannot redirect to any page.
So the problem was in session jcr which was closed after notifying the first user then this session was destructed by the function close() and that is why we cannot add permissions to the other users besides we cannot send the shared link to this document by email.

Fix: Instead of using close function of the object session and destruct it, we just use the function logout () session to let this dependency be used again by other services like DocumentService etc ...