### PR TITLE
TASK-57175: Add getDocumentsTransferRules function in transferRulesService.js

### DIFF
--- a/apps/portlet-documents/src/main/webapp/js/transferRulesService.js
+++ b/apps/portlet-documents/src/main/webapp/js/transferRulesService.js
@@ -15,3 +15,16 @@ export function getTransfertRulesDownloadDocumentStatus() {
     }
   });
 }
+
+export function getDocumentsTransferRules() {
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/transferRules/getTransfertRulesDocumentStatus`, {
+    credentials: 'include',
+    method: 'GET',
+  }).then(resp => {
+    if (!resp || !resp.ok) {
+      throw new Error('Response code indicates a server error');
+    } else {
+      return resp.json();
+    }
+  });
+}


### PR DESCRIPTION
Prior to this change, no backend restriction made for download documents depends on tranfer rules.
This PR should add a restriction depends on transfer rules choose settings