### PR TITLE
fix: Fix documents disappears from "My work" snapshot documents widget tab when they are modified by another user - EXO-58370

### DIFF
--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/FileSearchRestService.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/FileSearchRestService.java
@@ -183,8 +183,7 @@ public class FileSearchRestService implements ResourceContainer {
   private ElasticSearchFilter filterMyWorkingDocuments() {
     String userId = ConversationState.getCurrent().getIdentity().getUserId();
     StringBuilder recentFilter = new StringBuilder();
-    recentFilter.append("\"should\" : {\n \"term\" : { \"author\" : \"" + userId + "\" }\n },\n");
-    recentFilter.append("\"must\" : {\n \"term\" : { \"lastModifier\" : \"" + userId + "\" }\n }");
+    recentFilter.append("\"should\" :[\n{\n \"term\" : { \"author\" : \"" + userId + "\" }\n },{\n \"term\" : { \"lastModifier\" : \"" + userId + "\" }\n }\n]");
     return new ElasticSearchFilter(ElasticSearchFilterType.FILTER_MY_WORK_DOCS, "", recentFilter.toString());
   }
 


### PR DESCRIPTION
Prior to this change, when a user creates a document and the document is modified by another user, the document disappears from the list of tab "MY WORK". 
The problem is that the document appears only for the last modifier. After this change, we fix the Elasticsearch filter to display the documents for which I'm the author or the last modifier.