### PR TITLE
fix: Fix file preview height when hiding breadcrumb - EXO-60206

### DIFF
--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -1337,7 +1337,7 @@
 
   // Resize Event
   var resizeEventHandler = function() {
-    var pdfDisplayAreaHeight = window.innerHeight - 70 - ((documentPreview.settings.doc.fileInfo || documentPreview.settings.doc.breadCrumb) ? 55 : 0);
+    var pdfDisplayAreaHeight = window.innerHeight - 125;
     var $uiDocumentPreview = $('#uiDocumentPreview');
 
     // Show empty preview message


### PR DESCRIPTION
Prior to this change, when hideing the file preveiw breadcrumb, the title of the document will be hidden because of the preview height. This PR should make sure to keep same preview display height when hiding the breadcrumb to avoid hiding the document title