### PR TITLE
fix: restore cloud drive portlet - EXO-61440

### DIFF
--- a/apps/portlet-clouddrives/src/main/java/org/exoplatform/services/cms/clouddrives/portlet/CloudDrivePortlet.java
+++ b/apps/portlet-clouddrives/src/main/java/org/exoplatform/services/cms/clouddrives/portlet/CloudDrivePortlet.java
@@ -1,0 +1,60 @@
+
+/*
+ * Copyright (C) 2003-2022 eXo Platform SAS.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.exoplatform.services.cms.clouddrives.portlet;
+
+import java.io.IOException;
+
+import javax.portlet.GenericPortlet;
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import org.exoplatform.ecm.webui.clouddrives.CloudDriveContext;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.webui.application.WebuiRequestContext;
+
+/**
+ * Created by The eXo Platform SAS
+ * 
+ * @author <a href="mailto:pnedonosko@exoplatform.com">Peter Nedonosko</a>
+ * @version $Id: CloudDrivePortlet.java 00000 Jul 6, 2018 pnedonosko $
+ */
+public class CloudDrivePortlet extends GenericPortlet {
+
+  /** The Constant LOG. */
+  private static final Log LOG = ExoLogger.getLogger(CloudDrivePortlet.class);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected void doView(final RenderRequest request, final RenderResponse response) throws PortletException, IOException {
+    final String remoteUser = request.getRemoteUser();
+    try {
+      // We init core script w/o context workspace and path, this will init
+      // global UI enhancements (for Search etc.)
+      CloudDriveContext.init(WebuiRequestContext.getCurrentInstance());
+    } catch (Exception e) {
+      LOG.error("Error processing Cloud Drive portlet for user " + remoteUser, e);
+    }
+  }
+
+}

--- a/apps/portlet-clouddrives/src/main/webapp/WEB-INF/portlet.xml
+++ b/apps/portlet-clouddrives/src/main/webapp/WEB-INF/portlet.xml
@@ -5,6 +5,32 @@
              xsi:schemaLocation="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd
    http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd">
   <portlet>
+    <portlet-name>CloudDrivePortlet</portlet-name>
+    <display-name xml:lang="EN">Cloud Drive portlet</display-name>
+    <portlet-class>org.exoplatform.services.cms.clouddrives.portlet.CloudDrivePortlet</portlet-class>
+    <init-param>
+      <name>preload.resource.bundles</name>
+      <value>locale.clouddrive.CloudDrive</value>
+    </init-param>
+    <init-param>
+      <name>preload.resource.stylesheet</name>
+      <value><![CDATA[/cloud-drive-connectors/skin/clouddrive.css|/cloud-drive-connectors/skin/clouddrive-enterprise.css]]></value>
+    </init-param>
+    <init-param>
+      <name>preload.resource.rest</name>
+      <value><![CDATA[/portal/rest/clouddrive/features/status/enabled|/portal/rest/clouddrive/document/drive/personal]]></value>
+    </init-param>
+    <supports>
+      <mime-type>text/html</mime-type>
+    </supports>
+    <resource-bundle>locale.clouddrive.CloudDrive</resource-bundle>
+    <portlet-info>
+      <title>Cloud Drive portelt for eXo Platform</title>
+      <short-title>Cloud Drive</short-title>
+      <keywords>clouddrives</keywords>
+    </portlet-info>
+  </portlet>
+  <portlet>
     <portlet-name>cloudStoragePortlet</portlet-name>
     <display-name xml:lang="EN">Cloud storage portlet</display-name>
     <portlet-class>org.exoplatform.commons.api.portlet.GenericDispatchedViewPortlet</portlet-class>

--- a/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/dms-extension/dms/dms-clouddrives-configuration.xml
+++ b/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/dms-extension/dms/dms-clouddrives-configuration.xml
@@ -101,6 +101,38 @@
     <type>org.exoplatform.services.cms.clouddrives.webui.thumbnail.CloudDriveThumbnailRESTService</type>
   </component>
 
+  <external-component-plugins>
+    <target-component>org.exoplatform.commons.addons.AddOnService</target-component>
+    <component-plugin>
+      <name>addPlugin</name>
+      <set-method>addPlugin</set-method>
+      <type>org.exoplatform.commons.addons.AddOnPluginImpl</type>
+      <description>add application Config</description>
+      <init-params>
+        <value-param>
+          <name>priority</name>
+          <value>10</value>
+        </value-param>
+        <value-param>
+          <name>containerName</name>
+          <value>settings-bottom-container</value>
+        </value-param>
+        <object-param>
+          <name>CloudDrivePortlet</name>
+          <description>Cloud Drive portlet</description>
+          <object type="org.exoplatform.portal.config.serialize.PortletApplication">
+            <field name="state">
+              <object type="org.exoplatform.portal.config.model.TransientApplicationState">
+                <field name="contentId">
+                  <string>clouddrives/CloudDrivePortlet</string>
+                </field>
+              </object>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>cd
 
   <!-- use this plugin in external configuration, e.g. an extension -->
   <external-component-plugins>


### PR DESCRIPTION
Cloud drive portlet was mistakenly removed since it was added in all pages without a clear usage. This broke the possibility to connect user's cloud drives This fix will restore it and add it just in the User settings page to allow initiating synchroniation of cloud drives (Google, Microsoft, Box.com, etc ...) with user personal drives

(cherry picked from commit db79721cdd0c42b368f617b3cada3e5d1c3baae6)