### PR TITLE
Task-56752: Bad display for cloud storage page on Firefox

### DIFF
--- a/apps/portlet-clouddrives/src/main/webapp/vue-app/cloudStorage/components/CloudStorage.vue
+++ b/apps/portlet-clouddrives/src/main/webapp/vue-app/cloudStorage/components/CloudStorage.vue
@@ -12,7 +12,7 @@
       </v-row>
       <v-row>
         <v-col xs12>
-          <v-simple-table :dense="true" class="uiGrid table table-hover table-striped providersTable">
+          <v-simple-table :dense="true" class="uiGrid table-hover table-striped providersTable">
             <template #default>
               <thead>
                 <tr class="providersTableRow">

--- a/apps/resources-wcm/src/main/webapp/skin/less/ecms/portlets/cloudStorage/cloud-storage.less
+++ b/apps/resources-wcm/src/main/webapp/skin/less/ecms/portlets/cloudStorage/cloud-storage.less
@@ -6,7 +6,6 @@
     font-size: 24px;
     height: 23px;
     position: relative;
-    overflow: hidden;
 
     &:after {
       border-bottom: 1px solid @uiSwitcherBackground;


### PR DESCRIPTION
Prior to this change, when go to left Navigation menu -> administration-> documents -> cloud storage then hover in table , a scroll bar is displayed below the table , then page title is not well displayed.
Fix: i remove overflow hidden in the class "Title" , then remove class table in the selector v-simple-table 
After this change, that title is displayed clearly and a scroll bar is not be displayed.