### PR TITLE
Task-57047 : Access To Folder of a document from the preview mode (#1839)

### DIFF
--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -559,6 +559,23 @@
           for (var folderName in documentPreview.settings.doc.breadCrumb) {
             if (documentPreview.settings.doc.breadCrumb.hasOwnProperty(folderName)) {
               var folderPath = documentPreview.settings.doc.breadCrumb[folderName];
+              var baseurl = folderPath.slice(0,folderPath.indexOf('?'));
+              var path = decodeURIComponent(folderPath.slice(folderPath.indexOf('?'), folderPath.indexOf('&')));
+              if (eXo.env.portal.spaceName){
+                if(path.includes('/Documents')){
+                  const index = path.indexOf('/Documents');
+                  folderPath= baseurl.concat(path.substring(index+10));
+                }
+              } else {
+                if (path.includes('/Private')){
+                  const index  = path.indexOf('/Private');
+                  folderPath= baseurl.concat(path.substring(index));
+                }
+                if (path.includes('/Public')){
+                  const index = path.indexOf('/Public');
+                  folderPath= baseurl.concat(path.substring(index));
+                } 
+              }
               if(folderIndex > 0) {
                 breadCrumbContent += '&nbsp;<i class="uiIconArrowRight"></i>&nbsp;';
                 breadCrumbContentTooltip += " > ";


### PR DESCRIPTION
ISSUE :When opening a file preview from the Recent tab of Drives app or other emplacements(attached file to an article), then clicking on any folder from the path displayed at the bottom left corner of the document preview, we can't access directly to this selected folder.
FIX : get the folder path from the breadcrumb Preview attachments.
(cherry picked from commit bbdcf9d2b19b44fb8e0a015559fcc6ae393cdad5)