### PR TITLE
feat: Add an option to allow directly open attachments in editor by bypassing the preview step - EXO-60484

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/Attachment.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/Attachment.vue
@@ -16,7 +16,9 @@
         :files="files" />
       <attachments-list-drawer
         ref="attachmentsListDrawer"
-        :attachments="attachments" />
+        :supported-documents="supportedDocuments"
+        :attachments="attachments"
+        :open-attachments-in-editor="openAttachmentsInEditor" />
       <attachments-notification-alerts />
     </div>
   </v-app>
@@ -37,6 +39,8 @@ export default {
       sourceApp: null,
       drawerList: false,
       attachToEntity: true,
+      supportedDocuments: null,
+      openAttachmentsInEditor: false
     };
   },
   computed: {
@@ -80,11 +84,16 @@ export default {
           this.openAttachmentsDrawerList();
         });
     });
+    document.addEventListener('documents-supported-document-types-updated', this.refreshSupportedDocumentExtensions);
+    this.refreshSupportedDocumentExtensions();
   },
   mounted() {
     this.$root.$applicationLoaded();
   },
   methods: {
+    refreshSupportedDocumentExtensions () {
+      this.supportedDocuments = extensionRegistry.loadExtensions('documents', 'supported-document-types');
+    },
     openAttachmentsAppDrawer() {
       this.$root.$emit('open-attachments-app-drawer');
     },
@@ -111,6 +120,7 @@ export default {
       }
       this.entityType = config.entityType;
       this.entityId = config.entityId;
+      this.openAttachmentsInEditor = config.openAttachmentsInEditor || false;
       return this.initDefaultDrive();
     },
     startLoadingList() {

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsListDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsListDrawer.vue
@@ -37,6 +37,8 @@
             :key="attachment"
             class="list-complete-item">
             <attachment-item
+              :open-in-editor="openAttachmentsInEditor"
+              :is-file-editable="isFileEditable(attachment)"
               :allow-to-edit="false"
               :attachment="attachment"
               :can-access="attachment.acl && attachment.acl.canAccess"
@@ -63,11 +65,24 @@ export default {
       type: Array,
       default: () => []
     },
+    supportedDocuments: {
+      type: Array,
+      default: () => []
+    },
+    openAttachmentsInEditor: {
+      type: Boolean,
+      default: () => false
+    }
   },
   created() {
     this.$root.$on('open-attachments-list-drawer', () => this.openAttachmentsListDrawer());
   },
   methods: {
+    isFileEditable(attachment) {
+      const type = attachment && attachment.mimetype || '';
+      return this.supportedDocuments && this.supportedDocuments.filter(doc => doc.edit && doc.mimeType === type
+          && !attachment.cloudDriveFile).length > 0;
+    },
     startLoading() {
       this.$refs.attachmentsListDrawer.startLoading();
     },

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
@@ -4,7 +4,7 @@
       <v-list-item-avatar
         :class="smallAttachmentIcon ? 'me-0' :'me-3'"
         class="border-radius"
-        @click="openPreview()">
+        @click="openFile()">
         <div v-if="attachment.uploadProgress < 100" class="fileProgress">
           <v-progress-circular
             :rotate="-90"
@@ -26,7 +26,7 @@
           </v-icon>
         </div>
       </v-list-item-avatar>
-      <v-list-item-content @click="openPreview()">
+      <v-list-item-content @click="openFile()">
         <v-list-item-title class="uploadedFileTitle" :title="attachmentTitle">
           {{ attachmentTitle || notAccessibleAttachmentTitle }}
         </v-list-item-title>
@@ -125,6 +125,14 @@ export default {
       default: true
     },
     allowToPreview: {
+      type: Boolean,
+      default: false
+    },
+    openInEditor: {
+      type: Boolean,
+      default: false
+    },
+    isFileEditable: {
       type: Boolean,
       default: false
     },
@@ -295,6 +303,18 @@ export default {
     },
     fileInfo() {
       return `${this.$t('documents.preview.updatedOn')} ${this.absoluteDateModified()} ${this.$t('documents.preview.updatedBy')} ${this.attachment.lastEditor} ${this.attachment.size}`;
+    },
+    openFileInEditor() {
+      if (this.attachment && this.attachment.id) {
+        window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/oeditor?docId=${this.attachment.id}&source=peview`, '_blank');
+      }
+    },
+    openFile() {
+      if (this.openInEditor && this.isFileEditable && this.attachment.acl?.canEdit) {
+        this.openFileInEditor();
+      } else {
+        this.openPreview();
+      }
     },
     openPreview() {
       if (this.allowToPreview && this.attachment.id) {


### PR DESCRIPTION
Add an option to allow directly open attachments in editor by bypassing the preview step in attachments list drawer