### PR TITLE
MAINT-52789: Reindex nodes on jcr node_moved ExtendedEvent to allow searching moved files in different paths after clone or upload inside documents app

### DIFF
--- a/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-search-configuration.xml
+++ b/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-search-configuration.xml
@@ -129,7 +129,7 @@
                                 <value>
                                     <object type="org.exoplatform.services.jcr.impl.ext.action.ActionConfiguration">
                                         <field  name="workspace"><string>collaboration</string></field>
-                                        <field  name="eventTypes"><string>addNode,removeNode,addProperty,changeProperty,removeProperty,changePermission</string></field>
+                                        <field  name="eventTypes"><string>moveNode,addNode,removeNode,addProperty,changeProperty,removeProperty,changePermission</string></field>
                                         <field  name="path"><string>/</string></field>
                                         <field  name="isDeep"><boolean>true</boolean></field>
                                         <field  name="actionClassName"><string>org.exoplatform.services.wcm.search.connector.FileIndexerAction</string></field>

--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/connector/FileIndexerAction.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/connector/FileIndexerAction.java
@@ -85,6 +85,12 @@ public class FileIndexerAction implements AdvancedAction {
           applyIndexingOperationOnNodes(node, n -> indexingService.reindex(FileindexingConnector.TYPE, n.getInternalIdentifier()), n -> hasNotPrivilegeableMixin(n));
         }
         break;
+      case ExtendedEvent.NODE_MOVED:
+        node = (NodeImpl) context.get(InvocationContext.CURRENT_ITEM);
+        if (node != null && !trashService.isInTrash(node)) {
+          applyIndexingOperationOnNodes(node, n -> indexingService.reindex(FileindexingConnector.TYPE, n.getInternalIdentifier()), n -> true);
+        }
+        break;
     }
 
     return true;

--- a/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/dms-extension/dms/dms-actions-configuration.xml
+++ b/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/dms-extension/dms/dms-actions-configuration.xml
@@ -67,8 +67,23 @@
                     		</collection>
                    		</field>
                     </object>  
-                  </value>                                  
+                  </value>
 
+                  <value>
+                    <object type="org.exoplatform.services.cms.actions.impl.ActionConfig$Action">
+                      <field  name="type"><string>exo:move</string></field>
+                      <field  name="name"><string>moveNode</string></field>
+                      <field  name="description"><string>cut and past a node in a new destination</string></field>
+                      <field  name="srcWorkspace"><string>collaboration</string></field>
+                      <field  name="srcPath"><string>/</string></field>
+                      <field  name="isDeep"><boolean>true</boolean></field>
+                      <field  name="lifecyclePhase">
+                        <collection type="java.util.ArrayList">
+                          <value><string>node_moved</string></value>
+                        </collection>
+                      </field>
+                    </object>
+                  </value>
                 </collection>   
               </field>  
             </object>


### PR DESCRIPTION
…
ISSUE: When clone files from Google drive using gdriveimporter addon or upload inside docs app and move files into different folders and sub-folders the indexing engine doesn't reindex the files again which caused a wrong search result and
the disappearance of these files from the search result.
FIX: Add a new `ActionConfig` for the `exo:move` and the node_moved event and add the eventtype in `FileIndexerAction` to listen the event that dispatched from the `SessionActionInterceptor`