### PR TITLE
Task-58606: cant add files inside a folder which name contains special characters (#1835)

### DIFF
--- a/apps/portlet-clouddrives/package-lock.json
+++ b/apps/portlet-clouddrives/package-lock.json
@@ -478,7 +478,6 @@
         "merge-source-map": "^1.1.0",
         "postcss": "^7.0.36",
         "postcss-selector-parser": "^6.0.2",
-        "prettier": "^1.18.2 || ^2.0.0",
         "source-map": "~0.6.1",
         "vue-template-es2015-compiler": "^1.9.0"
       },

--- a/apps/portlet-documents/package-lock.json
+++ b/apps/portlet-documents/package-lock.json
@@ -483,7 +483,6 @@
         "merge-source-map": "^1.1.0",
         "postcss": "^7.0.36",
         "postcss-selector-parser": "^6.0.2",
-        "prettier": "^1.18.2 || ^2.0.0",
         "source-map": "~0.6.1",
         "vue-template-es2015-compiler": "^1.9.0"
       },

--- a/apps/portlet-documents/src/main/webapp/js/attachmentService.js
+++ b/apps/portlet-documents/src/main/webapp/js/attachmentService.js
@@ -1,4 +1,10 @@
 export function fetchFoldersAndFiles(currentDrive, workspace, parentPath) {
+  if (parentPath.startsWith('/')) {
+    parentPath = parentPath.substr(1);
+  }
+  if (parentPath.endsWith('/')) {
+    parentPath = parentPath.substr(0, parentPath.length - 1);
+  }
   return fetch(`/portal/rest/managedocument/getFoldersAndFiles/?driveName=${currentDrive}&workspaceName=${workspace}&currentFolder=${parentPath}`,
     {})
     .then(response => {

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
@@ -563,8 +563,15 @@ export default {
         const self = this;
         this.driveExplorerInitializing = true;
         //open it to generate the path
-        this.openDrive(this.defaultDrive).then(() => {
-          const defaultFolder = self.folders.find(folder => folder.title === self.defaultFolder);
+        let parentFolder = this.defaultFolder.substr(0, this.defaultFolder.lastIndexOf('/') + 1);
+        if (!parentFolder) {
+          parentFolder = '/';
+        }
+        if (!parentFolder.startsWith('/')) {
+          parentFolder = '/'.concat(parentFolder) ;
+        }
+        this.openDrive(this.defaultDrive, null, parentFolder).then(() => {
+          const defaultFolder = self.folders.find(folder => folder.name === self.defaultFolder.split('/').pop());
           if (self.entityType && self.entityId) {
             if (defaultFolder) {
               this.openFolder(defaultFolder).then(() => {
@@ -587,7 +594,10 @@ export default {
           } else if (self.defaultFolder.includes('/')){
             const pathParts= self.defaultFolder.split('/');
             const folderName = pathParts.pop();
-            const parentPath = pathParts.join('/');
+            let parentPath = pathParts.join('/');
+            if (!parentPath) {
+              parentPath = '/';
+            }
             this.fetchChildrenContents(parentPath).then(() => {
               const defaultFolder = self.folders.find(folder => folder.title === folderName);
               if (defaultFolder){
@@ -629,7 +639,7 @@ export default {
       this.privateDestinationForFile = folder.isPublic;
     },
 
-    openDrive(drive, group) {
+    openDrive(drive, group, parentPath) {
       this.currentAbsolutePath = '';
       this.selectedFolderPath = '';
       this.folderDestinationForFile = '';
@@ -642,7 +652,7 @@ export default {
         mainTitle: drive.mainTitle,
         isSelected: true
       };
-      return this.fetchChildrenContents('');
+      return this.fetchChildrenContents(parentPath);
     },
     fetchChildrenContents: function (parentPath) {
       this.loadingFolders = true;

--- a/apps/portlet-editors/package-lock.json
+++ b/apps/portlet-editors/package-lock.json
@@ -478,7 +478,6 @@
         "merge-source-map": "^1.1.0",
         "postcss": "^7.0.36",
         "postcss-selector-parser": "^6.0.2",
-        "prettier": "^1.18.2 || ^2.0.0",
         "source-map": "~0.6.1",
         "vue-template-es2015-compiler": "^1.9.0"
       },

--- a/apps/portlet-transferrules/package-lock.json
+++ b/apps/portlet-transferrules/package-lock.json
@@ -478,7 +478,6 @@
         "merge-source-map": "^1.1.0",
         "postcss": "^7.0.36",
         "postcss-selector-parser": "^6.0.2",
-        "prettier": "^1.18.2 || ^2.0.0",
         "source-map": "~0.6.1",
         "vue-template-es2015-compiler": "^1.9.0"
       },


### PR DESCRIPTION
Problem: in new document application we cant add files inside a folder which name contains special characters
The fix will reload the current folder correctly with its name instead of the title that may contain special characters, then reload all child folders of the parent folder to compare both before uploading the file.