### PR TITLE
Task-51341: many emails received after editing a watched document.

### DIFF
--- a/core/webui-clouddrives/src/main/java/org/exoplatform/services/cms/clouddrives/webui/watch/WatchCloudDocumentServiceImpl.java
+++ b/core/webui-clouddrives/src/main/java/org/exoplatform/services/cms/clouddrives/webui/watch/WatchCloudDocumentServiceImpl.java
@@ -33,6 +33,7 @@ import javax.jcr.query.Query;
 import javax.jcr.query.QueryManager;
 import javax.jcr.query.QueryResult;
 
+import org.exoplatform.services.wcm.core.NodetypeConstant;
 import org.picocontainer.Startable;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.cms.clouddrives.jcr.JCRLocalCloudDrive;
@@ -132,12 +133,13 @@ public class WatchCloudDocumentServiceImpl implements WatchDocumentService, Star
   public void watchDocument(Node documentNode, String userName, int notifyType) throws Exception {
     Value newWatcher = documentNode.getSession().getValueFactory().createValue(userName);
     EmailNotifyCloudDocumentListener listener = null;
+    Node specificNode = documentNode.isNodeType(NodetypeConstant.NT_FILE) ? documentNode.getNode("jcr:content") : documentNode;
     if (!documentNode.isNodeType(EXO_WATCHABLE_MIXIN)) {
       documentNode.addMixin(EXO_WATCHABLE_MIXIN);
       if (notifyType == NOTIFICATION_BY_EMAIL) {
         documentNode.setProperty(EMAIL_WATCHERS_PROP, new Value[] { newWatcher });
         listener = new EmailNotifyCloudDocumentListener(documentNode);
-        observeNode(documentNode, listener);
+        observeNode(specificNode, listener);
       }
     } else {
       List<Value> watcherList = new ArrayList<Value>();


### PR DESCRIPTION
Problem: Before this fix, when editing a watched file from users. The watcher was receiving many emails indicating that there is changes on the file.SO this problem occurred because the process of observation was on the node and not the child node which is the jcr:content, therefore, any action that happens in the file, can change many properties even if we open and close the file without changing it. So many events fired and On every event, there's an email.

Fix: In this fix, we changed the process of the observation on the content of the file and we let the list of watchers in property EMAIL_WATCHERS_PROP of the watched file. So any changes in the content of the watched file will fire an event that is received by the EmailNotifyCloudDocumentListener and finally this last will send one email to each watcher if exist.