### PR TITLE
backport fixes for task EXO-61664 (#1985)

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/Attachment.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/Attachment.vue
@@ -64,19 +64,15 @@ export default {
     });
     document.addEventListener('open-attachments-app-drawer', (event) => {
       this.drawerList = false;
-      this.readConfiguration(event.detail)
-        .then(() => {
-          this.initAttachmentEnvironment();
-          this.openAttachmentsAppDrawer();
-        });
+      this.readConfiguration(event.detail);
+      this.initAttachmentEnvironment();
+      this.openAttachmentsAppDrawer();
     });
     document.addEventListener('open-attachments-list-drawer', (event) => {
       this.drawerList = true;
-      this.readConfiguration(event.detail)
-        .then(() => {
-          this.initAttachmentEnvironment();
-          this.openAttachmentsDrawerList();
-        });
+      this.readConfiguration(event.detail);
+      this.initAttachmentEnvironment();
+      this.openAttachmentsDrawerList();
     });
   },
   mounted() {
@@ -88,14 +84,29 @@ export default {
     },
     readConfiguration(config) {
       config = config || {};
-      this.spaceId = this.getURLQueryParam('spaceId')  || config.spaceId || eXo.env.portal.spaceId;
-      this.defaultDrive = config.defaultDrive || {
-        isSelected: true,
-        name: eXo.env.portal.spaceGroup && `.spaces.${eXo.env.portal.spaceGroup}` || 'Personal Documents',
-        title: eXo.env.portal.spaceDisplayName || 'Personal Documents'
-      };
+      this.spaceId = this.getURLQueryParam('spaceId') || config.spaceId || eXo.env.portal.spaceId;
+      if (this.spaceId) {
+        this.$spaceService.getSpaceById(this.spaceId)
+          .then(space => {
+            if (space) {
+              this.currentSpace = space;
+              const spaceGroupId = space.groupId.split('/spaces/')[1];
+              this.defaultDrive = {
+                name: `.spaces.${spaceGroupId}`,
+                title: space.displayName,
+                isSelected: true
+              };
+            }
+          });
+      } else {
+        this.defaultDrive = config.defaultDrive || {
+          isSelected: true,
+          name: eXo.env.portal.spaceGroup && `.spaces.${eXo.env.portal.spaceGroup}` || 'Personal Documents',
+          title: eXo.env.portal.spaceDisplayName || 'Personal Documents'
+        };
+      }
       this.defaultFolder = config.defaultFolder
-        || (eXo.env.portal.spaceDisplayName && 'Documents') || 'Public';
+        || (eXo.env.portal.spaceId && 'Documents') || 'Public';
       this.sourceApp = config.sourceApp || null;
       this.attachments = config.attachments || [];
       if (typeof config.attachToEntity !== 'undefined') {
@@ -108,7 +119,7 @@ export default {
       }
       this.entityType = config.entityType;
       this.entityId = config.entityId;
-      return this.initDefaultDrive();
+      this.openAttachmentsInEditor = config.openAttachmentsInEditor || false;
     },
     startLoadingList() {
       if (this.drawerList && this.$refs.attachmentsListDrawer) {
@@ -194,24 +205,6 @@ export default {
           });
         }
       });
-    },
-    initDefaultDrive() {
-      if (this.spaceId) {
-        return this.$spaceService.getSpaceById(this.spaceId)
-          .then(space => {
-            if (space) {
-              this.currentSpace = space;
-              const spaceGroupId = space.groupId.split('/spaces/')[1];
-              this.defaultDrive = {
-                name: `.spaces.${spaceGroupId}`,
-                title: space.displayName,
-                isSelected: true
-              };
-            }
-          });
-      } else {
-        return Promise.resolve(null);
-      }
     },
     getURLQueryParam(paramName) {
       const urlParams = new URLSearchParams(window.location.search);

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
@@ -521,19 +521,7 @@ export default {
     },
     entityId() {
       this.initDestinationFolderPath();
-    },
-    entityType() {
-      this.initDestinationFolderPath();
-    },
-    spaceId() {
-      this.initDestinationFolderPath();
-    },
-    defaultDrive() {
-      this.initDestinationFolderPath();
-    },
-    defaultFolder() {
-      this.initDestinationFolderPath();
-    },
+    }
   },
   created() {
     this.initDestinationFolderPath();

--- a/core/services/src/main/java/org/exoplatform/services/attachments/utils/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/utils/Utils.java
@@ -24,6 +24,7 @@ import javax.jcr.Node;
 import javax.jcr.PathNotFoundException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -184,7 +185,7 @@ public class Utils {
         filteringAttachmentsMap.put(entity.getId(), entity);
       }
     }
-    return filteringAttachmentsMap.values().stream().collect(Collectors.toList());
+    return new ArrayList<>(filteringAttachmentsMap.values());
   }
 
   public static Node getNodeByIdentifier(Session session, String nodeId) {

--- a/ecms-social-integration/src/main/java/org/exoplatform/services/attachments/plugins/TaskAttachmentEntityTypePlugin.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/services/attachments/plugins/TaskAttachmentEntityTypePlugin.java
@@ -103,7 +103,7 @@ public class TaskAttachmentEntityTypePlugin extends AttachmentEntityTypePlugin {
       for (String permittedIdentity : taskPermittedIdentities) {
         if (permittedIdentity.contains(":/spaces/")) {
           String groupId = permittedIdentity.split(":")[1];
-          if (attachmentNode.getPath().contains(groupId + "/")) {
+          if (attachmentNode.getPath().contains(groupId + "/") && !linkNodes.contains(attachmentId)) {
             linkNodes.add(attachmentId);
           } else {
             // Create a symlink in Document app of the space if the task belongs to a
@@ -111,9 +111,12 @@ public class TaskAttachmentEntityTypePlugin extends AttachmentEntityTypePlugin {
             Node rootNode = getGroupNode(nodeHierarchyCreator, userSession, groupId);
             if (rootNode != null) {
               Node parentNode = getDestinationFolder(rootNode, task.getId());
-              Node linkNode = Utils.createSymlink(attachmentNode, parentNode, permittedIdentity);
-              if (linkNode != null) {
-                linkNodes.add(((ExtendedNode) linkNode).getIdentifier());
+              // We won't add the file symlink as attachment if another file exists with the same name
+              if(!parentNode.hasNode(attachmentNode.getName())) {
+                Node linkNode = Utils.createSymlink(attachmentNode, parentNode, permittedIdentity);
+                if (linkNode != null) {
+                  linkNodes.add(((ExtendedNode) linkNode).getIdentifier());
+                }
               }
             }
           }


### PR DESCRIPTION
Prior to this fix, attachment drawer takes Personal drive as default drive even when opened in a space then after a few seconds it switchs to the space drive. This causes some unexpected behavior (folders created twice in Personal and space drive). Besides, files are added twice to a task when they are attached to a process. This fix makes sure to get the current context to initialize the attachment drwaer with the correct drive and checks if the file is already attached before creating a symlink to it

(cherry picked from commit 6d785ac95b53218e64d115c0ba4bed04efc03b75)