### PR TITLE
Task-57905: document name displaying encoded items

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -706,7 +706,7 @@ public class Utils {
       extention = oldName.substring(oldName.lastIndexOf("."));
       oldName = oldName.substring(0,oldName.lastIndexOf(".")) ;
     }
-    String specialChar = "&#*@.'\"\t\r\n$\\><:;[]/%|";
+    String specialChar = "&#*@.'\"\t\r\n$\\><:;[]/|";
     StringBuilder ret = new StringBuilder();
     for (int i = 0; i < oldName.length(); i++) {
       char currentChar = oldName.charAt(i);

--- a/core/services/src/test/java/org/exoplatform/services/cms/impl/UtilsTest.java
+++ b/core/services/src/test/java/org/exoplatform/services/cms/impl/UtilsTest.java
@@ -7,7 +7,6 @@ public class UtilsTest extends TestCase {
   public void testCleanName() {
     // Given
     String title1 = "test|test";
-    String title2 = "test%test";
     String title3 = "test&test";
     String title4 = "test@test";
     String title5 = "test$test";
@@ -30,7 +29,6 @@ public class UtilsTest extends TestCase {
 
     // When
     String titleClean1 = Utils.cleanName(title1);
-    String titleClean2 = Utils.cleanName(title2);
     String titleClean3 = Utils.cleanName(title3);
     String titleClean4 = Utils.cleanName(title4);
     String titleClean5 = Utils.cleanName(title5);
@@ -53,7 +51,6 @@ public class UtilsTest extends TestCase {
 
     // Then
     assertEquals(titleClean1,"test_test");
-    assertEquals(titleClean2,"test_test");
     assertEquals(titleClean3,"test_test");
     assertEquals(titleClean4,"test_test");
     assertEquals(titleClean5,"test_test");


### PR DESCRIPTION
**prior to change**, when i upload a file , the name of her contain special character (**%**) replaced by  (**_**) generated by a function **cleanName()** for example t'ask replaced by **t_2527ask** so when i decrypted  item document it not converted correctly
Fix : when i upload file i skipped  char **%** from  variable **specialChar**  to not consider as special character 