### PR TITLE
TASK-56519: Do not show comments when previow document of activity comment

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityAttachment.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityAttachment.vue
@@ -157,6 +157,9 @@ export default {
     spaceURL() {
       return this.previewActivity && this.previewActivity.activityStream && this.previewActivity.activityStream.space && this.previewActivity.activityStream.space.groupId.replace('/spaces/', '');
     },
+    isCommentActivity() {
+      return this.activity && this.activity.activityId;
+    }
   },
   created() {
     this.image = this.attachment && this.attachment.image;
@@ -209,7 +212,8 @@ export default {
             },
             version: {
               number: attachment.version && Number(attachment.version) || 0,
-            }
+            },
+            showComments: !this.isCommentActivity
           });
         })
         .catch(e => {


### PR DESCRIPTION
Prior to this change, when priview a document attached to an activity comment, the comments drawer is displayed with the file preview with no comments and no ability to add comments,
This PR should make sure to not display the comments drawer with file preveiwer when its' an activity comment by activating the showComments property in the documentPrviewer