### PR TITLE
fix: fix owner property of activity stream attachments folder - EXO-59928

### DIFF
--- a/apps/portlet-documents/src/main/webapp/js/attachmentService.js
+++ b/apps/portlet-documents/src/main/webapp/js/attachmentService.js
@@ -56,7 +56,7 @@ export function getDrivers() {
     });
 }
 
-export function createFolder(currentDrive, workspace, parentPath, newFolderName, folderNodeType) {
+export function createFolder(currentDrive, workspace, parentPath, newFolderName, folderNodeType, isSystem) {
   const formData = new FormData();
   if (currentDrive) {
     formData.append('driveName', currentDrive);
@@ -72,6 +72,9 @@ export function createFolder(currentDrive, workspace, parentPath, newFolderName,
   }
   if (folderNodeType) {
     formData.append('folderNodeType', folderNodeType);
+  }
+  if (isSystem) {
+    formData.append('isSystem', isSystem);
   }
   const params = new URLSearchParams(formData).toString();
 

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
@@ -581,7 +581,7 @@ export default {
               }).finally(() => this.driveExplorerInitializing = false);
             // create a default folder for activity attachments if it doesn't exist
           } else if (!defaultFolder && self.defaultFolder === 'Activity Stream Documents') {
-            this.$attachmentService.createFolder(self.currentDrive.name, self.workspace, this.currentAbsolutePath, self.defaultFolder, 'nt:unstructured').then(() => {
+            this.$attachmentService.createFolder(self.currentDrive.name, self.workspace, this.currentAbsolutePath, self.defaultFolder, 'nt:unstructured', true).then(() => {
               this.initDestinationFolderPath();
             });
             //else if no default folder create file in root folder


### PR DESCRIPTION
Prior to this change, when recreate the activity stream attachments folder, the session used was the one of the current user wich gives the owner permission to the current creator user. This PR should add an isSystem flag for create folder endpoint to manage such system folders with system session