### PR TITLE
Task-54742: Avoid display files attachments when the activity type is not simple, file or link activity

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityComposerAttachments.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityComposerAttachments.vue
@@ -35,6 +35,10 @@ export default {
       type: Array,
       default: null,
     },
+    activityType: {
+      type: Array,
+      default: null,
+    },
   },
   data: () => ({
     attachments: null,
@@ -46,7 +50,7 @@ export default {
       return this.files.length;
     },
     displayAttachments() {
-      return this.attachmentsLength > 0;
+      return this.attachmentsLength > 0 && this.activityType && this.activityType.length === 0;
     },
     attachmentDrawerParams() {
       return {


### PR DESCRIPTION
Before this change, for any type of posted activity, when files attachments are uploaded, they will be displayed in the created activity body.
After this change, we will avoid displaying the files attachments when the activity type is not simple, file or link activity.