### PR TITLE
 TASK-59262: Several warning messages when uploading more than 20 files

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
@@ -192,20 +192,22 @@ export default {
         });
       }
 
-      newAttachedFiles.filter(file => !this.attachments.some(f => f.title === file.title)).forEach(newFile => {
-        this.queueUpload(newFile);
+      newAttachedFiles.filter(file => !this.attachments.some(f => f.title === file.title)).forEach((newFile,index) => {
+        if (this.attachments.length === this.maxFilesCount) {
+          if (this.newUploadedFiles[index-1] || index === 0){
+            this.$root.$emit('attachments-notification-alert', {
+              message: this.maxFileCountErrorLabel,
+              type: 'error',
+            });
+          }
+          return;
+        } else {
+          this.queueUpload(newFile);
+        }
       });
       this.$refs.uploadInput.value = null;
     },
     queueUpload: function (file) {
-      if (this.attachments.length >= this.maxFilesCount) {
-        this.$root.$emit('attachments-notification-alert', {
-          message: this.maxFileCountErrorLabel,
-          type: 'error',
-        });
-        return;
-      }
-
       const fileSizeInMb = file.size / this.BYTES_IN_MB;
       if (fileSizeInMb > this.maxFileSize) {
         this.$root.$emit('attachments-notification-alert', {


### PR DESCRIPTION
Prior to this change, when uplaod more than 21 files in the documents application, more than one warning message is displayed To fix this, Only one warning message displayed when maximum number of attachments list equals 21