### PR TITLE
Task-56970: Fix snackbar position in mobile version when space footer is dispalyed

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/snackbar/AttachmentsNotificationAlerts.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/snackbar/AttachmentsNotificationAlerts.vue
@@ -4,6 +4,7 @@
     color="transparent"
     elevation="0"
     app
+    absolute
     bottom
     left>
     <attachments-notification-alert


### PR DESCRIPTION
Before this fix on mobile version the snackbar is displayed under the footer space menu,
In this Fix, we add position absolute to the snackbar with a z-index higher than the z-index of the space menu.