### PR TITLE
Task-57148: Fix display detach button in upload file

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
@@ -120,6 +120,10 @@ export default {
       type: Boolean,
       default: false
     },
+    entityId: {
+      type: String,
+      default: ''
+    },
     canAccess: {
       type: Boolean,
       default: true
@@ -184,7 +188,7 @@ export default {
       return `${this.attachedFromOtherDrivesLabel} ${this.attachmentsWillBeDisplayedForLabel}`;
     },
     canDetachAttachment() {
-      return this.attachmentHasPermission && this.attachmentHasPermission.canDetach || !this.attachment.id || this.attachment.isSelectedFromDrives;
+      return this.attachmentHasPermission && this.attachmentHasPermission.canDetach || !this.attachment.id || this.attachment.isSelectedFromDrives || !this.entityId;
     },
     canMoveAttachment() {
       return this.canEdit && this.allowToEdit && !this.attachment.isSelectedFromDrives;

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadedFiles.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadedFiles.vue
@@ -107,8 +107,8 @@
             :allow-to-preview="false"
             :current-space="currentSpace"
             :current-drive="currentDrive"
-            :allow-to-detach="true"
             :entityId="entityId"
+            allow-to-detach
             allow-to-edit />
         </span>
       </transition-group>

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadedFiles.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadedFiles.vue
@@ -107,7 +107,8 @@
             :allow-to-preview="false"
             :current-space="currentSpace"
             :current-drive="currentDrive"
-            :allow-to-detach="allowToDetach"
+            :allow-to-detach="true"
+            :entityId="entityId"
             allow-to-edit />
         </span>
       </transition-group>


### PR DESCRIPTION

Prior to this fix, when user upload file, The file is displayed in the attachment section without a detach icon,
With this fix, we will be sure to display the detach icon in upload file when user allow-to-detach.
