### PR TITLE
TASK-55628 Fix Copying enrolled node in publication lifecycle (#1724)

### DIFF
--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/DeleteManageComponent.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/DeleteManageComponent.java
@@ -35,20 +35,29 @@ import javax.jcr.ReferentialIntegrityException;
 import javax.jcr.Session;
 import javax.jcr.lock.LockException;
 import javax.jcr.nodetype.ConstraintViolationException;
+import javax.jcr.query.Query;
 import javax.jcr.version.VersionException;
 import javax.portlet.PortletPreferences;
 
+import org.apache.commons.codec.binary.StringUtils;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.Validate;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.ecm.utils.lock.LockUtil;
 import org.exoplatform.ecm.webui.component.explorer.UIConfirmMessage;
 import org.exoplatform.ecm.webui.component.explorer.UIJCRExplorer;
 import org.exoplatform.ecm.webui.component.explorer.UIWorkingArea;
-import org.exoplatform.ecm.webui.component.explorer.control.filter.*;
+import org.exoplatform.ecm.webui.component.explorer.control.filter.CanDeleteNodeFilter;
+import org.exoplatform.ecm.webui.component.explorer.control.filter.IsNotEditingDocumentFilter;
+import org.exoplatform.ecm.webui.component.explorer.control.filter.IsNotLockedFilter;
+import org.exoplatform.ecm.webui.component.explorer.control.filter.IsNotMandatoryChildNode;
+import org.exoplatform.ecm.webui.component.explorer.control.filter.IsNotSpecificFolderNodeFilter;
+import org.exoplatform.ecm.webui.component.explorer.control.filter.IsNotTrashHomeNodeFilter;
 import org.exoplatform.ecm.webui.component.explorer.control.listener.UIWorkingAreaActionListener;
 import org.exoplatform.ecm.webui.utils.JCRExceptionManager;
-import org.exoplatform.ecm.utils.lock.LockUtil;
 import org.exoplatform.ecm.webui.utils.PermissionUtil;
 import org.exoplatform.ecm.webui.utils.Utils;
+import org.exoplatform.portal.webui.util.Util;
 import org.exoplatform.services.cms.actions.ActionServiceContainer;
 import org.exoplatform.services.cms.documents.TrashService;
 import org.exoplatform.services.cms.folksonomy.NewFolksonomyService;
@@ -59,6 +68,7 @@ import org.exoplatform.services.cms.relations.RelationsService;
 import org.exoplatform.services.cms.taxonomy.TaxonomyService;
 import org.exoplatform.services.cms.templates.TemplateService;
 import org.exoplatform.services.cms.thumbnail.ThumbnailService;
+import org.exoplatform.services.ecm.publication.PublicationService;
 import org.exoplatform.services.jcr.core.ManageableRepository;
 import org.exoplatform.services.jcr.ext.audit.AuditService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
@@ -66,6 +76,9 @@ import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.wcm.core.NodetypeConstant;
+import org.exoplatform.services.wcm.extensions.publication.lifecycle.authoring.AuthoringPublicationConstant;
+import org.exoplatform.services.wcm.publication.PublicationDefaultStates;
+import org.exoplatform.services.wcm.publication.WCMPublicationService;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.web.application.ApplicationMessage;
 import org.exoplatform.web.application.RequestContext;
@@ -194,8 +207,9 @@ public class DeleteManageComponent extends UIAbstractManagerComponent {
 
         TrashService trashService = WCMCoreUtils.getService(TrashService.class);
         node = trashService.getNodeByTrashId(trashId);
-        if(!isDocumentNodeType(node) 
-        		&& !node.getPrimaryNodeType().getName().equals(NodetypeConstant.NT_FILE)){
+        if (node != null
+            && !isDocumentNodeType(node)
+            && !node.getPrimaryNodeType().getName().equals(NodetypeConstant.NT_FILE)) {
           Queue<Node> queue = new LinkedList<Node>();
           queue.add(node);
 
@@ -390,6 +404,11 @@ public class DeleteManageComponent extends UIAbstractManagerComponent {
       if (PermissionUtil.canRemoveNode(node) && node.isNodeType(Utils.EXO_AUDITABLE)) {
         removeAuditForNode(node);
       }
+
+      // Workaround TASK-55628 : Remove referenced live revisions
+      updateReferencedLiveRevisionFromCopies(node, session);
+      // End Workaround TASK-55628
+
       //Remove symlinks
       LinkManager linkManager = WCMCoreUtils.getService(LinkManager.class);
       if(!node.isNodeType(NodetypeConstant.EXO_SYMLINK)) {
@@ -401,22 +420,24 @@ public class DeleteManageComponent extends UIAbstractManagerComponent {
       node.remove();
       parentNode.save();
     } catch (VersionException ve) {
+      LOG.warn("Error deleting node", ve);
       uiApp.addMessage(new ApplicationMessage("UIPopupMenu.msg.remove-verion-exception", null,
                                               ApplicationMessage.WARNING));
 
       uiExplorer.updateAjax(event);
       return;
     } catch (ReferentialIntegrityException ref) {
+      LOG.warn("Error deleting node", ref);
       session.refresh(false);
       uiExplorer.refreshExplorer();
-      uiApp
-      .addMessage(new ApplicationMessage(
+      uiApp.addMessage(new ApplicationMessage(
                                          "UIPopupMenu.msg.remove-referentialIntegrityException", null,
                                          ApplicationMessage.WARNING));
 
       uiExplorer.updateAjax(event);
       return;
     } catch (ConstraintViolationException cons) {
+      LOG.warn("Error deleting node", cons);
       session.refresh(false);
       uiExplorer.refreshExplorer();
       uiApp.addMessage(new ApplicationMessage("UIPopupMenu.msg.constraintviolation-exception",
@@ -425,17 +446,16 @@ public class DeleteManageComponent extends UIAbstractManagerComponent {
       uiExplorer.updateAjax(event);
       return;
     } catch (LockException lockException) {
+      LOG.warn("Error deleting node", lockException);
       uiApp.addMessage(new ApplicationMessage("UIPopupMenu.msg.node-locked-other-person", null,
                                               ApplicationMessage.WARNING));
 
       uiExplorer.updateAjax(event);
       return;
     } catch (Exception e) {
-      if (LOG.isErrorEnabled()) {
-        LOG.error("an unexpected error occurs while removing the node", e);
-      }
-      JCRExceptionManager.process(uiApp, e);
+      LOG.warn("an unexpected error occurs while removing the node", e);
 
+      JCRExceptionManager.process(uiApp, e);
       return;
     }
     if (!isMultiSelect) {
@@ -443,6 +463,57 @@ public class DeleteManageComponent extends UIAbstractManagerComponent {
         uiExplorer.setSelectNode(LinkUtils.getParentPath(virtualNodePath));
       else
         uiExplorer.setSelectNode(currentNode.getPath());
+    }
+  }
+
+  /**
+   * Workaround TASK-55628 : This method will search for nodes which references
+   * the same 'liveRevision' than the current node to delete.
+   * 
+   * In general case, this incoherence is due to the fact that the copy/paste node didn't
+   * considered the fact that a copied node must reference its own liveRevision.
+   * 
+   * @param nodeToDelete
+   * @param session
+   * @throws Exception
+   */
+  private void updateReferencedLiveRevisionFromCopies(Node nodeToDelete, Session session) throws Exception {
+    PublicationService publicationService = PortalContainer.getInstance().getComponentInstanceOfType(PublicationService.class);
+    WCMPublicationService wcmPublicationService = PortalContainer.getInstance()
+                                                                 .getComponentInstanceOfType(WCMPublicationService.class);
+    if (wcmPublicationService.isEnrolledInWCMLifecycle(nodeToDelete)
+        && nodeToDelete.hasProperty(AuthoringPublicationConstant.LIVE_REVISION_PROP)) {
+      String liveRevisionReference = nodeToDelete.getProperty(AuthoringPublicationConstant.LIVE_REVISION_PROP).getString();
+      Query query = session.getWorkspace()
+                           .getQueryManager()
+                           .createQuery("SELECT * from " + AuthoringPublicationConstant.PUBLICATION_LIFECYCLE_TYPE + " WHERE "
+                               + AuthoringPublicationConstant.LIVE_REVISION_PROP + " = '" + liveRevisionReference + "'",
+                                        Query.SQL);
+      NodeIterator nodes = query.execute().getNodes();
+      String siteName = Util.getPortalRequestContext().getPortalOwner();
+      String remoteUser = Util.getPortalRequestContext().getRemoteUser();
+
+      while (nodes.hasNext()) {
+        Node copiedNode = nodes.nextNode();
+        String lifecycleName = publicationService.getNodeLifecycleName(copiedNode);
+        String originalState = null;
+        if (copiedNode.hasProperty(AuthoringPublicationConstant.CURRENT_STATE)) {
+          originalState = copiedNode.getProperty(AuthoringPublicationConstant.CURRENT_STATE).getString();
+        } else {
+          originalState = PublicationDefaultStates.DRAFT;
+        }
+
+        wcmPublicationService.unsubcribeLifecycle(copiedNode);
+        wcmPublicationService.enrollNodeInLifecycle(copiedNode, lifecycleName);
+        // Make content draft again
+        wcmPublicationService.updateLifecyleOnChangeContent(copiedNode, siteName, remoteUser);
+
+        // Change node publication status to original state
+        String newState = publicationService.getCurrentState(copiedNode);
+        if (!StringUtils.equals(newState, originalState)) {
+          wcmPublicationService.updateLifecyleOnChangeContent(copiedNode, siteName, remoteUser, originalState);
+        }
+      }
     }
   }
 
@@ -587,7 +658,7 @@ public class DeleteManageComponent extends UIAbstractManagerComponent {
 
   private boolean isDocumentNodeType(Node node) throws Exception {
     boolean isDocument = true;
-    TemplateService templateService = WCMCoreUtils.getService(TemplateService.class);
+    TemplateService templateService = PortalContainer.getInstance().getComponentInstanceOfType(TemplateService.class);
     isDocument = templateService.getAllDocumentNodeTypes().contains(node.getPrimaryNodeType().getName());
     return isDocument;
   }

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/PasteManageComponent.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/PasteManageComponent.java
@@ -17,8 +17,35 @@
  **************************************************************************/
 package org.exoplatform.ecm.webui.component.explorer.rightclick.manager;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+
+import javax.jcr.AccessDeniedException;
+import javax.jcr.ItemExistsException;
+import javax.jcr.ItemNotFoundException;
+import javax.jcr.LoginException;
+import javax.jcr.Node;
+import javax.jcr.PathNotFoundException;
+import javax.jcr.Property;
+import javax.jcr.PropertyIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.Workspace;
+import javax.jcr.lock.LockException;
+import javax.jcr.nodetype.ConstraintViolationException;
+import javax.jcr.nodetype.NodeType;
+import javax.jcr.version.VersionException;
+
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
+import org.exoplatform.container.PortalContainer;
 import org.exoplatform.ecm.utils.lock.LockUtil;
 import org.exoplatform.ecm.webui.component.explorer.UIDocumentAutoVersionForm;
 import org.exoplatform.ecm.webui.component.explorer.UIDocumentInfo;
@@ -34,6 +61,7 @@ import org.exoplatform.ecm.webui.component.explorer.sidebar.UITreeNodePageIterat
 import org.exoplatform.ecm.webui.utils.JCRExceptionManager;
 import org.exoplatform.ecm.webui.utils.PermissionUtil;
 import org.exoplatform.ecm.webui.utils.Utils;
+import org.exoplatform.portal.webui.util.Util;
 import org.exoplatform.services.cms.actions.ActionServiceContainer;
 import org.exoplatform.services.cms.clipboard.ClipboardService;
 import org.exoplatform.services.cms.clipboard.jcr.model.ClipboardCommand;
@@ -43,6 +71,7 @@ import org.exoplatform.services.cms.jcrext.activity.ActivityCommonService;
 import org.exoplatform.services.cms.link.LinkUtils;
 import org.exoplatform.services.cms.relations.RelationsService;
 import org.exoplatform.services.cms.thumbnail.ThumbnailService;
+import org.exoplatform.services.ecm.publication.PublicationService;
 import org.exoplatform.services.jcr.access.PermissionType;
 import org.exoplatform.services.jcr.ext.ActivityTypeUtils;
 import org.exoplatform.services.jcr.impl.core.NodeImpl;
@@ -51,6 +80,9 @@ import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.wcm.core.NodetypeConstant;
+import org.exoplatform.services.wcm.extensions.publication.lifecycle.authoring.AuthoringPublicationConstant;
+import org.exoplatform.services.wcm.publication.PublicationDefaultStates;
+import org.exoplatform.services.wcm.publication.WCMPublicationService;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.web.application.ApplicationMessage;
 import org.exoplatform.webui.config.annotation.ComponentConfig;
@@ -65,20 +97,6 @@ import org.exoplatform.webui.ext.filter.UIExtensionFilter;
 import org.exoplatform.webui.ext.filter.UIExtensionFilters;
 import org.exoplatform.webui.ext.manager.UIAbstractManager;
 import org.exoplatform.webui.ext.manager.UIAbstractManagerComponent;
-
-import javax.jcr.*;
-import javax.jcr.lock.LockException;
-import javax.jcr.nodetype.*;
-import javax.jcr.version.VersionException;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Matcher;
 
 /**
  * Created by The eXo Platform SARL Author : Hoang Van Hung hunghvit@gmail.com
@@ -589,28 +607,28 @@ public class PasteManageComponent extends UIAbstractManagerComponent {
         thumbnailService.processRemoveThumbnail(srcThumbnailNode);
       }
     } catch (ConstraintViolationException ce) {
-      LOG.debug("Error pasting document from {} to {}", srcPath, destPath, ce);
+      LOG.warn("Error pasting document from {} to {}", srcPath, destPath, ce);
       uiApp.addMessage(new ApplicationMessage("UIPopupMenu.msg.current-node-not-allow-paste", null,
           ApplicationMessage.WARNING));
 
       uiExplorer.updateAjax(event);
       return;
     } catch (VersionException ve) {
-      LOG.debug("Error pasting document from {} to {}", srcPath, destPath, ve);
+      LOG.warn("Error pasting document from {} to {}", srcPath, destPath, ve);
       uiApp.addMessage(new ApplicationMessage("UIPopupMenu.msg.copied-node-in-versioning", null,
           ApplicationMessage.WARNING));
 
       uiExplorer.updateAjax(event);
       return;
     } catch (ItemExistsException iee) {
-      LOG.debug("Error pasting document from {} to {}", srcPath, destPath, iee);
+      LOG.warn("Error pasting document from {} to {}", srcPath, destPath, iee);
       uiApp.addMessage(new ApplicationMessage("UIPopupMenu.msg.paste-node-same-name", null,
           ApplicationMessage.WARNING));
 
       uiExplorer.updateAjax(event);
       return;
     } catch (LoginException e) {
-      LOG.debug("Error pasting document from {} to {}", srcPath, destPath, e);
+      LOG.warn("Error pasting document from {} to {}", srcPath, destPath, e);
       if (ClipboardCommand.CUT.equals(type)) {
         uiApp.addMessage(new ApplicationMessage("UIPopupMenu.msg.cannot-login-node", null,
             ApplicationMessage.WARNING));
@@ -668,6 +686,41 @@ public class PasteManageComponent extends UIAbstractManagerComponent {
     }
   }
 
+  private static void updatePublicationLifecycle(Node destNode) throws Exception {
+    try {
+      // Make copied content enrolled as draft in publication lifecycle to cleanup references to old content
+      WCMPublicationService wcmPublicationService = PortalContainer.getInstance().getComponentInstanceOfType(WCMPublicationService.class);
+      if (wcmPublicationService.isEnrolledInWCMLifecycle(destNode)) {
+        PublicationService publicationService = PortalContainer.getInstance().getComponentInstanceOfType(PublicationService.class);
+        String lifecycleName = publicationService.getNodeLifecycleName(destNode);
+        String originalState = null;
+        if (destNode.hasProperty(AuthoringPublicationConstant.CURRENT_STATE)) {
+          originalState = destNode.getProperty(AuthoringPublicationConstant.CURRENT_STATE).getString();
+        } else {
+          originalState = PublicationDefaultStates.DRAFT;
+        }
+
+        wcmPublicationService.unsubcribeLifecycle(destNode);
+        wcmPublicationService.enrollNodeInLifecycle(destNode, lifecycleName);
+
+        String siteName = Util.getPortalRequestContext().getPortalOwner();
+        String remoteUser = Util.getPortalRequestContext().getRemoteUser();
+        // Make content draft again
+        wcmPublicationService.updateLifecyleOnChangeContent(destNode, siteName, remoteUser);
+
+        // Change node publication status to original state
+        String newState = publicationService.getCurrentState(destNode);
+        if (!StringUtils.equals(newState, originalState)) {
+          wcmPublicationService.updateLifecyleOnChangeContent(destNode, siteName, remoteUser, originalState);
+        }
+      }
+    } catch (Exception e) {
+      LOG.warn("Error while cleaning Publication lifecycle of copied content '{}'. Continue to paste content by ignoring optional publication lifecycle cleanup process.",
+               destNode.getPath(),
+               e);
+    }
+  }
+
   private static void removeReferences(Node destNode) throws Exception {
     NodeType[] mixinTypes = destNode.getMixinNodeTypes();
     Session session = destNode.getSession();
@@ -691,6 +744,7 @@ public class PasteManageComponent extends UIAbstractManagerComponent {
       Node destNode = (Node) session.getItem(destPath);
       changeCopiedNodeOwner(destNode);
       removeReferences(destNode);
+      updatePublicationLifecycle(destNode);
     } else {
       try {
         if (LOG.isDebugEnabled())


### PR DESCRIPTION
Prior to this change, when copy/paste a content that is enrolled in Publication lifecycle, the property 'publication:liveRevision' (of type REFERENCE) references the original content published version. Consequently when attempting to delete original content from JCR, a ReferentialIntegrityException is thrown which will prevent content deletion. This change will enroll again the copied content inside the publication lifecycle to cleanup references to original node and will make the copied content as Draft, then change the state again to the original content's state (Published if it was 'Published', 'Staged', if it was 'Staged'...).

For previously copied contents and placed in Trash, we will have to add a specific workaround to allow deleting it (since the reference already exists and used the old 'Paste' algorithm that didn't cleaned Publication Information).
In fact, a previously published webcontent, which was copied at least once, will not be able to be deleted since the new copied nodes holds a reference to the same live Revision as the original. This workaround will attempt to delete those references by publishing again the copies (if no modification was already made by author user), else this will make the copied content as 'Draft' only without a referenced 'Live revision'. This will lead to unpublish some copied content as consequence that should be acceptable comparing to the fact that the original content can't be deleted anymore.