### PR TITLE
fix: Fix lost extension after renaming a document - EXO-60015

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
@@ -434,8 +434,8 @@ public class FileUploadHandler {
                                String existenceAction,
                                boolean isNewVersion) throws Exception {
     fileName = Utils.cleanNameWithAccents(fileName);
-    fileName = Utils.cleanName(fileName);
     String exoTitle = fileName;
+    fileName = Utils.cleanName(fileName);
     try {
       CacheControl cacheControl = new CacheControl();
       cacheControl.setNoCache(true);

--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -701,7 +701,7 @@ public class Utils {
 
   public static String cleanName(String oldName) {
     if (StringUtils.isEmpty(oldName)) return oldName;
-    String extension ="" ;
+    String extension = "" ;
     if(oldName.lastIndexOf(".") > -1){
       extension = oldName.substring(oldName.lastIndexOf("."));
       oldName = oldName.substring(0,oldName.lastIndexOf(".")) ;

--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -701,9 +701,9 @@ public class Utils {
 
   public static String cleanName(String oldName) {
     if (StringUtils.isEmpty(oldName)) return oldName;
-    String extention ="" ;
+    String extension ="" ;
     if(oldName.lastIndexOf(".") > -1){
-      extention = oldName.substring(oldName.lastIndexOf("."));
+      extension = oldName.substring(oldName.lastIndexOf("."));
       oldName = oldName.substring(0,oldName.lastIndexOf(".")) ;
     }
     String specialChar = "&#*@.'\"\t\r\n$\\><:;[]/|";
@@ -716,7 +716,7 @@ public class Utils {
         ret.append(currentChar);
       }
     }
-    ret.append(extention);
+    ret.append(extension);
     return ret.toString();
   }
 


### PR DESCRIPTION
Prior to change there is a regression caused by https://github.com/exoplatform/ecms/pull/1817, so the modification is reverted, no need to change the title since it is a property that does not need to be neither cleaned nor escaped for its illegal JCR characters.