### PR TITLE
Task-59221: fix listing documents under Personal drive

### DIFF
--- a/apps/portlet-documents/src/main/webapp/js/attachmentService.js
+++ b/apps/portlet-documents/src/main/webapp/js/attachmentService.js
@@ -1,9 +1,11 @@
 export function fetchFoldersAndFiles(currentDrive, workspace, parentPath) {
-  if (parentPath.startsWith('/')) {
-    parentPath = parentPath.substr(1);
-  }
-  if (parentPath.endsWith('/')) {
-    parentPath = parentPath.substr(0, parentPath.length - 1);
+  if(parentPath) {
+    if (parentPath.startsWith('/')) {
+      parentPath = parentPath.substr(1);
+    }
+    if (parentPath.endsWith('/')) {
+      parentPath = parentPath.substr(0, parentPath.length - 1);
+    }
   }
   return fetch(`/portal/rest/managedocument/getFoldersAndFiles/?driveName=${currentDrive}&workspaceName=${workspace}&currentFolder=${parentPath}`,
     {})

--- a/apps/portlet-documents/src/main/webapp/js/attachmentService.js
+++ b/apps/portlet-documents/src/main/webapp/js/attachmentService.js
@@ -6,6 +6,8 @@ export function fetchFoldersAndFiles(currentDrive, workspace, parentPath) {
     if (parentPath.endsWith('/')) {
       parentPath = parentPath.substr(0, parentPath.length - 1);
     }
+  } else {
+    parentPath = '';
   }
   return fetch(`/portal/rest/managedocument/getFoldersAndFiles/?driveName=${currentDrive}&workspaceName=${workspace}&currentFolder=${parentPath}`,
     {})

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityComposerAttachments.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityComposerAttachments.vue
@@ -52,11 +52,15 @@ export default {
   data: () => ({
     attachments: null,
     entityType: 'activity',
-    reminder: {}
+    reminder: {},
+    attachedFiles: {
+      type: Array,
+      default: () => []
+    }
   }),
   computed: {
     attachmentsLength() {
-      return this.files.length;
+      return this.attachedFiles.length;
     },
     displayAttachments() {
       return this.attachmentsLength > 0;
@@ -84,7 +88,8 @@ export default {
   },
   methods: {
     retrieveAttachments() {
-      this.attachments = JSON.parse(JSON.stringify(this.files));
+      this.attachedFiles = this.files;
+      this.attachments = JSON.parse(JSON.stringify(this.attachedFiles));
 
       this.files.forEach((attachment, index) => {
         if (this.activityId) {
@@ -111,15 +116,15 @@ export default {
         });
     },
     addAttachment(file) {
-      this.files.push(file.attachment);
-      document.dispatchEvent(new CustomEvent('activity-composer-edited', {detail: this.files}));
+      this.attachedFiles.push(file.attachment);
+      document.dispatchEvent(new CustomEvent('activity-composer-edited', {detail: this.attachedFiles}));
     },
     removeAttachment(file) {
-      const index = this.files.findIndex(attachment => attachment.id === file.id);
+      const index = this.attachedFiles.findIndex(attachment => attachment.id === file.id);
       if (index >= 0) {
-        this.files.splice(index, 1);
+        this.attachedFiles.splice(index, 1);
       }
-      document.dispatchEvent(new CustomEvent('activity-composer-edited', {detail: this.files}));
+      document.dispatchEvent(new CustomEvent('activity-composer-edited', {detail: this.attachedFiles}));
     },
     openComposerChangesReminder() {
       this.reminder = {

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadedFiles.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadedFiles.vue
@@ -107,7 +107,7 @@
             :allow-to-preview="false"
             :current-space="currentSpace"
             :current-drive="currentDrive"
-            :entityId="entityId"
+            :entity-id="entityId"
             allow-to-detach
             allow-to-edit />
         </span>


### PR DESCRIPTION
Documents are not listed in some cases because the parentPath is undefined , and when we pass this value to the Rest call, it is converted to the String 'undefined' which does not represent a valid folder.
The fix ensures that all false values of parentPath are converted as empty String : CHerry-picked from [PR](https://github.com/exoplatform/ecms/pull/1848)

Due to null value, an error was thrown when opening Personal documents from the Attachment drawer.
We added a check for nullity before invoking function that will list contents of a folder, and cleaned up the code to remove all warnings emitted by NPM : Cherry-picked from [PR](https://github.com/exoplatform/ecms/pull/1848)