### PR TITLE
Task-54616: Can't click on icon "cloud" to connect a cloud drive

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
@@ -51,6 +51,7 @@
           :entity-id="entityId"
           :entity-type="entityType"
           :default-drive="defaultDrive"
+          :extension-refs="$refs"
           :default-folder="defaultFolder"
           :attached-files="attachments" />
         <div

--- a/apps/resources-wcm/src/main/webapp/skin/less/ecms/portlets/attachments/attachmentsApp.less
+++ b/apps/resources-wcm/src/main/webapp/skin/less/ecms/portlets/attachments/attachmentsApp.less
@@ -154,6 +154,7 @@
             border: 1px solid #b3b3b3;
             border-radius: 15%;
             color: #4d5466;
+            cursor: pointer;
 
             &:before {
               content: '+';


### PR DESCRIPTION
Prior this change, and after updating the activity composer drawer with the new attachments drawer, the "cloud" icon is no longer clickable due to missing references in the component