### PR TITLE
fix: Image can't be saved after selection from computer -EXO-60730

### DIFF
--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/UISelectImage.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/UISelectImage.js
@@ -546,7 +546,9 @@
               });
             }
           })
-              .then(xmlStr => (new window.DOMParser()).parseFromString(xmlStr, 'text/xml'))
+              .then(xmlStr => {
+                return (new window.DOMParser()).parseFromString(xmlStr, 'text/xml');
+              })
               .then(xml => {
                 if (xml) {
                   return xml.childNodes[0].attributes[0].value;


### PR DESCRIPTION
Prior to this change, when creating a new note and clicking on the upload image button from the insert plugin drawer of notes ckeditor, the upload process does not finish correctly. After this change the upload process works correctly for all browsers.