### PR TITLE
TASK-57017: Print a PDF document isn't functional 

### DIFF
--- a/apps/resources-wcm/src/main/webapp/pdf.js/viewer.js
+++ b/apps/resources-wcm/src/main/webapp/pdf.js/viewer.js
@@ -7207,7 +7207,7 @@ function webViewerInitialized() {
     document.getElementById('secondaryOpenFile').setAttribute('hidden', 'true');
   }
 
-  var locale = eXo.env.portal.language || navigator.language;
+  var locale = typeof eXo !== 'undefined' && eXo.env.portal.language || navigator.language;
 
   if (PDFViewerApplication.preferencePdfBugEnabled) {
     // Special debugging flags in the hash section of the URL.


### PR DESCRIPTION
Prior to this change, when press the print button the pdf.js viewer a new page is opened to print the document, where the eXo object variable isn't defined which caused an exception because we use this object to
determine the user choosed lang in the platform, and so the moz10L couldn't parse the labels key as the locale varibale will be null.
This PR should add a check of undefined on the eXo object variable to avoid this execption and allow parse the label keys depends on naigator lang.