### PR TITLE
Task-58507: Add connection status after cloud drive connect action

### DIFF
--- a/apps/portlet-clouddrives/src/main/webapp/vue-app/cloudDriveSettings/components/CloudDriveAlert.vue
+++ b/apps/portlet-clouddrives/src/main/webapp/vue-app/cloudDriveSettings/components/CloudDriveAlert.vue
@@ -1,0 +1,53 @@
+<!--
+Copyright (C) 2022 eXo Platform SAS.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+<template>
+  <v-snackbar
+    v-model="snackbar"
+    :left="!$vuetify.rtl"
+    :right="$vuetify.rtl"
+    color="transparent"
+    elevation="0"
+    app>
+    <exo-notification-alert
+      :alert="alert"
+      @dismissed="clear" />
+  </v-snackbar>
+</template>
+
+<script>
+
+export default {
+
+  data: () => ({
+    snackbar: false,
+    alert: null,
+  }),
+  watch: {
+    alert() {
+      this.snackbar = !!this.alert;
+    },
+  },
+  created() {
+    this.$root.$on('connectors-connection-alert', alert => this.alert = alert);
+  },
+  methods: {
+    clear() {
+      this.alert = null;
+    },
+  }
+};
+</script>

--- a/apps/portlet-clouddrives/src/main/webapp/vue-app/cloudDriveSettings/components/CloudDriveConnector.vue
+++ b/apps/portlet-clouddrives/src/main/webapp/vue-app/cloudDriveSettings/components/CloudDriveConnector.vue
@@ -91,6 +91,7 @@ export default {
           // note: if drawer was opened before and some drive finished its connecting this will close drawer
           // end loading connect button
           this.$set(provider, 'loading', false);
+          this.$emit('display-alert', this.$t('cloudDriveSettings.alert.successMessage'));
         },
         (error) => {
           if (error) {
@@ -101,6 +102,7 @@ export default {
           }
           // end loading connect button
           this.$set(provider, 'loading', false);
+          this.$emit('display-alert', this.$t('cloudDriveSettings.alert.errorMessage'), 'error');
 
           this.$emit('updateProgress', { progress: null }); // hide progress line at the top of composer
         },
@@ -113,6 +115,7 @@ export default {
           }
           // end loading connect button
           this.$set(provider, 'loading', false);
+          this.$emit('display-alert', this.$t('agenda.exchangeCalendar.settings.connection.errorMessage'), 'error');
 
           this.$emit('updateProgress', { progress: progressData.progress }); // update progress at the top of composer
         }

--- a/apps/portlet-clouddrives/src/main/webapp/vue-app/cloudDriveSettings/components/CloudDriveSettings.vue
+++ b/apps/portlet-clouddrives/src/main/webapp/vue-app/cloudDriveSettings/components/CloudDriveSettings.vue
@@ -43,7 +43,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       </v-list>
     </v-card>
     <cloud-drive-settings-drawer ref="cloudDriveSettingsDrawer" :connectors="enabledConnectors" />
-    <cloud-drive-connector @connectors-loaded="connectors = $event" />
+    <cloud-drive-connector @connectors-loaded="connectors = $event" @display-alert="displayAlert" />
+    <cloud-drive-alert />
   </v-app>
 </template>
 
@@ -60,6 +61,12 @@ export default {
   methods: {
     openDriveConnectorsDrawer() {
       this.$refs.cloudDriveSettingsDrawer.open();
+    },
+    displayAlert(message, type) {
+      this.$root.$emit('connectors-connection-alert', {
+        message,
+        type: type || 'success',
+      });
     }
   }
 };

--- a/apps/portlet-clouddrives/src/main/webapp/vue-app/cloudDriveSettings/initComponents.js
+++ b/apps/portlet-clouddrives/src/main/webapp/vue-app/cloudDriveSettings/initComponents.js
@@ -17,11 +17,13 @@
 import CloudDriveSettings from './components/CloudDriveSettings.vue';
 import CloudDriveSettingsDrawer from './components/CloudDriveSettingsDrawer.vue';
 import CloudDriveConnector from './components/CloudDriveConnector.vue';
+import CloudDriveAlert from './components/CloudDriveAlert.vue';
 
 const components = {
   'cloud-drive-settings': CloudDriveSettings,
   'cloud-drive-settings-drawer': CloudDriveSettingsDrawer,
   'cloud-drive-connector': CloudDriveConnector,
+  'cloud-drive-alert': CloudDriveAlert,
 };
 
 for (const key in components) {

--- a/core/webui-clouddrives/src/main/resources/locale/clouddrive/CloudDrive_en.xml
+++ b/core/webui-clouddrives/src/main/resources/locale/clouddrive/CloudDrive_en.xml
@@ -115,5 +115,9 @@
       </button>
       <noConnector>No personal drive connector available</noConnector>
     </drawer>
+    <alert>
+      <successMessage>Your cloud drive is connected correctly</successMessage>
+      <errorMessage>Failed connection</errorMessage>
+    </alert>
   </cloudDriveSettings>
 </bundle>


### PR DESCRIPTION
Prior to these changes, after connect action using any cloud drive connector, no information displayed to verify if the connection is established successfully or not.

After these changes, an information alert will be displayed after connect action to inform either the connection is success or failed.