### PR TITLE
TASK-57293 Add Transfer Rules Administration Menu Categorization Configuration

### DIFF
--- a/apps/portlet-transferrules/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/apps/portlet-transferrules/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -5,4 +5,5 @@
   xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
 
   <import>war:/conf/transferRules/portal/portal-configuration.xml</import>
+  <import>war:/conf/transferRules/portal/navigation-categories-configuration.xml</import>
 </configuration>


### PR DESCRIPTION
Prior to this change, the Administration Menu 'transferRiles' categorization configuration wasn't included. This change will simply include the configuration file in kernel file.