### PR TITLE
TASK-57545: fix file upload using safari

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
@@ -433,6 +433,7 @@ public class FileUploadHandler {
                                String userId,
                                String existenceAction,
                                boolean isNewVersion) throws Exception {
+    fileName = Utils.cleanNameWithAccents(fileName);
     String exoTitle = fileName;
     fileName = Utils.cleanName(fileName);
     try {


### PR DESCRIPTION
ISSUE: IOS devices use ISO-8859-1 to encode character which intoduces problems when uploading a file containing french characters (different code for non standard alphabet characters )
FIX: used already predefined method to clean the name
(cherry picked from commit 8cf41705f37d177aeb8a635d68ca1f796aeaa8ea)