### PR TITLE
Task-59203: Fix encoded special characters on preview's breadcrumb

### DIFF
--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -580,7 +580,7 @@
                 breadCrumbContent += '&nbsp;<i class="uiIconArrowRight"></i>&nbsp;';
                 breadCrumbContentTooltip += " > ";
               }
-              breadCrumbContent += '<a href="' + folderPath + '" onclick="event.stopPropagation();window.location.href=this.href">' + XSSUtils.escapeHtml(folderName) + '</a>';
+              breadCrumbContent += '<a href="' + folderPath + '" onclick="event.stopPropagation();window.location.href=this.href">' + folderName + '</a>';
               breadCrumbContentTooltip += folderName;
               folderIndex++;
             }


### PR DESCRIPTION
ISSUE : When user create or upload a new file inside folder  with name contain a special characters and open this file on preview mode , the right breadcrumb displayed encoded. 
The breadcrumb folder name is escaped html characters from  the back-end part  and also escaped in the front and that's cause the displayed encoded characters.
FIX : remove the unnecessary escape Html method  call in front-end part . 