### PR TITLE
Task-59123: Add progress loader in cloud drives connect button while connecting

### DIFF
--- a/apps/portlet-clouddrives/src/main/webapp/vue-app/cloudDriveSettings/components/CloudDriveConnector.vue
+++ b/apps/portlet-clouddrives/src/main/webapp/vue-app/cloudDriveSettings/components/CloudDriveConnector.vue
@@ -107,8 +107,6 @@ export default {
             this.$emit('updateDrivesInProgress', { drives: this.drivesInProgress }); // drives update in parent component
             this.openDriveFolder(progressData.drive.path, progressData.drive.title); // display drive in composer
           }
-          // end loading connect button
-          this.$set(provider, 'loading', false);
 
           this.$emit('updateProgress', { progress: progressData.progress }); // update progress at the top of composer
         }


### PR DESCRIPTION
Prior to this fix, during the connect action especially if the selected cloud drive is heavy and take a while to finish sync action, there is no progress indication to make the user waiting on.
After this fix, a progress loader will be added on the cloud drives connect button, it will disappear after finishing the sync process. 