### PR TITLE
Task-56979: Missing icon preview for potx files in activity attachment

### DIFF
--- a/apps/resources-wcm/src/main/webapp/skin/less/ecms/portlets/attachments/attachmentsApp.less
+++ b/apps/resources-wcm/src/main/webapp/skin/less/ecms/portlets/attachments/attachmentsApp.less
@@ -580,6 +580,7 @@
 }
 
 .uiIconFileTypeapplicationvndgoogle-appspresentation:before,
+.uiIconFileTypeapplicationvndopenxmlformats-officedocumentpresentationmltemplate:before,
 .uiIconFileTypeapplicationvndopenxmlformats-officedocumentpresentationmlpresentation:before {
   content: "\e703";
   color: #D07B7B;


### PR DESCRIPTION
Prior to this change, potx files have no dedicated fontawsome class icon.
This PR should associate the powerpoint icon for potx file as the way for pptx