### PR TITLE
TASK-57249 fix encoding accented file names displayed in the footer of document preview

### DIFF
--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -516,8 +516,8 @@
                 }
 
                 if (!this.settings.showComments) {
-                  html += '<div class="fileName" data-container="body" rel="tooltip" data-placement="top" title="' + documentPreview.settings.doc.title + '">' +
-                      '<div class="ellipsis">' + documentPreview.settings.doc.title + '</div>';
+                  html += '<div class="fileName" data-container="body" rel="tooltip" data-placement="top" title="' + decodeURI(documentPreview.settings.doc.title) + '">' +
+                      '<div class="ellipsis">' + decodeURI(documentPreview.settings.doc.title) + '</div>';
                   if (documentPreview.settings.version && (documentPreview.settings.version.number != 0)) {
                     html +='<div class="label primary fileVersion"' + (documentPreview.settings.doc.openUrl ? 'onclick="window.location.href=\'' + documentPreview.settings.doc.openUrl + '&versions=true\'"' : "") + '>V' + documentPreview.settings.version.number + '</div>';
                   }


### PR DESCRIPTION


Problem: the preview document page displays encoding characters instead of the accented parts of filenames.
Fix: use the function decodeURI() to replace escape sequences in filename with their respective special characters.