### PR TITLE
fix: Fix recent documents display in my work tab of snapshot documents portlet -EXO-60243

### DIFF
--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/FileSearchRestService.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/FileSearchRestService.java
@@ -78,9 +78,6 @@ public class FileSearchRestService implements ResourceContainer {
                                         @Parameter(description = "Tag names list") @Schema(defaultValue = "false") @QueryParam("tags") List<String> tagNames
                                         ) throws Exception {
 
-    if (StringUtils.isBlank(query) && !favorites && CollectionUtils.isEmpty(tagNames)) {
-      return Response.status(Response.Status.BAD_REQUEST).entity("'query' parameter is mandatory").build();
-    }
     if (limit <= 0) {
       limit = DEFAULT_LIMIT;
     }


### PR DESCRIPTION
Prior to this change, my work tab of snapshot documents portlet is empty, no recent documents are displayed. It is caused by a 404 error mentioning that query param is required in rest API call. After this change, since query param is not mandatory, we have fixed that by removing the check on mandatory query pram in order to ensure displaying recent documents properly in my work tab.