### PR TITLE
Fix: fix created version content on choose createNewVersion option - EXO-60233

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
@@ -556,7 +556,6 @@ public class FileUploadHandler {
         jcrContent = file.addNode("jcr:content","nt:resource");
       }else if(parent.hasNode(nodeName)){
         file = parent.getNode(nodeName);
-        autoVersionService.autoVersion(file,isNewVersion);
         jcrContent = file.hasNode("jcr:content")?file.getNode("jcr:content"):file.addNode("jcr:content","nt:resource");
       } else if(parent.isNodeType(NodetypeConstant.NT_FILE)){
         file = parent;
@@ -567,6 +566,11 @@ public class FileUploadHandler {
       jcrContent.setProperty("jcr:lastModified", new GregorianCalendar());
       jcrContent.setProperty("jcr:data", new BufferedInputStream(new FileInputStream(new File(location))));
       jcrContent.setProperty("jcr:mimeType", mimetype);
+
+      if(parent.hasNode(nodeName) && CREATE_VERSION.equals(existenceAction)) {
+        file.save();
+        autoVersionService.autoVersion(file,isNewVersion);
+      }
       if(fileCreated) {
         file.getParent().save();
         autoVersionService.autoVersion(file,isNewVersion);


### PR DESCRIPTION
Prior to this change, when choose create a new version the already used function was creating the version then update the file content, which will be resulted in an updates in root version and an old content in the newly created version.
This PR should make sure to create a version after updating the file content