### PR TITLE
Task-55243: Keep attached files when the activity type is not simple, file or link activity

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityComposerAttachments.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityComposerAttachments.vue
@@ -35,10 +35,6 @@ export default {
       type: Array,
       default: null,
     },
-    activityType: {
-      type: Array,
-      default: null,
-    },
   },
   data: () => ({
     attachments: null,
@@ -50,7 +46,7 @@ export default {
       return this.files.length;
     },
     displayAttachments() {
-      return this.attachmentsLength > 0 && this.activityType && this.activityType.length === 0;
+      return this.attachmentsLength > 0;
     },
     attachmentDrawerParams() {
       return {


### PR DESCRIPTION
Prior to this change, attached files are not kept the activity type is not simple, file or link activity. This PR will revert commit 51264950a5f2f373cb0f85ec5a02a18f9493796c in order to keep attached files in that case.