### PR TITLE
TASK-50471: Add createCustomThumbnail function in thumbnail service

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/thumbnail/ThumbnailService.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/thumbnail/ThumbnailService.java
@@ -164,4 +164,14 @@ public interface ThumbnailService {
    * @return ComponentPlugin list
    */
   public List<ComponentPlugin> getComponentPlugins();
+
+  /**
+   * Creates a thumbnail with custom provided width and height
+   *
+   * @param imageContent original image content
+   * @param targetWidth target resized image width
+   * @param targetHeight target resized image height
+   * @return byte array of image content
+   */
+  byte[] createCustomThumbnail(byte [] imageContent, int targetWidth, int targetHeight) throws Exception;
 }

--- a/core/services/src/main/java/org/exoplatform/services/cms/thumbnail/impl/ThumbnailServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/thumbnail/impl/ThumbnailServiceImpl.java
@@ -17,6 +17,8 @@
 package org.exoplatform.services.cms.thumbnail.impl;
 
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -273,6 +275,23 @@ public class ThumbnailServiceImpl implements ThumbnailService {
 
   public List<ComponentPlugin> getComponentPlugins() {
     return plugins_;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public byte[] createCustomThumbnail(byte[] imageContent, int targetWidth, int targetHeight) throws Exception {
+    BufferedImage image = toBufferedImage(imageContent);
+    if (image != null) {
+      return ImageUtils.scaleImage(image, targetWidth, targetHeight).readAllBytes();
+    }
+    return imageContent;
+  }
+
+  private BufferedImage toBufferedImage(byte[] imageBytes) throws IOException {
+    ByteArrayInputStream bis = new ByteArrayInputStream(imageBytes);
+    return ImageIO.read(bis);
   }
 
   /**


### PR DESCRIPTION
Add createCustomThumbnail function in thumbnail service

Prior to this change, the existing scale function in thumbnail service are linked to jcr storage, each created thumbnail will be stored in jcr.
THis PR should add a new createCustomThumbnail function to scale images to custom given dimension without store in jcr