### PR TITLE
TASK-54440: Add the is-composer-attachment prop in the attachmentDrawerConfig and allow dispatch attachments data on entity-attachments-updated

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment-integration/components/AttachmentApp.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment-integration/components/AttachmentApp.vue
@@ -86,6 +86,14 @@ export default {
       type: String,
       default: ''
     },
+    attachmentsList: {
+      type: Array,
+      default: () => []
+    },
+    isComposerAttachment: {
+      type: Boolean,
+      default: false
+    }
   },
   data() {
     return {
@@ -99,7 +107,9 @@ export default {
         'entityType': this.entityType,
         'defaultDrive': this.defaultDrive,
         'defaultFolder': this.defaultFolder,
-        'spaceId': this.spaceId
+        'spaceId': this.spaceId,
+        'attachments': this.attachmentsList,
+        'isComposerAttachment': this.isComposerAttachment,
       };
     }
   },

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/Attachment.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/Attachment.vue
@@ -25,10 +25,6 @@
 <script>
 export default {
   props: {
-    isComposerAttachment: {
-      type: Boolean,
-      default: false
-    },
     attachmentAppConfiguration: {
       type: Object,
       default: () => null
@@ -61,6 +57,9 @@ export default {
     },
     entityHasAttachments() {
       return this.attachments && this.attachments.length;
+    },
+    isComposerAttachment() {
+      return this.attachmentAppConfiguration && this.attachmentAppConfiguration.isComposerAttachment;
     }
   },
   created() {
@@ -136,7 +135,7 @@ export default {
           this.$root.$emit('set-source-app', this.attachmentAppConfiguration.sourceApp);
         }
       }
-      this.attachments = [];
+      this.attachments = this.attachmentAppConfiguration.attachments || [];
       this.openAttachmentsAppDrawer();
       this.initAttachmentEnvironment();
     });

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
@@ -200,7 +200,7 @@ export default {
     uploadFinished() {
       if (this.uploadFinished && this.uploadingCount === 0 && this.entityHasNewAttachments) {
         this.$root.$emit('entity-attachments-updated', this.attachments);
-        document.dispatchEvent(new CustomEvent('entity-attachments-updated'));
+        document.dispatchEvent(new CustomEvent('entity-attachments-updated', {detail: {'attachments': this.attachments}}));
         this.displaySuccessMessage();
         this.$refs.attachmentsAppDrawer.endLoading();
       }


### PR DESCRIPTION
…
Add the is-composer-attachment prop in the attachmentDrawerConfig and allow dispatch attachments data on entity-attachments-update to make it possible to get the attached files with event listener.
Also adding an attachmentList props to persist the display and the actions on the already attached files when re-open the attachment drawer.