### PR TITLE
Task-57039: Impossible to add to favorites for a document when its on read only

### DIFF
--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/FavouriteManageComponent.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/FavouriteManageComponent.java
@@ -74,11 +74,10 @@ public class FavouriteManageComponent extends UIAbstractManagerComponent {
   private static final List<UIExtensionFilter> FILTERS
         = Arrays.asList(new UIExtensionFilter[]{new IsNotInTrashFilter(),
                                                 new IsNotFavouriteFilter(),
-                                                 new IsNotLockedFilter(),
-                                                 new IsCheckedOutFilter(),
-                                                 new CanSetPropertyFilter(),
-                                                 new IsNotTrashHomeNodeFilter(),
-                                                 new IsDocumentFilter() });
+                                                new IsNotLockedFilter(),
+                                                new IsCheckedOutFilter(),
+                                                new IsNotTrashHomeNodeFilter(),
+                                                new IsDocumentFilter() });
 
   private final static Log       LOG  = ExoLogger.getLogger(FavouriteManageComponent.class.getName());
 
@@ -132,10 +131,9 @@ public class FavouriteManageComponent extends UIAbstractManagerComponent {
     }
 
     try {
-      if (!node.isCheckedOut())
+      if (!node.isCheckedOut()) {
         throw new VersionException("node is locked, can't add favourite to node:" + node.getPath());
-      if (!PermissionUtil.canSetProperty(node))
-        throw new AccessDeniedException("access denied, can't add favourite to node:" + node.getPath());
+      }
       favoriteService.addFavorite(node, ConversationState.getCurrent().getIdentity().getUserId());
       uiExplorer.updateAjax(event);
     } catch (LockException e) {

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/RemoveFavouriteManageComponent.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/rightclick/manager/RemoveFavouriteManageComponent.java
@@ -74,10 +74,9 @@ public class RemoveFavouriteManageComponent extends UIAbstractManagerComponent {
   private static final List<UIExtensionFilter> FILTERS
       = Arrays.asList(new UIExtensionFilter[] { new IsNotInTrashFilter(),
                                                 new IsFavouriteFilter(),
-                                                 new IsNotLockedFilter(),
-                                                 new IsCheckedOutFilter(),
-                                                 new HasRemovePermissionFilter(),
-                                                 new IsNotTrashHomeNodeFilter() });
+                                                new IsNotLockedFilter(),
+                                                new IsCheckedOutFilter(),
+                                                new IsNotTrashHomeNodeFilter() });
 
   private final static Log       LOG  = ExoLogger.getLogger(RemoveFavouriteManageComponent.class.getName());
 
@@ -137,10 +136,9 @@ public class RemoveFavouriteManageComponent extends UIAbstractManagerComponent {
       }
 
       try {
-        if (!node.isCheckedOut())
+        if (!node.isCheckedOut()) {
           throw new VersionException("node is locked, can't remove favourite of node :" + node.getPath());
-        if (!PermissionUtil.canRemoveNode(node))
-          throw new AccessDeniedException("access denied, can't remove favourite of node:" + node.getPath());
+        }
         favoriteService.removeFavorite(node, ConversationState.getCurrent().getIdentity().getUserId());
         uiExplorer.updateAjax(event);
       } catch (LockException e) {


### PR DESCRIPTION
Prior this change, when the document permission is read-only, the option to add favorite or remove favorite disappears (for old document App).
Update : Remove restriction for these actions, since we no longer need to create a symbolic link or update node property when adding a favorite for document