### PR TITLE
Task-49268: text area components are no longer extensible

### DIFF
--- a/apps/resources-wcm/src/main/webapp/skin/less/ecms/portlets/administration/ecms-administration.less
+++ b/apps/resources-wcm/src/main/webapp/skin/less/ecms/portlets/administration/ecms-administration.less
@@ -43,7 +43,9 @@
 				.controls{
 					.textarea{
 						height: 150px;
+						width: 90%;
 						vertical-align: top;
+						max-height: unset;
 					}
 				}
 				.controls-full{

--- a/apps/resources-wcm/src/main/webapp/skin/less/ecms/portlets/explorer/ecms-explorer.less
+++ b/apps/resources-wcm/src/main/webapp/skin/less/ecms/portlets/explorer/ecms-explorer.less
@@ -716,6 +716,7 @@
 				height: 175px;
 				width: 90%;
 				vertical-align: top;
+				max-height: unset;
 			}
 
 			> div > span {


### PR DESCRIPTION
**Problem:** in CMS setting and backoffice, text areas in web contents and list templates aren't extensible in term of hight
**Fix:** I set the two proprieties of Textarea which are width to 95% and max-height to unset in web contents and list templates to be extensible in term of hight