### PR TITLE
Task 54048: Share document from a user having a read only permission.

### DIFF
--- a/ecms-social-integration/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/ShareDocumentsComponent.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/ShareDocumentsComponent.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.exoplatform.ecm.webui.component.explorer.UIJCRExplorer;
+import org.exoplatform.ecm.webui.component.explorer.control.filter.CanSetPropertyFilter;
 import org.exoplatform.ecm.webui.component.explorer.control.filter.IsDocumentFilter;
 import org.exoplatform.ecm.webui.component.explorer.control.filter.ShareDocumentFilter;
 import org.exoplatform.ecm.webui.component.explorer.control.listener.UIWorkingAreaActionListener;
@@ -72,7 +73,7 @@ public class ShareDocumentsComponent extends UIAbstractManagerComponent{
   }
 
   private static final List<UIExtensionFilter> FILTERS = Arrays.asList(new UIExtensionFilter[] {
-          new IsDocumentFilter(), new ShareDocumentFilter()
+          new IsDocumentFilter(), new ShareDocumentFilter(), new CanSetPropertyFilter()
   });
 
   @UIExtensionFilters


### PR DESCRIPTION
Problem: before this fix, When the members of space have the permission read-only in a document, the icon of a share document was always showing. So we need to add this icon just when the members have edit permission.
    
Fix: in this fix, we add the filter CanSetPropertyFilter to ShareDocumentsComponent for be added to toolbarAction  just when the user or group has edit permission.