### PR TITLE
EXO-59221: fix listing documents under Personal drive

### DIFF
--- a/apps/portlet-documents/src/main/webapp/js/attachmentService.js
+++ b/apps/portlet-documents/src/main/webapp/js/attachmentService.js
@@ -6,6 +6,8 @@ export function fetchFoldersAndFiles(currentDrive, workspace, parentPath) {
     if (parentPath.endsWith('/')) {
       parentPath = parentPath.substr(0, parentPath.length - 1);
     }
+  } else {
+    parentPath = '';
   }
   return fetch(`/portal/rest/managedocument/getFoldersAndFiles/?driveName=${currentDrive}&workspaceName=${workspace}&currentFolder=${parentPath}`,
     {})


### PR DESCRIPTION
Documents are n ot listed in some cases because the parentPath is undefined , and when we pass this value to the Rest call, it is converted to the String 'undefined' which does not represent a valid folder.
The fix ensures that all falsy values of parentPath are converted as empty String