### PR TITLE
Task-57195: cleaning node name that contains "."

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -701,7 +701,7 @@ public class Utils {
 
   public static String cleanName(String oldName) {
     if (StringUtils.isEmpty(oldName)) return oldName;
-    String specialChar = "&#*@'\"\t\r\n$\\><:;[]/%|";
+    String specialChar = "&#*@.'\"\t\r\n$\\><:;[]/%|";
     StringBuilder ret = new StringBuilder();
     for (int i = 0; i < oldName.length(); i++) {
       char currentChar = oldName.charAt(i);

--- a/core/services/src/test/java/org/exoplatform/services/cms/impl/UtilsTest.java
+++ b/core/services/src/test/java/org/exoplatform/services/cms/impl/UtilsTest.java
@@ -25,6 +25,7 @@ public class UtilsTest extends TestCase {
     String title17 = "test < test";
     String title18 = "test # test";
     String title19 = "test * test";
+    String title20 = "test . test";
 
     // When
     String titleClean1 = Utils.cleanName(title1);
@@ -46,6 +47,7 @@ public class UtilsTest extends TestCase {
     String titleClean17 = Utils.cleanName(title17);
     String titleClean18 = Utils.cleanName(title18);
     String titleClean19 = Utils.cleanName(title19);
+    String titleClean20 = Utils.cleanName(title20);
 
     // Then
     assertEquals(titleClean1,"test-test");
@@ -67,5 +69,6 @@ public class UtilsTest extends TestCase {
     assertEquals(titleClean17,"test-test");
     assertEquals(titleClean18,"test-test");
     assertEquals(titleClean19,"test-test");
+    assertEquals(titleClean20,"test-test");
   }
 }


### PR DESCRIPTION
Issue: an exception is thrown when creating a node which has the character "." in name.
Fix:  Replace `.` character with `-` in reusable method `Utils.cleanName`