### PR TITLE
TASK-57240: Fix refreshing uploaded files when editing an activity

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
@@ -570,7 +570,6 @@ export default {
         }}));
         this.sendDocumentAnalytics(file);
         this.newUploadedFiles.push(file);
-        this.uploadedFiles.push(file);
       }
     },
     sendDocumentAnalytics(file) {


### PR DESCRIPTION
ISSUE: Sometimes when attaching newly created doc files, the attachments section in the "Add Documents" drawer isn't updated.
FIX: When creating a document in the "Add Documents" drawer, we will not push the created doc to the uploadedFiles array since the push will emit the "entity-attachments-updated" event which reinitializes the attachments list.