### PR TITLE
fix: add possibility to create attachment plugin per functionality - EXO-58740

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
@@ -669,6 +669,7 @@ public class ManageDocumentService implements ResourceContainer {
       return node;
     }
     for (String folder : currentFolder.split("/")) {
+      folder = Text.escapeIllegalJcrChars(org.exoplatform.services.cms.impl.Utils.cleanString(folder));
       if (node.hasNode(folder)) {
         node = node.getNode(folder);
       } else {

--- a/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentEntityTypePlugin.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentEntityTypePlugin.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.services.attachments.service;
+
+
+import org.exoplatform.container.component.BaseComponentPlugin;
+
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.exoplatform.services.attachments.utils.Utils.EMPTY_STRING;
+
+/**
+ * This class is the super-class that defines classes which provide the possibility
+ * to customize how and where attachments will be saved after they are attached to a specific entity.
+ */
+public class AttachmentEntityTypePlugin extends BaseComponentPlugin {
+
+  /**
+   * Returns the ID of the attachment to link with the entity
+   * @param entityType type of the entity
+   * @param entityId ID of the entity
+   * @param attachmentId the original attachment ID that may be changed after calling this function
+   * @return the ID of the attachment to link with provided entity
+   */
+  public List<String> getlinkedAttachments(String entityType, long entityId, String attachmentId) {
+    return Collections.singletonList(attachmentId);
+  }
+
+  /**
+   * return the entity type that will be used to map the AttachmentEntityTypePlugin with the entity type
+   * @return the entity type
+   */
+  public String getEntityType() {
+    return EMPTY_STRING;
+  }
+}

--- a/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentService.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentService.java
@@ -162,4 +162,17 @@ public interface AttachmentService {
    * @throws Exception the exception
    */
   Attachment createNewDocument(Identity userIdentity, String title, String path, String pathDrive, String templateName) throws Exception;
+
+  /**
+   * Register a new AttachmentEntityTypePlugin
+   * @param attachmentEntityTypePlugin
+   */
+  public void addAttachmentEntityTypePlugin(AttachmentEntityTypePlugin attachmentEntityTypePlugin);
+
+  /**
+   * Retrieves a AttachmentEntityTypePlugin from the registered plugins
+   * @param entityType
+   * @return the registered AttachmentEntityTypePlugin
+   */
+  public AttachmentEntityTypePlugin getAttachmentEntityTypePlugin (String entityType);
 }

--- a/core/services/src/main/java/org/exoplatform/services/attachments/storage/AttachmentStorageImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/storage/AttachmentStorageImpl.java
@@ -24,6 +24,7 @@ import org.exoplatform.services.attachments.utils.Utils;
 import org.exoplatform.services.cms.documents.DocumentService;
 import org.exoplatform.services.cms.link.LinkManager;
 import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.core.ExtendedSession;
 import org.exoplatform.services.jcr.ext.app.SessionProviderService;
 
 import javax.jcr.AccessDeniedException;
@@ -98,10 +99,11 @@ public class AttachmentStorageImpl implements AttachmentStorage {
                                                                    attachmentId);
           attachments.add(attachment);
         }
+        attachments = Utils.removeDuplicatedAttachments(userSession, attachments);
       }
       return attachments.stream()
                         .filter(Objects::nonNull)
-                        .collect(Collectors.toList());
+                        .toList();
     } finally {
       if (systemSession != null) {
         systemSession.logout();
@@ -150,7 +152,7 @@ public class AttachmentStorageImpl implements AttachmentStorage {
 
   private boolean checkAttachmentNodeExistence(Session session, String attachmentId) throws RepositoryException {
     try {
-      session.getNodeByUUID(attachmentId);
+      ((ExtendedSession)session).getNodeByIdentifier(attachmentId);
     } catch (ItemNotFoundException | AccessDeniedException e) {
       return false;
     }

--- a/core/services/src/main/java/org/exoplatform/services/attachments/utils/EntityBuilder.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/utils/EntityBuilder.java
@@ -96,7 +96,7 @@ public class EntityBuilder {
     }
 
     Attachment attachment = new Attachment();
-    attachment.setId(((NodeImpl) originalAttachmentNode).getIdentifier());
+    attachment.setId(((NodeImpl) attachmentNode).getIdentifier());
     String attachmentsTitle = getStringProperty(originalAttachmentNode, "exo:title");
     attachment.setTitle(attachmentsTitle);
     String attachmentsPath = attachmentNode.getPath();

--- a/core/services/src/main/java/org/exoplatform/services/attachments/utils/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/utils/Utils.java
@@ -2,25 +2,44 @@ package org.exoplatform.services.attachments.utils;
 
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
+import org.exoplatform.services.attachments.model.Attachment;
 import org.exoplatform.services.attachments.model.AttachmentContextEntity;
 import org.exoplatform.services.cms.BasePath;
 import org.exoplatform.services.cms.drives.DriveData;
 import org.exoplatform.services.cms.drives.ManageDriveService;
 import org.exoplatform.services.cms.link.NodeFinder;
 import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.access.PermissionType;
+import org.exoplatform.services.jcr.core.ExtendedNode;
+import org.exoplatform.services.jcr.core.ExtendedSession;
 import org.exoplatform.services.jcr.ext.app.SessionProviderService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
 import org.exoplatform.services.security.ConversationState;
+import org.exoplatform.services.wcm.core.NodetypeConstant;
 
 import javax.jcr.Node;
+import javax.jcr.PathNotFoundException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import static org.exoplatform.services.wcm.core.NodetypeConstant.*;
+import static org.exoplatform.services.wcm.core.NodetypeConstant.EXO_PRIVILEGEABLE;
 
 public class Utils {
 
+  private static final Log LOG                      = ExoLogger.getExoLogger(Utils.class);
+
   public static final String QUARANTINE_FOLDER = "Quarantine";
+
+  public static final String EMPTY_STRING = "";
+
+  public static final String  EXO_SYMLINK_UUID         = "exo:uuid";
 
   public static void sortAttachmentsByDate(List<AttachmentContextEntity> attachments) {
     attachments.sort((attachment1, attachment2) -> ObjectUtils.compare(attachment2.getAttachedDate(),
@@ -66,6 +85,42 @@ public class Utils {
     return getTargetNode(session, nodeFinder, parentPathStr);
   }
 
+  /**
+   * Creates a symlink for the file defined by attachmentNode inside the parentNode folder with setting the permission
+   * @param attachmentNode the attached file
+   * @param parentNode the folder where the attachment will be saved
+   * @param permission the permission to set to the file
+   * @return the node representing the link for the file
+   */
+  public static Node createSymlink(Node attachmentNode, Node parentNode, String permission) {
+    Node linkNode;
+    try {
+      linkNode = parentNode.addNode(attachmentNode.getName(), EXO_SYMLINK);
+      linkNode.setProperty(EXO_WORKSPACE, attachmentNode.getSession().getWorkspace().getName());
+      linkNode.setProperty(EXO_PRIMARYTYPE, attachmentNode.getPrimaryNodeType().getName());
+      linkNode.setProperty(EXO_SYMLINK_UUID, ((ExtendedNode) attachmentNode).getIdentifier());
+      if (linkNode.canAddMixin(EXO_SORTABLE)) {
+        linkNode.addMixin(EXO_SORTABLE);
+      }
+      if (attachmentNode.hasProperty(EXO_TITLE)) {
+        linkNode.setProperty(EXO_TITLE, attachmentNode.getProperty(EXO_TITLE).getString());
+      }
+      linkNode.setProperty(EXO_NAME, attachmentNode.getName());
+      String nodeMimeType = getMimeType(attachmentNode);
+      linkNode.addMixin(MIX_FILE_TYPE);
+      linkNode.setProperty(EXO_FILE_TYPE, nodeMimeType);
+      if (linkNode.canAddMixin(EXO_PRIVILEGEABLE)) {
+        linkNode.addMixin(EXO_PRIVILEGEABLE);
+      }
+      ((ExtendedNode) linkNode).setPermission(permission, new String[] { PermissionType.READ });
+      parentNode.save();
+      return linkNode;
+    } catch (Exception e) {
+      LOG.error("Error updating sharing of document {}", attachmentNode, e);
+      return null;
+    }
+  }
+
   public static Node getTargetNode(Session session, NodeFinder nodeFinder, String path) throws Exception {
     return (Node) nodeFinder.getItem(session, path, true);
   }
@@ -87,7 +142,59 @@ public class Utils {
   }
 
   public static boolean isQuarantinedItem(Session systemSession, String attachmentId) throws RepositoryException {
-    Node attachmentNode = systemSession.getNodeByUUID(attachmentId);
+    Node attachmentNode = ((ExtendedSession)systemSession).getNodeByIdentifier(attachmentId);
     return attachmentNode.getPath().startsWith("/" + QUARANTINE_FOLDER + "/");
+  }
+
+  /**
+   * Get the MimeType
+   *
+   * @param node the node
+   * @return the MimeType
+   */
+  public static String getMimeType(Node node) {
+    try {
+      if (node.getPrimaryNodeType().getName().equals(NodetypeConstant.NT_FILE) && node.hasNode(NodetypeConstant.JCR_CONTENT)) {
+        return node.getNode(NodetypeConstant.JCR_CONTENT).getProperty(NodetypeConstant.JCR_MIME_TYPE).getString();
+      }
+    } catch (RepositoryException e) {
+      LOG.error(e.getMessage(), e);
+    }
+    return "";
+  }
+
+  /**
+   * Removes duplicated items and symlinks if their original file is present in the list
+   * @param userSession JCR session for the user
+   * @param attachments List of attachments
+   * @return list of attachments with no duplicates
+   */
+  public static List<Attachment> removeDuplicatedAttachments(Session userSession, List<Attachment> attachments) {
+    Map<String, Attachment> filteringAttachmentsMap = new HashMap<>();
+    for(Attachment entity : attachments) {
+      Node entityNode = getNodeByIdentifier(userSession, entity.getId());
+      try {
+        if (entityNode != null && entityNode.isNodeType(EXO_SYMLINK)) {
+          String originalEntityNodeId = entityNode.getProperty(EXO_SYMLINK_UUID).getString();
+          filteringAttachmentsMap.put(originalEntityNodeId, entity);
+        } else {
+          filteringAttachmentsMap.put(entity.getId(), entity);
+        }
+      } catch (Exception e) {
+        filteringAttachmentsMap.put(entity.getId(), entity);
+      }
+    }
+    return filteringAttachmentsMap.values().stream().toList();
+  }
+
+  public static Node getNodeByIdentifier(Session session, String nodeId) {
+    try {
+      return ((ExtendedSession) session).getNodeByIdentifier(nodeId);
+    } catch (PathNotFoundException e) {
+      LOG.info("Node with identifier {} was not found !", nodeId);
+    } catch (RepositoryException e) {
+      LOG.debug("Error retrieving node with identifier {}", nodeId, e);
+    }
+    return null;
   }
 }

--- a/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImpl.java
@@ -27,6 +27,7 @@ import javax.jcr.query.QueryResult;
 
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.services.jcr.core.ExtendedNode;
 import org.gatein.api.Portal;
 import org.gatein.api.navigation.Navigation;
 import org.gatein.api.navigation.Nodes;
@@ -486,10 +487,10 @@ public class DocumentServiceImpl implements DocumentService {
       if (currentNode.isNodeType(NodetypeConstant.EXO_SYMLINK)) {
         currentNode = linkManager.getTarget(currentNode);
       }
-      List<Node> nodes = new ArrayList<Node>();
-      String CurrentNodeWorkspaceName = currentNode.getSession().getWorkspace().getName();
-      nodes = linkManager.getNodeSymlinksUnderFolder(currentNode.getUUID(), shared.getPath(), CurrentNodeWorkspaceName);
-      if (nodes.size() != 0) {
+      List<Node> nodes;
+      String currentNodeWorkspaceName = currentNode.getSession().getWorkspace().getName();
+      nodes = linkManager.getNodeSymlinksUnderFolder(((ExtendedNode)currentNode).getIdentifier(), shared.getPath(), currentNodeWorkspaceName);
+      if (!nodes.isEmpty()) {
         link = nodes.get(0);
       }
       if (link == null && currentNode.isNodeType(NodetypeConstant.NT_FILE)) {
@@ -1036,8 +1037,8 @@ public class DocumentServiceImpl implements DocumentService {
   }
   
   public LinkedHashMap<String, String> getFilePreviewBreadCrumb(Node fileNode) {
-    LinkedHashMap<String, String> docFolderBreadCrumb = getDocFolderRelativePathWithLinks(fileNode);
     LinkedHashMap<String, String> fileBreadCrumb = new LinkedHashMap<>();
+    LinkedHashMap<String, String> docFolderBreadCrumb = getDocFolderRelativePathWithLinks(fileNode);
     if (docFolderBreadCrumb != null) {
       int breadCrumbSize = docFolderBreadCrumb.size();
       int folderIndex = 0;
@@ -1101,7 +1102,7 @@ public class DocumentServiceImpl implements DocumentService {
         String drivePublicFolderHomePath = null;
         if (ManageDriveServiceImpl.PERSONAL_DRIVE_NAME.equals(drive.getName())) {
           drivePublicFolderHomePath = driveHomePath.replace("/" + ManageDriveServiceImpl.PERSONAL_DRIVE_PRIVATE_FOLDER_NAME, "/"
-              + ManageDriveServiceImpl.PERSONAL_DRIVE_PUBLIC_FOLDER_NAME);
+                  + ManageDriveServiceImpl.PERSONAL_DRIVE_PUBLIC_FOLDER_NAME);
         }
 
         // calculate the relative path to the drive by browsing up the content
@@ -1131,20 +1132,22 @@ public class DocumentServiceImpl implements DocumentService {
           // title is used if it exists, otherwise the name is used
           if (parentPath.equals(driveHomePath)) {
             nodeName = driveName;
-          } else if (parentContentNode.hasProperty("exo:title")) {
-            nodeName = parentContentNode.getProperty("exo:title").getString();
+          } else if (parentContentNode.hasProperty(EXO_TITLE_PROP)) {
+            nodeName = parentContentNode.getProperty(EXO_TITLE_PROP).getString();
           } else {
             nodeName = parentContentNode.getName();
           }
           reversedFolderPathWithLinks.put(nodeName + "_" + reversedFolderPathWithLinks.size(), getDocOpenUri(parentContentNode));
 
-          if (parentPath.equals("/")) {
+          if (parentPath.equals("/") || parentPath.equals(driveHomePath)) {
             break;
           } else {
             parentContentNode = parentContentNode.getParent();
           }
         }
       }
+    } catch (AccessDeniedException ade) {
+      LOG.warn(ade.getMessage());
     } catch (Exception re) {
       LOG.error("Cannot retrieve path of doc " + re.getMessage(), re);
     }

--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -664,7 +664,7 @@ public class Utils {
     Transliterator accentsconverter = Transliterator.getInstance("Latin; NFD; [:Nonspacing Mark:] Remove; NFC;");
     str = accentsconverter.transliterate(str);
     //the character ? seems to not be changed to d by the transliterate function
-    StringBuffer cleanedStr = new StringBuffer(str.trim());
+    StringBuilder cleanedStr = new StringBuilder(str.trim());
     // delete special character
     int strLength = cleanedStr.length();
     int i = 0;
@@ -683,7 +683,7 @@ public class Utils {
     while (StringUtils.isNotEmpty(cleanedStr.toString()) && !Character.isLetterOrDigit(cleanedStr.charAt(0))) {
       cleanedStr.deleteCharAt(0);
     }
-    String clean = cleanedStr.toString().toLowerCase();
+    String clean = cleanedStr.toString();
     if (clean.endsWith("-")) {
       clean = clean.substring(0, clean.length()-1);
     }

--- a/core/services/src/main/java/org/exoplatform/services/rest/AttachmentsRestService.java
+++ b/core/services/src/main/java/org/exoplatform/services/rest/AttachmentsRestService.java
@@ -170,7 +170,7 @@ public class AttachmentsRestService implements ResourceContainer {
         attachmentsEntities = attachments.stream()
                                          .map(attachment -> EntityBuilder.fromAttachment(identityManager, attachment))
                                          .filter(attachmentEntity -> attachmentEntity.getAcl().isCanView())
-                                         .collect(Collectors.toList());
+                                         .toList();
       }
       return Response.ok(attachmentsEntities).build();
     } catch (IllegalAccessException e) {

--- a/core/services/src/test/java/org/exoplatform/services/attachments/service/AttachmentServiceTest.java
+++ b/core/services/src/test/java/org/exoplatform/services/attachments/service/AttachmentServiceTest.java
@@ -172,7 +172,7 @@ public class AttachmentServiceTest extends BaseExoTestCase {
     Node nodeContent1 = mock(Node.class);
     Property property = mock(Property.class);
     Workspace workSpace = mock(Workspace.class);
-    when(((ExtendedSession) session).getNodeByIdentifier(anyString())).thenReturn(node1);
+    when(((ExtendedSession) session).getNodeByIdentifier(String.valueOf(1))).thenReturn(node1);
     when(session.getNodeByUUID(anyString())).thenReturn(node1);
     when(session.getWorkspace()).thenReturn(workSpace);
     lenient().when(node1.getSession()).thenReturn(session);
@@ -196,7 +196,7 @@ public class AttachmentServiceTest extends BaseExoTestCase {
     lenient().when(((NodeImpl) node2).getIdentifier()).thenReturn("2");
     Property property2 = mock(Property.class);
     when(session.getNodeByUUID(anyString())).thenReturn(node2);
-    when(((ExtendedSession) session).getNodeByIdentifier(anyString())).thenReturn(node2);
+    when(((ExtendedSession) session).getNodeByIdentifier(String.valueOf(2))).thenReturn(node2);
     when(session.getWorkspace()).thenReturn(workSpace);
     lenient().when(node2.getProperty(anyString())).thenReturn(property2);
     lenient().when(node2.getNode(anyString())).thenReturn(nodeContent2);
@@ -211,10 +211,9 @@ public class AttachmentServiceTest extends BaseExoTestCase {
     lenient().when(node3.getSession()).thenReturn(session);
     node3 = mock(NodeImpl.class);
     Node nodeContent3 = mock(NodeImpl.class);
-    lenient().when(((NodeImpl) node2).getIdentifier()).thenReturn("3");
+    lenient().when(((NodeImpl) node3).getIdentifier()).thenReturn("3");
     Property property3 = mock(Property.class);
-    when(session.getNodeByUUID(anyString())).thenReturn(node3);
-    when(((ExtendedSession) session).getNodeByIdentifier(anyString())).thenReturn(node3);
+    when(((ExtendedSession) session).getNodeByIdentifier(String.valueOf(3))).thenReturn(node3);
     lenient().when(session.getWorkspace()).thenReturn(workSpace);
     lenient().when(node3.getProperty(anyString())).thenReturn(property3);
     lenient().when(node3.getNode(anyString())).thenReturn(nodeContent3);
@@ -222,7 +221,6 @@ public class AttachmentServiceTest extends BaseExoTestCase {
     lenient().when(property3.getDate()).thenReturn(Calendar.getInstance());
     lenient().when(property3.getLong()).thenReturn((long) 3);
     lenient().when(node3.getPath()).thenReturn("/collaboration/");
-    when(session.getNodeByUUID(String.valueOf(3))).thenReturn(node3);
     when(((ExtendedSession) session).getNodeByIdentifier(String.valueOf(3))).thenReturn(node3);
 
     String username = "testuser";
@@ -310,7 +308,6 @@ public class AttachmentServiceTest extends BaseExoTestCase {
     ManageableRepository manageableRepository = repositoryService.getRepository("repository");
     lenient().when(repositoryService.getRepository(Mockito.anyString())).thenReturn(manageableRepository);
     Node parentNode = mock(Node.class);
-    when(session.getNodeByUUID(anyString())).thenReturn(parentNode);
     Node node1 = mock(Node.class);
     Node nodeContent1 = mock(Node.class);
     Property property = mock(Property.class);

--- a/ecms-social-integration/src/main/java/org/exoplatform/services/attachments/plugins/TaskAttachmentEntityTypePlugin.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/services/attachments/plugins/TaskAttachmentEntityTypePlugin.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2022 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.services.attachments.plugins;
+
+import org.apache.commons.lang3.StringUtils;
+import org.exoplatform.services.attachments.service.AttachmentEntityTypePlugin;
+import org.exoplatform.services.attachments.utils.Utils;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.access.PermissionType;
+import org.exoplatform.services.jcr.core.ExtendedNode;
+import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.jcr.ext.app.SessionProviderService;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.task.dto.TaskDto;
+import org.exoplatform.task.service.ProjectService;
+import org.exoplatform.task.service.TaskService;
+
+import javax.jcr.*;
+import java.util.*;
+
+import static org.exoplatform.services.attachments.utils.Utils.EXO_SYMLINK_UUID;
+import static org.exoplatform.services.wcm.core.NodetypeConstant.*;
+
+/**
+ * Plugin to define how and where files attached to tasks are stored
+ */
+public class TaskAttachmentEntityTypePlugin extends AttachmentEntityTypePlugin {
+
+  private static final Log           LOG                      = ExoLogger.getExoLogger(TaskAttachmentEntityTypePlugin.class);
+
+  private final TaskService          taskService;
+
+  private final ProjectService       projectService;
+
+  private final NodeHierarchyCreator nodeHierarchyCreator;
+
+  private final SessionProviderService sessionProviderService;
+
+  private final RepositoryService repositoryService;
+
+  public static final String         DOCUMENTS_NODE           = "Documents";
+
+  private static final String        DEFAULT_GROUPS_HOME_PATH = "/Groups"; //NOSONAR
+
+  public static final String         GROUPS_PATH_ALIAS        = "groupsPath";
+
+  public TaskAttachmentEntityTypePlugin(TaskService taskService,
+                                        ProjectService projectService,
+                                        NodeHierarchyCreator nodeHierarchyCreator,
+                                        SessionProviderService sessionProviderService,
+                                        RepositoryService repositoryService) {
+    this.taskService = taskService;
+    this.projectService = projectService;
+    this.nodeHierarchyCreator = nodeHierarchyCreator;
+    this.repositoryService = repositoryService;
+    this.sessionProviderService = sessionProviderService;
+  }
+
+  @Override
+  public List<String> getlinkedAttachments(String entityType, long entityId, String attachmentId) {
+
+    SessionProvider sessionProvider = sessionProviderService.getSessionProvider(null);
+    try {
+      TaskDto task = taskService.getTask(entityId);
+      Set<String> taskPermittedIdentities = projectService.getParticipator(task.getStatus().getProject().getId());
+
+      ManageableRepository repository = repositoryService.getCurrentRepository();
+      Session userSession = sessionProvider.getSession(repository.getConfiguration().getDefaultWorkspaceName(), repository);
+
+      // check if content is still there
+      Node attachmentNode = Utils.getNodeByIdentifier(userSession, attachmentId);
+      if (attachmentNode == null) {
+        return Collections.singletonList(attachmentId);
+      }
+
+      // Check if the content is symlink, then get the original content
+      if (attachmentNode.isNodeType(EXO_SYMLINK)) {
+        String sourceNodeId = attachmentNode.getProperty(EXO_SYMLINK_UUID).getString();
+        Node originalNode = Utils.getNodeByIdentifier(userSession, sourceNodeId);
+        if (originalNode != null) {
+          attachmentNode = originalNode;
+        }
+      }
+
+      List<String> linkNodes = new ArrayList<>();
+      for (String permittedIdentity : taskPermittedIdentities) {
+        if (permittedIdentity.contains(":/spaces/")) {
+          String groupId = permittedIdentity.split(":")[1];
+          if (attachmentNode.getPath().contains(groupId + "/")) {
+            linkNodes.add(attachmentId);
+          } else {
+            // Create a symlink in Document app of the space if the task belongs to a
+            // project of a space
+            Node rootNode = getGroupNode(nodeHierarchyCreator, userSession, groupId);
+            if (rootNode != null) {
+              Node parentNode = getDestinationFolder(rootNode, task.getId());
+              Node linkNode = Utils.createSymlink(attachmentNode, parentNode, permittedIdentity);
+              if (linkNode != null) {
+                linkNodes.add(((ExtendedNode) linkNode).getIdentifier());
+              }
+            }
+          }
+        }
+        // set read permission for users or groups different from spaces
+        if (attachmentNode.canAddMixin(EXO_PRIVILEGEABLE)) {
+          attachmentNode.addMixin(EXO_PRIVILEGEABLE);
+        }
+        ((ExtendedNode) attachmentNode).setPermission(permittedIdentity, new String[]{PermissionType.READ});
+        attachmentNode.save();
+      }
+      return linkNodes;
+    } catch (Exception e) {
+      LOG.error("Error getting linked documents {}", attachmentId, e);
+    }
+    return Collections.singletonList(attachmentId);
+  }
+
+  @Override
+  public String getEntityType() {
+    return "task";
+  }
+
+  private Node getDestinationFolder(Node rootNode, Long entityId) {
+    Node parentNode;
+    try {
+      if (rootNode.hasNode("task")) {
+        parentNode = rootNode.getNode("task");
+      } else {
+        parentNode = rootNode.addNode("task", NT_FOLDER);
+        rootNode.save();
+      }
+      if (parentNode.hasNode(String.valueOf(entityId))) {
+        return parentNode.getNode(String.valueOf(entityId));
+      } else {
+        Node taskNode = parentNode.addNode(String.valueOf(entityId), NT_FOLDER);
+        parentNode.save();
+        return taskNode;
+      }
+    } catch (RepositoryException repositoryException) {
+      LOG.error("Could not create and return parent folder for task {} under root folder {}",
+                entityId,
+                rootNode,
+                repositoryException);
+      return rootNode;
+    }
+  }
+
+  private static Node getGroupNode(NodeHierarchyCreator nodeHierarchyCreator,
+                                   Session session,
+                                   String groupId) throws RepositoryException {
+    String groupsHomePath = getGroupsPath(nodeHierarchyCreator);
+    String groupPath = groupsHomePath + groupId + "/" + DOCUMENTS_NODE;
+    if (session.itemExists(groupPath)) {
+      return (Node) session.getItem(groupPath);
+    }
+    return null;
+  }
+
+  private static String getGroupsPath(NodeHierarchyCreator nodeHierarchyCreator) {
+    String groupsPath = nodeHierarchyCreator.getJcrPath(GROUPS_PATH_ALIAS);
+    if (StringUtils.isBlank(groupsPath)) {
+      groupsPath = DEFAULT_GROUPS_HOME_PATH;
+    }
+    return groupsPath;
+  }
+}

--- a/ecms-social-integration/src/main/resources/conf/portal/configuration.xml
+++ b/ecms-social-integration/src/main/resources/conf/portal/configuration.xml
@@ -73,4 +73,13 @@
     </component-plugin>
   </external-component-plugins>
 
+  <external-component-plugins>
+    <target-component>org.exoplatform.services.attachments.service.AttachmentService</target-component>
+    <component-plugin>
+      <name>TaskAttachmentEntityTypePlugin</name>
+      <set-method>addAttachmentEntityTypePlugin</set-method>
+      <type>org.exoplatform.services.attachments.plugins.TaskAttachmentEntityTypePlugin</type>
+    </component-plugin>
+  </external-component-plugins>
+
 </configuration>

--- a/ecms-social-integration/src/test/java/org/exoplatform/services/attachments/plugins/TaskAttachmentEntityTypePluginTest.java
+++ b/ecms-social-integration/src/test/java/org/exoplatform/services/attachments/plugins/TaskAttachmentEntityTypePluginTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2022 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.services.attachments.plugins;
+
+import junit.framework.TestCase;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.config.RepositoryEntry;
+import org.exoplatform.services.jcr.core.ExtendedSession;
+import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.jcr.ext.app.SessionProviderService;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
+import org.exoplatform.services.jcr.impl.core.NodeImpl;
+import org.exoplatform.services.jcr.impl.core.SessionImpl;
+import org.exoplatform.services.jcr.impl.core.WorkspaceImpl;
+import org.exoplatform.task.dto.ProjectDto;
+import org.exoplatform.task.dto.StatusDto;
+import org.exoplatform.task.dto.TaskDto;
+import org.exoplatform.task.service.ProjectService;
+import org.exoplatform.task.service.TaskService;
+import org.powermock.api.mockito.PowerMockito;
+
+import javax.jcr.nodetype.NodeType;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.exoplatform.services.wcm.core.NodetypeConstant.NT_FOLDER;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TaskAttachmentEntityTypePluginTest extends TestCase {
+
+  public void testGetAttachmentOrLinkId() throws Exception {
+    long entityId = 1;
+
+    // Mock services
+    TaskService taskService = PowerMockito.mock(TaskService.class);
+    ProjectService projectService = PowerMockito.mock(ProjectService.class);
+    NodeHierarchyCreator nodeHierarchyCreator = PowerMockito.mock(NodeHierarchyCreator.class);
+    RepositoryService repositoryService = PowerMockito.mock(RepositoryService.class);
+    SessionProviderService sessionProviderService = PowerMockito.mock(SessionProviderService.class);
+
+    // Mock SessionProvider
+    SessionProvider sessionProvider = PowerMockito.mock(SessionProvider.class);
+    when(sessionProviderService.getSessionProvider(null)).thenReturn(sessionProvider);
+
+    // Mock Repository service and JCR session
+    ManageableRepository repository = mock(ManageableRepository.class);
+    when(repositoryService.getCurrentRepository()).thenReturn(repository);
+    RepositoryEntry repositoryEntry = mock(RepositoryEntry.class);
+    when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repository.getConfiguration().getDefaultWorkspaceName()).thenReturn("collaboration");
+    ExtendedSession extendedSession = mock(ExtendedSession.class);
+    when(sessionProvider.getSession(any(), any())).thenReturn(extendedSession);
+
+    // Mock Task
+    TaskDto task = new TaskDto();
+    task.setId(1);
+    ProjectDto project = new ProjectDto();
+    project.setId(1);
+    StatusDto status = new StatusDto();
+    status.setProject(project);
+    task.setStatus(status);
+    when(taskService.getTask(1)).thenReturn(task);
+    when(projectService.getParticipator(anyLong())).thenReturn(new HashSet<>(Arrays.asList("user1",
+            "/platform/users", "member:/spaces/space1")));
+
+    // Instantiate the TaskAttachmentEntityTypePlugin
+    TaskAttachmentEntityTypePlugin taskAttachmentEntityTypePlugin = new TaskAttachmentEntityTypePlugin(taskService,
+                                                                                                       projectService,
+                                                                                                       nodeHierarchyCreator,
+                                                                                                       sessionProviderService,
+                                                                                                       repositoryService);
+
+    // Node does not exist, we return the same attachmentId
+    String attachmentId = "123456789Azerty";
+    String attachmentName = "testFile.docx";
+    assertEquals(1, taskAttachmentEntityTypePlugin.getlinkedAttachments("task", entityId, attachmentId).size());
+    assertEquals(attachmentId, taskAttachmentEntityTypePlugin.getlinkedAttachments("task", entityId, attachmentId).get(0));
+
+    // Node exist
+    NodeImpl node = mock(NodeImpl.class);
+    when(node.getIdentifier()).thenReturn(attachmentId);
+    when(node.getName()).thenReturn(attachmentName);
+    NodeType nodeType = mock(NodeType.class);
+    when(nodeType.getName()).thenReturn("nt:file");
+    when(node.getPrimaryNodeType()).thenReturn(nodeType);
+    when(extendedSession.getNodeByIdentifier(anyString())).thenReturn(node);
+    when(extendedSession.itemExists(anyString())).thenReturn(true);
+
+    // Create different nodes
+    NodeImpl rootNode = mock(NodeImpl.class);
+    NodeImpl taskParentNode = mock(NodeImpl.class);
+    NodeImpl taskNode = mock(NodeImpl.class);
+    NodeImpl linkNode = mock(NodeImpl.class);
+    String linkNodeIdentifier = "link_identifier_123456789Azerty";
+    SessionImpl session = mock(SessionImpl.class);
+    WorkspaceImpl workspace = mock(WorkspaceImpl.class);
+    when(workspace.getName()).thenReturn("collaboration");
+    when(session.getWorkspace()).thenReturn(workspace);
+    when(node.getSession()).thenReturn(session);
+    when(node.getPath()).thenReturn("/Groups/spaces/spaceOne/documents/testFile.docx");
+    when(linkNode.getIdentifier()).thenReturn(linkNodeIdentifier);
+    when(taskNode.addNode(anyString(), anyString())).thenReturn(linkNode);
+    when(taskParentNode.getNode(String.valueOf(anyLong()))).thenReturn(taskNode);
+    when(taskParentNode.addNode(String.valueOf(entityId), NT_FOLDER)).thenReturn(taskNode);
+    when(rootNode.addNode("task", NT_FOLDER)).thenReturn(taskParentNode);
+    when(extendedSession.getItem(anyString())).thenReturn(rootNode);
+
+    // Will return link ID instead of the original attached file
+    assertEquals(1, taskAttachmentEntityTypePlugin.getlinkedAttachments("task", 1, attachmentId).size());
+    assertEquals(linkNodeIdentifier, taskAttachmentEntityTypePlugin.getlinkedAttachments("task", 1, attachmentId).get(0));
+
+
+    when(projectService.getParticipator(anyLong())).thenReturn(new HashSet<>(Arrays.asList("user1",
+            "/platform/users", "member:/spaces/space1", "member:/spaces/spaceOne")));
+
+    // Will return link ID instead of the original attached file
+    assertEquals(2, taskAttachmentEntityTypePlugin.getlinkedAttachments("task", 1, attachmentId).size());
+    assertTrue(taskAttachmentEntityTypePlugin.getlinkedAttachments("task", 1, attachmentId).contains(attachmentId));
+    assertTrue(taskAttachmentEntityTypePlugin.getlinkedAttachments("task", 1, attachmentId).contains(linkNodeIdentifier));
+
+  }
+}


### PR DESCRIPTION
For the sake of easier integration, we can add a new plugin for each type of entities using the attachmentService. The plugin will define how and where we can store attached files to entities based on the entity type. TaskAttachmentEntityTypePlugin is the plugin used by Tasks module and will put attached files inside the right folder or creates a symlink if the file is attached from another space

(cherry picked from commit f23c7804c62c32b59c792a1d308dca6e9148c101)