### PR TITLE
Task-53377:  Warning message is displayed when creating more than one doc in attachment drawer

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachment-document-creator/AttachmentCreateDocumentInput.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachment-document-creator/AttachmentCreateDocumentInput.vue
@@ -89,7 +89,7 @@ export default {
       newDocumentActionExtension: 'new-document-action',
       newDocumentActions: {},
       MAX_DOCUMENT_TITLE_LENGTH: 510,
-      documentTitleRules: [title => title && title.trim().length <= this.MAX_DOCUMENT_TITLE_LENGTH - this.selectedDocType.extension.length || this.newDocTitleMaxLengthLabel],
+      documentTitleRules: [title => !title || title && title.trim().length <= this.MAX_DOCUMENT_TITLE_LENGTH - this.selectedDocType.extension.length || this.newDocTitleMaxLengthLabel],
     };
   },
   computed: {


### PR DESCRIPTION
Prior this change, when creating a doc form the attachment drawer and then try to create another doc , a warning message related to the max length displayed.
Fix : Update warning condition