### PR TITLE
fix: Fix source mode view problem on ckeditor when creating or editing a web content

### DIFF
--- a/apps/portlet-explorer/src/main/webapp/javascript/eXo/ecm/ckeditorCustom/config.js
+++ b/apps/portlet-explorer/src/main/webapp/javascript/eXo/ecm/ckeditorCustom/config.js
@@ -23,13 +23,12 @@ CKEDITOR.editorConfig = function( config ) {
     // The configuration options below are needed when running CKEditor from source files.
     CKEDITOR.plugins.addExternal('simpleLink','/commons-extension/eXoPlugins/simpleLink/','plugin.js');
     CKEDITOR.plugins.addExternal('simpleImage','/commons-extension/eXoPlugins/simpleImage/','plugin.js');
-    CKEDITOR.plugins.addExternal('suggester','/commons-extension/eXoPlugins/suggester/','plugin.js');
 	CKEDITOR.plugins.addExternal('content','/eXoWCMResources/eXoPlugins/content/','plugin.js');
 	CKEDITOR.plugins.addExternal('insertPortalLink','/commons-extension/eXoPlugins/insertPortalLink/','plugin.js');
 	CKEDITOR.plugins.addExternal('wcmImage','/eXoWCMResources/eXoPlugins/wcmImage/','plugin.js');
   
     //TODO we should ensure adding these plugins
-    config.extraPlugins = 'simpleLink,simpleImage,suggester,content,insertPortalLink,wcmImage';
+    config.extraPlugins = 'simpleLink,simpleImage,content,insertPortalLink,wcmImage';
 
     // Move toolbar below the test area
     config.toolbarLocation = 'bottom';
@@ -85,10 +84,4 @@ CKEDITOR.editorConfig = function( config ) {
     config.autoGrow_minHeight = 80;
 
     config.language = eXo.env.portal.language || 'en';
-    config.suggester = {
-        suffix: ' ',
-        renderMenuItem: '<li data-value="${uid}"><div class="avatarSmall" style="display: inline-block;"><img src="${avatar}"></div>${name} (${uid})</li>',
-        renderItem: '<span class="exo-mention">${name}<a href="#" class="remove"><i class="uiIconClose uiIconLightGray"></i></a></span>',
-        sourceProviders: ['exo:people']
-    };
 };


### PR DESCRIPTION
Prior to this change, we have many js errors in browser console and no action (save, save and close ...) is possible when we want to create or edit a web-content, use source mode view on ckeditor then return to normal mode view. This is due to a problem with suggester plugin which should be removed. After this commit, we ensure to remove this useless plugin in order to make other plugins work correctly.

(cherry picked from commit bbb8a54f71561254c93c5308ccf6190599bae0dc)