### PR TITLE
fix: Refresh needed to display created document - EXO-61166 (#1958)

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
@@ -241,9 +241,8 @@ export default {
     this.$root.$on('add-new-created-document', (doc) =>{
       this.creationType = this.$t('attachments.added.by.platform');
       this.addNewCreatedDocument(doc);
-    }
-    );
-    this.getCloudDriveStatus();
+      document.dispatchEvent(new CustomEvent('entity-attachments-updated'));
+    });
     document.addEventListener('extension-AttachmentsComposer-attachments-composer-action-updated', () => this.attachmentsComposerActions = getAttachmentsComposerExtensions());
     this.attachmentsComposerActions = getAttachmentsComposerExtensions();
   },

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachment-document-creator/AttachmentCreateDocumentInput.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachment-document-creator/AttachmentCreateDocumentInput.vue
@@ -179,7 +179,10 @@ export default {
         doc.drive = this.currentDrive.title;
         doc.date = doc.created;
         this.$root.$emit('add-new-created-document', doc);
-        this.$root.$emit('end-loading-attachment-drawer');
+        this.$root.$emit('attachments-notification-alert', {
+          message: this.$t('attachments.upload.success'),
+          type: 'success',
+        });
         this.resetNewDocInput();
         window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/oeditor?docId=${doc.id}`, '_blank');
       }


### PR DESCRIPTION
prior to this change, a refresh is needed after creating to display into the files list. after this change, after adding the document an event is sent to update the list and success alert is displayeds

(cherry picked from commit f7c0b89b710781e8c81df2c6760d1c423e262a64)