### PR TITLE
Exclude imgscalr packaging to avoid conflict with Meeds during addon install

### DIFF
--- a/ecms-packaging/src/main/assemblies/ecms-addon-package.xml
+++ b/ecms-packaging/src/main/assemblies/ecms-addon-package.xml
@@ -42,7 +42,6 @@
       <includes>
         <include>org.exoplatform.ecms:*:jar</include>
         <include> org.icepdf.os:icepdf-core:jar</include>
-        <include>org.imgscalr:imgscalr-lib:jar</include>
         <include>com.totsp.feedpod:itunes-com-podcast:jar</include>
         <include>com.sun.media:jai-codec:jar</include>
         <include>com.sun.media:jai-core:jar</include>


### PR DESCRIPTION
Regression from https://github.com/Meeds-io/commons/commit/26b8aeb453a55640efd5edc5fab62d5242c1cb3c