### PR TITLE
TASK-55628 Fix Copying enrolled node in publication lifecycle

### DIFF
--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/DeleteManageComponent.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/DeleteManageComponent.java
@@ -32,12 +32,17 @@ import javax.jcr.NodeIterator;
 import javax.jcr.PathNotFoundException;
 import javax.jcr.PropertyIterator;
 import javax.jcr.ReferentialIntegrityException;
+import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.jcr.ValueFormatException;
 import javax.jcr.lock.LockException;
 import javax.jcr.nodetype.ConstraintViolationException;
+import javax.jcr.query.InvalidQueryException;
+import javax.jcr.query.Query;
 import javax.jcr.version.VersionException;
 import javax.portlet.PortletPreferences;
 
+import org.apache.commons.codec.binary.StringUtils;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.Validate;
 import org.exoplatform.ecm.webui.component.explorer.UIConfirmMessage;
@@ -50,6 +55,7 @@ import org.exoplatform.container.PortalContainer;
 import org.exoplatform.ecm.utils.lock.LockUtil;
 import org.exoplatform.ecm.webui.utils.PermissionUtil;
 import org.exoplatform.ecm.webui.utils.Utils;
+import org.exoplatform.portal.webui.util.Util;
 import org.exoplatform.services.cms.actions.ActionServiceContainer;
 import org.exoplatform.services.cms.documents.TrashService;
 import org.exoplatform.services.cms.folksonomy.NewFolksonomyService;
@@ -60,6 +66,8 @@ import org.exoplatform.services.cms.relations.RelationsService;
 import org.exoplatform.services.cms.taxonomy.TaxonomyService;
 import org.exoplatform.services.cms.templates.TemplateService;
 import org.exoplatform.services.cms.thumbnail.ThumbnailService;
+import org.exoplatform.services.ecm.publication.NotInPublicationLifecycleException;
+import org.exoplatform.services.ecm.publication.PublicationService;
 import org.exoplatform.services.jcr.core.ManageableRepository;
 import org.exoplatform.services.jcr.ext.audit.AuditService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
@@ -67,6 +75,10 @@ import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.wcm.core.NodetypeConstant;
+import org.exoplatform.services.wcm.extensions.publication.lifecycle.authoring.AuthoringPublicationConstant;
+import org.exoplatform.services.wcm.extensions.publication.lifecycle.authoring.AuthoringPublicationPlugin;
+import org.exoplatform.services.wcm.publication.PublicationDefaultStates;
+import org.exoplatform.services.wcm.publication.WCMPublicationService;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.web.application.ApplicationMessage;
 import org.exoplatform.web.application.RequestContext;
@@ -392,6 +404,11 @@ public class DeleteManageComponent extends UIAbstractManagerComponent {
       if (PermissionUtil.canRemoveNode(node) && node.isNodeType(Utils.EXO_AUDITABLE)) {
         removeAuditForNode(node);
       }
+
+      // Workaround TASK-55628 : Remove referenced live revisions
+      updateReferencedLiveRevisionFromCopies(node, session);
+      // End Workaround TASK-55628
+
       //Remove symlinks
       LinkManager linkManager = WCMCoreUtils.getService(LinkManager.class);
       if(!node.isNodeType(NodetypeConstant.EXO_SYMLINK)) {
@@ -446,6 +463,57 @@ public class DeleteManageComponent extends UIAbstractManagerComponent {
         uiExplorer.setSelectNode(LinkUtils.getParentPath(virtualNodePath));
       else
         uiExplorer.setSelectNode(currentNode.getPath());
+    }
+  }
+
+  /**
+   * Workaround TASK-55628 : This method will search for nodes which references
+   * the same 'liveRevision' than the current node to delete.
+   * 
+   * In general case, this incoherence is due to the fact that the copy/paste node didn't
+   * considered the fact that a copied node must reference its own liveRevision.
+   * 
+   * @param nodeToDelete
+   * @param session
+   * @throws Exception
+   */
+  private void updateReferencedLiveRevisionFromCopies(Node nodeToDelete, Session session) throws Exception {
+    PublicationService publicationService = PortalContainer.getInstance().getComponentInstanceOfType(PublicationService.class);
+    WCMPublicationService wcmPublicationService = PortalContainer.getInstance()
+                                                                 .getComponentInstanceOfType(WCMPublicationService.class);
+    if (wcmPublicationService.isEnrolledInWCMLifecycle(nodeToDelete)
+        && nodeToDelete.hasProperty(AuthoringPublicationConstant.LIVE_REVISION_PROP)) {
+      String liveRevisionReference = nodeToDelete.getProperty(AuthoringPublicationConstant.LIVE_REVISION_PROP).getString();
+      Query query = session.getWorkspace()
+                           .getQueryManager()
+                           .createQuery("SELECT * from " + AuthoringPublicationConstant.PUBLICATION_LIFECYCLE_TYPE + " WHERE "
+                               + AuthoringPublicationConstant.LIVE_REVISION_PROP + " = '" + liveRevisionReference + "'",
+                                        Query.SQL);
+      NodeIterator nodes = query.execute().getNodes();
+      String siteName = Util.getPortalRequestContext().getPortalOwner();
+      String remoteUser = Util.getPortalRequestContext().getRemoteUser();
+
+      while (nodes.hasNext()) {
+        Node copiedNode = nodes.nextNode();
+        String lifecycleName = publicationService.getNodeLifecycleName(copiedNode);
+        String originalState = null;
+        if (copiedNode.hasProperty(AuthoringPublicationConstant.CURRENT_STATE)) {
+          originalState = copiedNode.getProperty(AuthoringPublicationConstant.CURRENT_STATE).getString();
+        } else {
+          originalState = PublicationDefaultStates.DRAFT;
+        }
+
+        wcmPublicationService.unsubcribeLifecycle(copiedNode);
+        wcmPublicationService.enrollNodeInLifecycle(copiedNode, lifecycleName);
+        // Make content draft again
+        wcmPublicationService.updateLifecyleOnChangeContent(copiedNode, siteName, remoteUser);
+
+        // Change node publication status to original state
+        String newState = publicationService.getCurrentState(copiedNode);
+        if (!StringUtils.equals(newState, originalState)) {
+          wcmPublicationService.updateLifecyleOnChangeContent(copiedNode, siteName, remoteUser, originalState);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Prior to this change, when copy/paste a content that is enrolled in Publication lifecycle, the property 'publication:liveRevision' (of type REFERENCE) references the original content published version. Consequently when attempting to delete original content from JCR, a ReferentialIntegrityException is thrown which will prevent content deletion. This change will enroll again the copied content inside the publication lifecycle to cleanup references to original node and will make the copied content as Draft, then change the state again to the original content's state (Published if it was 'Published', 'Staged', if it was 'Staged'...).

For previously copied contents and placed in Trash, we will have to add a specific workaround to allow deleting it (since the reference already exists and used the old 'Paste' algorithm that didn't cleaned Publication Information).
In fact, a previously published webcontent, which was copied at least once, will not be able to be deleted since the new copied nodes holds a reference to the same live Revision as the original. This workaround will attempt to delete those references by publishing again the copies (if no modification was already made by author user), else this will make the copied content as 'Draft' only without a referenced 'Live revision'. This will lead to unpublish some copied content as consequence that should be acceptable comparing to the fact that the original content can't be deleted anymore.

( **Remaining**: to be tested and validated on 6.3.x & 5.2.x )