### PR TITLE
Task-57047 : Access To Folder of a document from the preview mode

### DIFF
--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -564,7 +564,7 @@
               if (eXo.env.portal.spaceName){
                 if(path.includes('/Documents'){
                   const index = path.indexOf('/Documents');
-                  folderPath= `${baseurl}${path.substring(index+10)}`;
+                  folderPath= `${baseurl}${path.substring(index+10)`;
                 }
               } else {
                 if (path.includes('/Private')){

--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -560,7 +560,7 @@
             if (documentPreview.settings.doc.breadCrumb.hasOwnProperty(folderName)) {
               var folderPath = documentPreview.settings.doc.breadCrumb[folderName];
               var baseurl = folderPath.slice(0,folderPath.indexOf('?'));
-              var path =decodeURIComponent( folderPath.slice(folderPath.indexOf('?') , folderPath.indexOf('&')));
+              var path = decodeURIComponent(folderPath.slice(folderPath.indexOf('?'), folderPath.indexOf('&')));
               if (eXo.env.portal.spaceName){
                 if(path.includes('/Documents'){
                   const index = path.indexOf('/Documents');

--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -48,6 +48,7 @@
     isDownloadStatusActivated: true,
 
     init: function (docPreviewSettings) {
+
       $('.spaceButtomNavigation').addClass('hidden');
       if($('.commentsLoaded').length) {
         $("#documentPreviewContent").html('<div class="loading">' +
@@ -399,7 +400,7 @@
                 breadCrumbContent += '&nbsp;<i class="uiIconArrowRight"></i>&nbsp;';
                 breadCrumbContentTooltip += " > ";
               }
-              breadCrumbContent += '<a href="' + folderPath + '" onclick="event.stopPropagation();window.location.href=this.href">' + XSSUtils.escapeHtml(folderName) + '</a>';
+              breadCrumbContent += '<a href="' + decodeURI(folderPath) + '" onclick="event.stopPropagation();window.location.href=this.href">' + XSSUtils.escapeHtml(folderName) + '</a>';
               breadCrumbContentTooltip += folderName;
               folderIndex++;
             }
@@ -559,6 +560,27 @@
           for (var folderName in documentPreview.settings.doc.breadCrumb) {
             if (documentPreview.settings.doc.breadCrumb.hasOwnProperty(folderName)) {
               var folderPath = documentPreview.settings.doc.breadCrumb[folderName];
+              var baseurl = folderPath.slice(0,folderPath.indexOf('?'));
+              var path =decodeURIComponent( folderPath.slice(folderPath.indexOf('?') , folderPath.indexOf('&')));
+              if (eXo.env.portal.spaceName){
+                const index = path.indexOf('/Documents');
+                if (index !== -1){
+                  folderPath= `${baseurl}${path.substring(index+10)}`;
+                }
+              } else {
+                if (path.includes('/Private')){
+                  const index  = path.indexOf('/Private');
+                  if (index !== -1){
+                    folderPath= `${baseurl}${path.substring(index)}`;
+                  }
+                }
+                if (path.includes('/Public')){
+                  const index = path.indexOf('/Public');
+                  if (index !== -1){
+                    folderPath= `${baseurl}${path.substring(index)}`;
+                  }
+                } 
+              }
               if(folderIndex > 0) {
                 breadCrumbContent += '&nbsp;<i class="uiIconArrowRight"></i>&nbsp;';
                 breadCrumbContentTooltip += " > ";

--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -573,7 +573,7 @@
                 }
                 if (path.includes('/Public')){
                   const index = path.indexOf('/Public');
-                    folderPath= `${baseurl}${path.substring(index)}`;
+                  folderPath= `${baseurl}${path.substring(index)}`;
                 } 
               }
               if(folderIndex > 0) {

--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -569,15 +569,11 @@
               } else {
                 if (path.includes('/Private')){
                   const index  = path.indexOf('/Private');
-                  if (index !== -1){
                     folderPath= `${baseurl}${path.substring(index)}`;
-                  }
                 }
                 if (path.includes('/Public')){
                   const index = path.indexOf('/Public');
-                  if (index !== -1){
                     folderPath= `${baseurl}${path.substring(index)}`;
-                  }
                 } 
               }
               if(folderIndex > 0) {

--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -564,7 +564,7 @@
               if (eXo.env.portal.spaceName){
                 if(path.includes('/Documents'){
                   const index = path.indexOf('/Documents');
-                  folderPath= `${baseurl}${path.substring(index+10)`;
+                  folderPath= `${baseurl}${path.substring(index+10)}`;
                 }
               } else {
                 if (path.includes('/Private')){

--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -562,8 +562,8 @@
               var baseurl = folderPath.slice(0,folderPath.indexOf('?'));
               var path =decodeURIComponent( folderPath.slice(folderPath.indexOf('?') , folderPath.indexOf('&')));
               if (eXo.env.portal.spaceName){
-                const index = path.indexOf('/Documents');
-                if (index !== -1){
+                if(path.includes('/Documents'){
+                  const index = path.indexOf('/Documents');
                   folderPath= `${baseurl}${path.substring(index+10)}`;
                 }
               } else {

--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -400,7 +400,7 @@
                 breadCrumbContent += '&nbsp;<i class="uiIconArrowRight"></i>&nbsp;';
                 breadCrumbContentTooltip += " > ";
               }
-              breadCrumbContent += '<a href="' + decodeURI(folderPath) + '" onclick="event.stopPropagation();window.location.href=this.href">' + XSSUtils.escapeHtml(folderName) + '</a>';
+              breadCrumbContent += '<a href="' + folderPath + '" onclick="event.stopPropagation();window.location.href=this.href">' + XSSUtils.escapeHtml(folderName) + '</a>';
               breadCrumbContentTooltip += folderName;
               folderIndex++;
             }

--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -48,7 +48,6 @@
     isDownloadStatusActivated: true,
 
     init: function (docPreviewSettings) {
-
       $('.spaceButtomNavigation').addClass('hidden');
       if($('.commentsLoaded').length) {
         $("#documentPreviewContent").html('<div class="loading">' +

--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -569,7 +569,7 @@
               } else {
                 if (path.includes('/Private')){
                   const index  = path.indexOf('/Private');
-                    folderPath= `${baseurl}${path.substring(index)}`;
+                  folderPath= `${baseurl}${path.substring(index)}`;
                 }
                 if (path.includes('/Public')){
                   const index = path.indexOf('/Public');


### PR DESCRIPTION
ISSUE :When opening a file preview from the Recent tab of Drives app or other emplacements(attached file to an article),  then clicking on any folder from the path displayed at the bottom left corner of the document preview,  we can't access directly to this selected folder.
FIX : get the folder path from the breadcrumbPreview attachments.