### PR TITLE
Task-58643: Related the attached file thumbnails to attachment file extension

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
@@ -434,8 +434,8 @@ public class FileUploadHandler {
                                String existenceAction,
                                boolean isNewVersion) throws Exception {
     fileName = Utils.cleanNameWithAccents(fileName);
-    String exoTitle = fileName;
     fileName = Utils.cleanName(fileName);
+    String exoTitle = fileName;
     try {
       CacheControl cacheControl = new CacheControl();
       cacheControl.setNoCache(true);

--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -701,16 +701,22 @@ public class Utils {
 
   public static String cleanName(String oldName) {
     if (StringUtils.isEmpty(oldName)) return oldName;
+    String extention ="" ;
+    if(oldName.lastIndexOf(".") > -1){
+      extention = oldName.substring(oldName.lastIndexOf("."));
+      oldName = oldName.substring(0,oldName.lastIndexOf(".")) ;
+    }
     String specialChar = "&#*@.'\"\t\r\n$\\><:;[]/%|";
     StringBuilder ret = new StringBuilder();
     for (int i = 0; i < oldName.length(); i++) {
       char currentChar = oldName.charAt(i);
       if (specialChar.indexOf(currentChar) > -1) {
-        ret.append('-');
+        ret.append('_');
       } else {
         ret.append(currentChar);
       }
     }
+    ret.append(extention);
     return ret.toString();
   }
 

--- a/core/services/src/test/java/org/exoplatform/services/cms/impl/UtilsTest.java
+++ b/core/services/src/test/java/org/exoplatform/services/cms/impl/UtilsTest.java
@@ -6,26 +6,27 @@ public class UtilsTest extends TestCase {
 
   public void testCleanName() {
     // Given
-    String title1 = "test | test";
-    String title2 = "test % test";
-    String title3 = "test & test";
-    String title4 = "test @ test";
-    String title5 = "test $ test";
-    String title6 = "test / test";
-    String title7 = "test [ test";
-    String title8 = "test ] test";
-    String title9 = "test : test";
-    String title10 = "test ; test";
-    String title11 = "test \\ test";
-    String title12 = "test \t test";
-    String title13 = "test \" test";
-    String title14 = "test \n test";
-    String title15 = "test \r test";
-    String title16 = "test > test";
-    String title17 = "test < test";
-    String title18 = "test # test";
-    String title19 = "test * test";
-    String title20 = "test . test";
+    String title1 = "test|test";
+    String title2 = "test%test";
+    String title3 = "test&test";
+    String title4 = "test@test";
+    String title5 = "test$test";
+    String title6 = "test/test";
+    String title7 = "test[test";
+    String title8 = "test]test";
+    String title9 = "test:test";
+    String title10 = "test;test";
+    String title11 = "test\\test";
+    String title12 = "test\ttest";
+    String title13 = "test\"test";
+    String title14 = "test\ntest";
+    String title15 = "test\rtest";
+    String title16 = "test>test";
+    String title17 = "test<test";
+    String title18 = "test#test";
+    String title19 = "test*test";
+    String title20 = "test.test";
+    String title21 = "test.test.pdf";
 
     // When
     String titleClean1 = Utils.cleanName(title1);
@@ -48,27 +49,29 @@ public class UtilsTest extends TestCase {
     String titleClean18 = Utils.cleanName(title18);
     String titleClean19 = Utils.cleanName(title19);
     String titleClean20 = Utils.cleanName(title20);
+    String titleClean21 = Utils.cleanName(title21);
 
     // Then
-    assertEquals(titleClean1,"test-test");
-    assertEquals(titleClean2,"test-test");
-    assertEquals(titleClean3,"test-test");
-    assertEquals(titleClean4,"test-test");
-    assertEquals(titleClean5,"test-test");
-    assertEquals(titleClean6,"test-test");
-    assertEquals(titleClean7,"test-test");
-    assertEquals(titleClean8,"test-test");
-    assertEquals(titleClean9,"test-test");
-    assertEquals(titleClean10,"test-test");
-    assertEquals(titleClean11,"test-test");
-    assertEquals(titleClean12,"test-test");
-    assertEquals(titleClean13,"test-test");
-    assertEquals(titleClean14,"test-test");
-    assertEquals(titleClean15,"test-test");
-    assertEquals(titleClean16,"test-test");
-    assertEquals(titleClean17,"test-test");
-    assertEquals(titleClean18,"test-test");
-    assertEquals(titleClean19,"test-test");
-    assertEquals(titleClean20,"test-test");
+    assertEquals(titleClean1,"test_test");
+    assertEquals(titleClean2,"test_test");
+    assertEquals(titleClean3,"test_test");
+    assertEquals(titleClean4,"test_test");
+    assertEquals(titleClean5,"test_test");
+    assertEquals(titleClean6,"test_test");
+    assertEquals(titleClean7,"test_test");
+    assertEquals(titleClean8,"test_test");
+    assertEquals(titleClean9,"test_test");
+    assertEquals(titleClean10,"test_test");
+    assertEquals(titleClean11,"test_test");
+    assertEquals(titleClean12,"test_test");
+    assertEquals(titleClean13,"test_test");
+    assertEquals(titleClean14,"test_test");
+    assertEquals(titleClean15,"test_test");
+    assertEquals(titleClean16,"test_test");
+    assertEquals(titleClean17,"test_test");
+    assertEquals(titleClean18,"test_test");
+    assertEquals(titleClean19,"test_test");
+    assertEquals(titleClean20,"test.test");
+    assertEquals(titleClean21,"test_test.pdf");
   }
 }


### PR DESCRIPTION
ISSUE : when user create process and attached a file all attached file thumbnails displayed as media , the problem is when clean name of uploaded document can't extract the extension from the name .
FIX : modified clean name method to correctly clean the name file