### PR TITLE
fix: Fix recreating the activity stream attachments folder after delete or move it from root path - EXO-59928

### DIFF
--- a/apps/portlet-documents/src/main/webapp/js/attachmentService.js
+++ b/apps/portlet-documents/src/main/webapp/js/attachmentService.js
@@ -56,8 +56,26 @@ export function getDrivers() {
     });
 }
 
-export function createFolder(currentDrive, workspace, parentPath, newFolderName) {
-  return fetch(`/portal/rest/managedocument/createFolder?driveName=${currentDrive}&workspaceName=${workspace}&currentFolder=${parentPath}&folderName=${newFolderName}`, {})
+export function createFolder(currentDrive, workspace, parentPath, newFolderName, folderNodeType) {
+  const formData = new FormData();
+  if (currentDrive) {
+    formData.append('driveName', currentDrive);
+  }
+  if (workspace) {
+    formData.append('workspaceName', workspace);
+  }
+  if (parentPath) {
+    formData.append('currentFolder', parentPath);
+  }
+  if (newFolderName) {
+    formData.append('folderName', newFolderName);
+  }
+  if (folderNodeType) {
+    formData.append('folderNodeType', folderNodeType);
+  }
+  const params = new URLSearchParams(formData).toString();
+
+  return fetch(`/portal/rest/managedocument/createFolder?${params}`, {})
     .then(response => {
       if (response.ok) {
         return response.text();

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
@@ -581,7 +581,9 @@ export default {
               }).finally(() => this.driveExplorerInitializing = false);
             // create a default folder for activity attachments if it doesn't exist
           } else if (!defaultFolder && self.defaultFolder === 'Activity Stream Documents') {
-            this.$attachmentService.createFolder(self.currentDrive.name, self.workspace, this.currentAbsolutePath, self.defaultFolder);
+            this.$attachmentService.createFolder(self.currentDrive.name, self.workspace, this.currentAbsolutePath, self.defaultFolder, 'nt:unstructured').then(() => {
+              this.initDestinationFolderPath();
+            });
             //else if no default folder create file in root folder
           } else if (self.defaultFolder.includes('/')){
             const pathParts= self.defaultFolder.split('/');

--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
@@ -320,7 +320,7 @@ public class ManageDocumentService implements ResourceContainer {
     try {
       Node node = getNode(driveName, workspaceName, currentFolder);
       // The name automatically determined from the title according to the current algorithm.
-      String name = Text.escapeIllegalJcrChars(org.exoplatform.services.cms.impl.Utils.cleanString(folderName));
+      String name = Text.escapeIllegalJcrChars(Utils.cleanName(folderName));
       // Set default name if new title contain no valid character
       name = (StringUtils.isEmpty(name)) ? DEFAULT_NAME : name;
 


### PR DESCRIPTION
Prior to this change, when delete or move the activity stream attachments folder, the attachment drawer is no more able to recreate it again and upload attachments inside due to a bad manipulation while creating the folder, in backend service, and a missing internalization after recreation it in frontend in the attachment drawer. This PR should make sure to correctly create the folder with its correct name and node type and reinitialize the drawer in case of recreating the folder.