### PR TITLE
Task-54703: Document: link in the email notification is not functional

### DIFF
--- a/core/webui-clouddrives/src/main/java/org/exoplatform/services/cms/clouddrives/webui/watch/WatchCloudDocumentServiceImpl.java
+++ b/core/webui-clouddrives/src/main/java/org/exoplatform/services/cms/clouddrives/webui/watch/WatchCloudDocumentServiceImpl.java
@@ -160,7 +160,7 @@ public class WatchCloudDocumentServiceImpl implements WatchDocumentService, Star
         && !documentNode.hasProperty(CLOUDDRIVE_WATCH_LINK)) {
       // init Cloud Drive document with document URI in portal and store this
       // URI
-      documentNode.setProperty(CLOUDDRIVE_WATCH_LINK, listener.getViewableLink());
+      documentNode.setProperty(CLOUDDRIVE_WATCH_LINK, listener.getViewableLink(documentNode));
     }
 
     documentNode.save();


### PR DESCRIPTION
Prior to this change, when post a document in group space , then select the document and click in Watch then check Notify by email ,then click to document and modify it.
This is due to the fact that mail is send but the link sometimes the link is empty and sometimes it not redirected at the true destination.
After this change, we ensure that email send a link to notify users that document is changed and that link to redirect in the destination document.