### PR TITLE
TASK-56598 Fix bulk moving files from attachment drawer (#1733)

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/Attachment.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/Attachment.vue
@@ -56,8 +56,8 @@ export default {
     this.$root.$on('attachments-changed-from-drives', (selectedFromDrives, removedFilesFromDrive) => {
       this.updateAttachmentsFromDrives(selectedFromDrives, removedFilesFromDrive);
     });
-    this.$root.$on('add-destination-path-for-all', (defaultDestinationFolderPath, pathDestinationFolder, currentDrive) => {
-      this.addDestinationFolderForAll(defaultDestinationFolderPath, pathDestinationFolder, currentDrive);
+    this.$root.$on('add-destination-path-for-all', (defaultDestinationFolderPath, folderRelativePath, currentDrive) => {
+      this.addDestinationFolderForAll(defaultDestinationFolderPath, folderRelativePath, currentDrive);
     });
     this.$root.$on('reset-attachment-list', () => {
       this.attachments = [];
@@ -179,13 +179,21 @@ export default {
         this.attachments.splice(fileIndex, fileIndex >= 0 ? 1 : 0);
       }
     },
-    addDestinationFolderForAll(defaultDestinationFolderPath, pathDestinationFolder, currentDrive) {
-      for (const attachment in this.attachments) {
-        if (!attachment.destinationFolder || attachment.destinationFolder === defaultDestinationFolderPath) {
-          attachment.destinationFolder = pathDestinationFolder;
-          attachment.fileDrive = currentDrive;
+    addDestinationFolderForAll(defaultDestinationFolderPath, folderRelativePath, currentDrive) {
+      this.attachments.forEach(attachment => {
+        if (attachment.id && (!attachment.destinationFolder || attachment.destinationFolder === defaultDestinationFolderPath)) {
+          this.$attachmentService.moveAttachmentToNewPath(
+            currentDrive.name,
+            folderRelativePath,
+            attachment.id,
+            this.entityType,
+            this.entityId
+          ).then(() => {
+            this.$root.$emit('entity-attachments-updated');
+            document.dispatchEvent(new CustomEvent('entity-attachments-updated'));
+          });
         }
-      }
+      });
     },
     initDefaultDrive() {
       if (this.spaceId) {

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
@@ -217,8 +217,8 @@ export default {
     this.$root.$on('remove-destination-for-file', (folderId) => {
       this.deleteDestinationPathForFile(folderId);
     });
-    this.$root.$on('select-destination-path-for-all', (pathDestinationFolder, folderName, currentDrive) => {
-      this.addDestinationFolderForAll(pathDestinationFolder, folderName, currentDrive);
+    this.$root.$on('select-destination-path-for-all', (pathDestinationFolder, folderRelativePath, folderName, currentDrive) => {
+      this.addDestinationFolderForAll(pathDestinationFolder, folderRelativePath, folderName, currentDrive);
     });
     this.$root.$on('link-new-added-attachments', () => {
       this.uploadAddedAttachments();
@@ -331,11 +331,11 @@ export default {
         });
       }
     },
-    addDestinationFolderForAll(pathDestinationFolder, folder, currentDrive) {
+    addDestinationFolderForAll(pathDestinationFolder, folderRelativePath, folder, currentDrive) {
       this.currentDrive = currentDrive;
       this.pathDestinationFolder = pathDestinationFolder;
       this.schemaFolder = folder.split('/');
-      this.$root.$emit('add-destination-path-for-all', this.defaultDestinationFolderPath, this.pathDestinationFolder, this.currentDrive);
+      this.$root.$emit('add-destination-path-for-all', this.defaultDestinationFolderPath, folderRelativePath, currentDrive);
     },
     moveFileToNewDestinationFile(movedFile, pathDestinationFolder, folder, newDestinationPathDrive) {
       this.$attachmentService.moveAttachmentToNewPath(

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
@@ -832,7 +832,7 @@ export default {
           this.$root.$emit('add-destination-path-for-file', this.movedFile, this.getRelativePath(this.selectedFolderPath), this.folderDestinationForFile, this.currentDrive);
           this.modeFolderSelectionForFile = false;
         } else {
-          this.$root.$emit('select-destination-path-for-all', this.selectedFolderPath, this.schemaFolder, this.currentDrive);
+          this.$root.$emit('select-destination-path-for-all', this.selectedFolderPath, this.getRelativePath(this.selectedFolderPath), this.schemaFolder, this.currentDrive);
         }
       } else {
         this.addSelectedFiles();
@@ -924,7 +924,7 @@ export default {
       });
     },
     closeFolderActionsMenu: function () {
-      this.$refs.folderActionsMenu.closeMenu();
+      this.$refs.folderActionsMenu?.closeMenu();
     },
     deleteFolder() {
       if (this.selectedFolder.canRemove) {
@@ -962,7 +962,7 @@ export default {
         if (this.selectedFolder.title) {
           this.newName = this.selectedFolder.title;
           this.renameFolderAction = true;
-          this.$refs.folderActionsMenu.closeMenu();
+          this.$refs.folderActionsMenu?.closeMenu();
           this.$nextTick(() => {
             this.$refs.rename[0].focus();
           });

--- a/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentServiceImpl.java
@@ -383,7 +383,7 @@ public class AttachmentServiceImpl implements AttachmentService {
                                               attachmentId);
     } catch (Exception e) {
       throw new IllegalStateException("Error while trying to move attachment node with id " + attachmentId + " to the new path "
-          + newPath);
+          + newPath, e);
     } finally {
       if (session != null) {
         session.logout();


### PR DESCRIPTION
Prior to this change, when moving the files from attachment drawer using parent folder selection, the files aren't moved at all. This fix will ensure to apply the 'move' action to all files which doesn't have a specific folder to newly selected parent folder.