### PR TITLE
TASK-59178: Use PATCH annotation from Meeds WS implementation

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/clouddrives/FeaturesService.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/clouddrives/FeaturesService.java
@@ -28,7 +28,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
-import io.swagger.jaxrs.PATCH;
+import org.exoplatform.services.rest.http.PATCH;
 import org.exoplatform.commons.api.settings.SettingService;
 import org.exoplatform.commons.api.settings.SettingValue;
 import org.exoplatform.commons.api.settings.data.Scope;


### PR DESCRIPTION
Prior to this change, All endpoints those use http patch requests are using the swagger jaxrs PATCH annotation,
This PR should use the PATCH annotation from Meeds WS implementation instead of swagger jaxrs annotation