### PR TITLE
Task-58103: Title of space not displayed in breadcrumb broken attachement

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
@@ -43,7 +43,7 @@
                 data-toggle="tooltip"
                 rel="tooltip"
                 data-placement="bottom">
-                {{ currentDrive.mainTitle }}
+                {{ currentDrive.title }}
               </a>
             </div>
             <div v-if="foldersHistory.length > 2" class="longFolderHistory d-flex align-center">


### PR DESCRIPTION
Problem: when i upload file in attachement in breadcrumb broken , title of space is not displayed.
Fix:  the variable displayed is not true 'currentDrive.mainTitle' , so i change it To 'currentDrive.title' of space to show the Title of Space in breadcrumb.