### PR TITLE
fix: Upload and create document error - EXO-61814 (#1984)

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
@@ -204,7 +204,10 @@ export default {
         this.displaySuccessMessage();
         this.$refs.attachmentsAppDrawer.endLoading();
       }
-    }
+    },
+    defaultDrive() {
+      this.initDefaultDestinationFolderPath(this.defaultFolder);
+    },
   },
   created() {
     document.addEventListener('paste', this.onPaste, false);


### PR DESCRIPTION
prior to this change, it is not possible to upload or create a document since the current drive and the DefaultDestinationFolderPath are not initialized after this change, the attributes are initialized, and adding documents works perfectly