### PR TITLE
MAINT-43884: Fix new_folder i18n value in file attachment drawer

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
@@ -827,7 +827,7 @@ export default {
     addNewFolder() {
       if (!this.creatingNewFolder) {
         this.creatingNewFolder = true;
-        this.newFolderName = 'new_folder';
+        this.newFolderName = this.$t('Folder.label.newfolder');
         this.folders.unshift({
           id: 'new_folder',
           type: 'new_folder',

--- a/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoFoldersFilesSelector.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoFoldersFilesSelector.vue
@@ -502,7 +502,7 @@ export default {
   },
   methods: {
     getI18nTitle(title, key) {
-      const label = `${key}.label.${title.replace(/\s+/g, '')}`;
+      const label = `${key}.label.${title.replace(/\s+|_/g, '')}`;
       const translation = this.$t(label);
       return translation === label && title || translation;
     },
@@ -722,7 +722,7 @@ export default {
     addNewFolder() {
       if (!this.creatingNewFolder) {
         this.creatingNewFolder = true;
-        this.newFolderName = 'new_folder';
+        this.newFolderName = this.$t('Folder.label.newfolder');
         this.folders.unshift({
           id: 'new_folder',
           type: 'new_folder',


### PR DESCRIPTION
* MAINT-43884: Fix new_folder i18n value in file attachment drawer
ISSUE: The getI18nTitle wasn't take in consideration the title with underscore when building the key label in order to offer a translation for the title.
FIX: Update the used regex of label key building to support titles with underscore to allow translate the new_folder label

* MAINT-43884: Add an i18n translated title when adding a new folder
ISSUE: when adding a new folder an input field is appeared shows taking a default new_folder value as a name which is not a good us even if the label will be translaed after saving the folder
FIX: Add a translated title for the new_folder since the pre_saving of the new folder