### PR TITLE
fix: Fix previewing a shared document by its copied link - EXO-58927

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/DocumentEditorsRESTService.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/DocumentEditorsRESTService.java
@@ -23,7 +23,6 @@ import javax.annotation.security.RolesAllowed;
 import javax.jcr.AccessDeniedException;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.FormParam;
@@ -47,13 +46,13 @@ import org.exoplatform.services.cms.documents.impl.EditorProvidersHelper;
 import org.exoplatform.services.cms.documents.impl.EditorProvidersHelper.ProviderInfo;
 import org.exoplatform.services.cms.link.LinkManager;
 import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.core.ExtendedSession;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.Group;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.rest.resource.ResourceContainer;
 import org.exoplatform.services.security.ConversationState;
-import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
@@ -303,8 +302,8 @@ public class DocumentEditorsRESTService implements ResourceContainer {
    * @throws RepositoryException the repository exception
    */
   protected String getTargetFileId(String fileId, String workspace) throws RepositoryException {
-    Session systemSession = repositoryService.getCurrentRepository().getSystemSession(workspace);
-    Node node = systemSession.getNodeByUUID(fileId);
+    ExtendedSession systemSession = (ExtendedSession) repositoryService.getCurrentRepository().getSystemSession(workspace);
+    Node node = systemSession.getNodeByIdentifier(fileId);
     if (node.isNodeType(EXO_SYMLINK)) {
       node = linkManager.getTarget(node, true);
       if (node != null) {

--- a/core/services/src/main/java/org/exoplatform/services/attachments/utils/EntityBuilder.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/utils/EntityBuilder.java
@@ -24,6 +24,7 @@ import org.exoplatform.services.cms.documents.DocumentService;
 import org.exoplatform.services.cms.link.LinkManager;
 import org.exoplatform.services.cms.mimetype.DMSMimeTypeResolver;
 import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.core.ExtendedSession;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
@@ -72,8 +73,9 @@ public class EntityBuilder {
                                                     String attachmentId) throws Exception {
     Node attachmentNode = null;
     Permission acl = new Permission();
+    ExtendedSession extendedSession = (ExtendedSession) session;
     try {
-      attachmentNode = session.getNodeByUUID(attachmentId);
+      attachmentNode = extendedSession.getNodeByIdentifier(attachmentId);
     } catch (AccessDeniedException e) {
       Attachment privateAttachment = new Attachment();
       acl.setCanAccess(false);

--- a/core/services/src/test/java/org/exoplatform/services/attachments/service/AttachmentServiceTest.java
+++ b/core/services/src/test/java/org/exoplatform/services/attachments/service/AttachmentServiceTest.java
@@ -1,22 +1,24 @@
 package org.exoplatform.services.attachments.service;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.List;
 
-import javax.jcr.*;
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.Session;
+import javax.jcr.Workspace;
 
-import org.exoplatform.services.attachments.dao.AttachmentDAO;
-import org.exoplatform.services.attachments.storage.AttachmentStorageImpl;
-import org.exoplatform.services.attachments.utils.Utils;
-import org.exoplatform.services.cms.documents.*;
-import org.exoplatform.services.cms.drives.ManageDriveService;
-import org.exoplatform.services.cms.link.LinkManager;
-import org.exoplatform.services.cms.link.NodeFinder;
-import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
-import org.exoplatform.services.security.MembershipEntry;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -24,14 +26,30 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import org.exoplatform.commons.testing.BaseExoTestCase;
 import org.exoplatform.commons.utils.CommonsUtils;
-import org.exoplatform.component.test.*;
+import org.exoplatform.component.test.ConfigurationUnit;
+import org.exoplatform.component.test.ConfiguredBy;
+import org.exoplatform.component.test.ContainerScope;
+import org.exoplatform.services.attachments.dao.AttachmentDAO;
 import org.exoplatform.services.attachments.model.Attachment;
 import org.exoplatform.services.attachments.storage.AttachmentStorage;
+import org.exoplatform.services.attachments.storage.AttachmentStorageImpl;
+import org.exoplatform.services.attachments.utils.Utils;
+import org.exoplatform.services.cms.documents.DocumentEditorProvider;
+import org.exoplatform.services.cms.documents.DocumentService;
+import org.exoplatform.services.cms.documents.NewDocumentTemplate;
+import org.exoplatform.services.cms.documents.NewDocumentTemplateConfig;
+import org.exoplatform.services.cms.documents.NewDocumentTemplateProvider;
+import org.exoplatform.services.cms.drives.ManageDriveService;
+import org.exoplatform.services.cms.link.LinkManager;
+import org.exoplatform.services.cms.link.NodeFinder;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.config.RepositoryEntry;
+import org.exoplatform.services.jcr.core.ExtendedSession;
 import org.exoplatform.services.jcr.core.ManageableRepository;
 import org.exoplatform.services.jcr.ext.app.SessionProviderService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
+import org.exoplatform.services.security.MembershipEntry;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.manager.IdentityManager;
@@ -82,8 +100,8 @@ public class AttachmentServiceTest extends BaseExoTestCase {
   @Mock
   LinkManager                 linkManager;
 
-  @Mock
-  Session                     session;
+  @Mock(extraInterfaces = {ExtendedSession.class})
+  Session session;
 
   @Before
   public void setUp() throws Exception {
@@ -155,8 +173,9 @@ public class AttachmentServiceTest extends BaseExoTestCase {
     Node node1 = mock(Node.class);
     Node nodeContent1 = mock(Node.class);
     Property property = mock(Property.class);
-    when(session.getNodeByUUID(anyString())).thenReturn(node1);
     Workspace workSpace = mock(Workspace.class);
+    when(((ExtendedSession) session).getNodeByIdentifier(anyString())).thenReturn(node1);
+    when(session.getNodeByUUID(anyString())).thenReturn(node1);
     when(session.getWorkspace()).thenReturn(workSpace);
     lenient().when(node1.getSession()).thenReturn(session);
     lenient().when(node1.getProperty(anyString())).thenReturn(property);
@@ -166,11 +185,13 @@ public class AttachmentServiceTest extends BaseExoTestCase {
     lenient().when(property.getLong()).thenReturn((long) 1);
     lenient().when(node1.getPath()).thenReturn("/collaboration/");
     lenient().when(session.getNodeByUUID(String.valueOf(1))).thenReturn(node1);
+    lenient().when(((ExtendedSession) session).getNodeByIdentifier(String.valueOf(1))).thenReturn(node1);
 
     Node node2 = mock(Node.class);
     Node nodeContent2 = mock(Node.class);
     Property property2 = mock(Property.class);
     when(session.getNodeByUUID(anyString())).thenReturn(node2);
+    when(((ExtendedSession) session).getNodeByIdentifier(anyString())).thenReturn(node2);
     when(session.getWorkspace()).thenReturn(workSpace);
     lenient().when(node2.getSession()).thenReturn(session);
     lenient().when(node2.getProperty(anyString())).thenReturn(property2);
@@ -180,11 +201,13 @@ public class AttachmentServiceTest extends BaseExoTestCase {
     lenient().when(property2.getLong()).thenReturn((long) 2);
     lenient().when(node2.getPath()).thenReturn("/collaboration/");
     lenient().when(session.getNodeByUUID(String.valueOf(2))).thenReturn(node2);
+    lenient().when(((ExtendedSession) session).getNodeByIdentifier(String.valueOf(2))).thenReturn(node2);
 
     Node node3 = mock(Node.class);
     Node nodeContent3 = mock(Node.class);
     Property property3 = mock(Property.class);
     when(session.getNodeByUUID(anyString())).thenReturn(node3);
+    when(((ExtendedSession) session).getNodeByIdentifier(anyString())).thenReturn(node3);
     lenient().when(session.getWorkspace()).thenReturn(workSpace);
     lenient().when(node3.getSession()).thenReturn(session);
     lenient().when(node3.getProperty(anyString())).thenReturn(property3);
@@ -193,7 +216,8 @@ public class AttachmentServiceTest extends BaseExoTestCase {
     lenient().when(property3.getDate()).thenReturn(Calendar.getInstance());
     lenient().when(property3.getLong()).thenReturn((long) 3);
     lenient().when(node3.getPath()).thenReturn("/collaboration/");
-    Mockito.when(session.getNodeByUUID(String.valueOf(3))).thenReturn(node3);
+    when(session.getNodeByUUID(String.valueOf(3))).thenReturn(node3);
+    when(((ExtendedSession) session).getNodeByIdentifier(String.valueOf(3))).thenReturn(node3);
 
     String username = "testuser";
     long currentIdentityId = 2;
@@ -295,7 +319,7 @@ public class AttachmentServiceTest extends BaseExoTestCase {
     lenient().when(node1.getPath()).thenReturn("/collaboration/");
     lenient().when(node1.getName()).thenReturn(docTitle);
     lenient().when(node1.getUUID()).thenReturn(createdDocUUID);
-    lenient().when(session.getNodeByUUID(createdDocUUID)).thenReturn(node1);
+    lenient().when(((ExtendedSession) session).getNodeByIdentifier(createdDocUUID)).thenReturn(node1);
     lenient().when(Utils.getParentFolderNode(session, manageDriveService,nodeHierarchyCreator, nodeFinder, pathDrive, docPath)).thenReturn(parentNode);
     lenient().when(documentService.createDocumentFromTemplate(parentNode, docTitle, documentTemplate)).thenReturn(node1);
     lenient().when(documentService.getNewDocumentTemplateProviders()).thenReturn(Collections.singletonList(documentTemplateProvider));

--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/document/service/rest/ContentViewerRESTService.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/document/service/rest/ContentViewerRESTService.java
@@ -40,6 +40,7 @@ import org.exoplatform.resolver.ResourceResolver;
 import org.exoplatform.services.cms.link.LinkManager;
 import org.exoplatform.services.cms.templates.TemplateService;
 import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.core.ExtendedSession;
 import org.exoplatform.services.jcr.core.ManageableRepository;
 import org.exoplatform.services.jcr.ext.app.SessionProviderService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
@@ -95,8 +96,8 @@ public class ContentViewerRESTService implements ResourceContainer {
     String content = null;
     try {
       ManageableRepository repository = repositoryService.getCurrentRepository();
-      Session session = getSystemProvider().getSession(workspaceName, repository);
-      Node contentNode = session.getNodeByUUID(uuid);
+      ExtendedSession session = (ExtendedSession) getSystemProvider().getSession(workspaceName, repository);
+      Node contentNode = session.getNodeByIdentifier(uuid);
 
       if(contentNode != null && contentNode.isNodeType(NodetypeConstant.EXO_SYMLINK)) {
         contentNode = linkManager.getTarget(contentNode);


### PR DESCRIPTION

Prior to this change, we are not able to preview a shared document by its copied link since it is not possible to retrieve to corresponding symlink node using session.getNodeByUUID(). To fix that, we use extendedSession.getNodeByIdentifier in order to retrieve correctly the symlink node and preview it correctly.