### PR TITLE
fix: Force videos to display thumbnail in Safari - EXO-42230

### DIFF
--- a/core/viewer/src/main/resources/resources/templates/HTML5VideoViewer.gtmpl
+++ b/core/viewer/src/main/resources/resources/templates/HTML5VideoViewer.gtmpl
@@ -41,6 +41,8 @@
   RepositoryService rService = uicomponent.getApplicationComponent(RepositoryService.class);
   String repository = rService.getCurrentRepository().getConfiguration().getName();
   def binarySrc = Utils.getWebdavURL(currentNode);
+  // force retrieving an image for video thumbnail
+  binarySrc += "#t=0.001";
 %>
 
   <video src="$binarySrc" controls="controls" class="videoContent">


### PR DESCRIPTION

Prior to this fix, HTML video tag was not showing video thumbnail in files preview, it shows a grey image. This fix will force the preview of the video thumbnail by forcing read the first millisecond of the video.