### PR TITLE
Task-57047 : Access To Folder of a document from the preview mode

### DIFF
--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -562,18 +562,18 @@
               var baseurl = folderPath.slice(0,folderPath.indexOf('?'));
               var path = decodeURIComponent(folderPath.slice(folderPath.indexOf('?'), folderPath.indexOf('&')));
               if (eXo.env.portal.spaceName){
-                if(path.includes('/Documents'){
+                if(path.includes('/Documents')){
                   const index = path.indexOf('/Documents');
-                  folderPath= `${baseurl}${path.substring(index+10)}`;
+                  folderPath= baseurl.concat(path.substring(index+10));
                 }
               } else {
                 if (path.includes('/Private')){
                   const index  = path.indexOf('/Private');
-                  folderPath= `${baseurl}${path.substring(index)}`;
+                  folderPath= baseurl.concat(path.substring(index));
                 }
                 if (path.includes('/Public')){
                   const index = path.indexOf('/Public');
-                  folderPath= `${baseurl}${path.substring(index)}`;
+                  folderPath= baseurl.concat(path.substring(index));
                 } 
               }
               if(folderIndex > 0) {


### PR DESCRIPTION
ISSUE :When opening a file preview from the Recent tab of Drives app or other emplacements(attached file to an article), then clicking on any folder from the path displayed at the bottom left corner of the document preview, we can't access directly to this selected folder.
FIX : get the folder path from the breadcrumbPreview attachments.