### PR TITLE
fix: No version in the history version drawer if a file is created : EXO-61044 (#1955)

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImpl.java
@@ -586,6 +586,10 @@ public class DocumentServiceImpl implements DocumentService {
     listenerService.broadcast(ActivityCommonService.FILE_CREATED_ACTIVITY, null, addedNode);
     currentNode.save();
     data.close();
+    AutoVersionService autoVersionService = WCMCoreUtils.getService(AutoVersionService.class);
+    if(autoVersionService != null) {
+      autoVersionService.autoVersion(addedNode);
+    }
     return addedNode;
   }
 


### PR DESCRIPTION
prior to this change, after creating a document (Excel, Word, PPT), the history version drawer is empty since no version is added after this change, auto version is added after creating a document