### PR TITLE
Task-57767: Decoding the attachment name in the attachmentsDriveExplorerDrawer

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
@@ -441,6 +441,7 @@ export default {
       }
       files.forEach(file => {
         file.isSelected = this.attachedFiles.some(f => f.id === file.id);
+        file.name = decodeURI(file.name);
       });
       return files;
     },


### PR DESCRIPTION
ISSUE : If user open the attachments drive drawer the name of attachments with a special character displayed encoded.
FIX : decode the attachment name .