### PR TITLE
TASK-53835 Fix Analytics Profile for JCR Action configuration

### DIFF
--- a/ecms-social-integration/src/main/resources/conf/portal/configuration.xml
+++ b/ecms-social-integration/src/main/resources/conf/portal/configuration.xml
@@ -27,7 +27,7 @@
     </component-plugin>
   </external-component-plugins>
 
-  <external-component-plugins profiles="ecms">
+  <external-component-plugins profiles="analytics">
     <target-component>org.exoplatform.services.jcr.impl.ext.action.SessionActionCatalog</target-component>       
     <component-plugin>
       <name>addActions</name>


### PR DESCRIPTION
Prior to this this change, the Analytics Listener configuration is added even when analytics addon isn't installed. This modification ensures that this listener isn't added in such case, by introducing profiles=analytics value in configuration file.