### PR TITLE
TASK-57198: Fix jcr session already closed while saving news article

### DIFF
--- a/ecms-social-integration/src/main/java/org/exoplatform/ecms/uploads/HTMLUploadImageProcessorImpl.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/ecms/uploads/HTMLUploadImageProcessorImpl.java
@@ -230,10 +230,6 @@ public class HTMLUploadImageProcessorImpl implements HTMLUploadImageProcessor {
       throw new IllegalArgumentException("Cannot find File location, content will not be changed", e);
     } catch (IOException e) {
       throw new IllegalArgumentException("Cannot create the image, content will not be changed", e);
-    } finally {
-      if (sessionProvider != null) {
-        sessionProvider.close();
-      }
     }
   }
 
@@ -309,10 +305,6 @@ public class HTMLUploadImageProcessorImpl implements HTMLUploadImageProcessor {
       throw new IllegalArgumentException("Cannot find File location", e);
     } catch (IOException e) {
       throw new IllegalArgumentException("Cannot create the image", e);
-    } finally {
-      if (sessionProvider != null) {
-        sessionProvider.close();
-      }
     }
   }
 
@@ -369,10 +361,6 @@ public class HTMLUploadImageProcessorImpl implements HTMLUploadImageProcessor {
       throw new IllegalArgumentException("Cannot create the image", e);
     } catch (Exception e) {
       throw new IllegalArgumentException("Cannot find user data location", e);
-    }finally {
-      if (sessionProvider != null) {
-        sessionProvider.close();
-      }
     }
   }
   @Override
@@ -446,10 +434,6 @@ public class HTMLUploadImageProcessorImpl implements HTMLUploadImageProcessor {
       throw new IllegalArgumentException("Cannot create the image", e);
     } catch (Exception e) {
       throw new IllegalArgumentException("Cannot find user data location", e);
-    }finally {
-      if (sessionProvider != null) {
-        sessionProvider.close();
-      }
     }
   }
 
@@ -518,10 +502,6 @@ public class HTMLUploadImageProcessorImpl implements HTMLUploadImageProcessor {
       throw new IllegalArgumentException("Cannot create the image", e);
     } catch (Exception e) {
       throw new IllegalArgumentException("Cannot find user data location", e);
-    } finally {
-      if (sessionProvider != null) {
-        sessionProvider.close();
-      }
     }
   }
 
@@ -575,10 +555,6 @@ public class HTMLUploadImageProcessorImpl implements HTMLUploadImageProcessor {
       }
     } catch (Exception e) {
       throw new IllegalArgumentException("Cannot process the content", e);
-    } finally {
-      if (sessionProvider != null) {
-        sessionProvider.close();
-      }
     }
     return content_;
   }


### PR DESCRIPTION
Prior to this change, both `HtmlUploadImageProcessor` and other services such as news using `sessionProviderService` to get the session provider. Since the `sessionProviderService` shares the `sessionProivder` in a local thread, closing the session provider by the processor made it inaccessible and not useful for other services in the same thread.
This PR removes the `sessionprovider` close in the `HTMLUploadImageProcessor` to avoid such exception.