### PR TITLE
TASK-57042: NPE while detecting keywords by DLP

### DIFF
--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/connector/FileSearchServiceConnector.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/connector/FileSearchServiceConnector.java
@@ -164,7 +164,7 @@ public class FileSearchServiceConnector extends ElasticSearchServiceConnector {
     ecmsSearchResult.setImageUrl(getImageUrl(workspace, nodePath));
     ecmsSearchResult.setPreviewUrl(getPreviewUrl(jsonHit, searchContext, downloadUrl));
     ecmsSearchResult.setExcerpt(searchResult.getExcerpt());
-
+    ecmsSearchResult.setExcerpts(searchResult.getExcerpts());
     String formattedDate = getFormattedDate(searchResult.getDate(), lang);
     ecmsSearchResult.setDetail(driveName + formattedFileSize + " - " + formattedDate);
 

--- a/core/search/src/test/java/org/exoplatform/services/wcm/search/connector/TestFileSearchServiceConnector.java
+++ b/core/search/src/test/java/org/exoplatform/services/wcm/search/connector/TestFileSearchServiceConnector.java
@@ -93,7 +93,12 @@ public class TestFileSearchServiceConnector {
           "               \"exo:internalUse\": \"false\",\n" +
           "               \"fileType\": \"application/pdf\",\n" +
           "               \"dc:publisher\": \"cairo 1.9.5 (http://cairographics.org)\"\n" +
-          "            }\n" +
+          "            },\n" +
+          "            \"highlight\":{ \n"+
+          "                  \"attachment.content\": [\n"+
+          "                 \"Hello <em>text</em> test\" \n" +
+          "                         ]\n" +
+          "             }\n" +
           "          }\n" +
           "        ]\n" +
           "      } }";
@@ -248,6 +253,7 @@ public class TestFileSearchServiceConnector {
     assertNotNull(searchResults);
     assertEquals(1, searchResults.size());
     SearchResult searchResult = searchResults.iterator().next();
+    assertEquals(1, searchResult.getExcerpts().size());
     assertEquals("exo-documentation.pdf", searchResult.getTitle());
     assertEquals("exo-tag-doc-john", ((EcmsSearchResult) searchResult).getTags().get(0));
     assertEquals(1505312333066L, searchResult.getDate());


### PR DESCRIPTION
Prior to this change, when upload, attach or edit documents, the dlp connector fails to process document contents due to an NPE while getting searchResult excerpts because it wasn't already insilized by the constructor.
This PR should make sure to set the excerpts while building the result from serchResult object.