### PR TITLE
fix: Attach from existing upload :  folder name with accent - EXO-61813 (#1989)

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
@@ -669,9 +669,11 @@ public class ManageDocumentService implements ResourceContainer {
       return node;
     }
     for (String folder : currentFolder.split("/")) {
-      folder = Text.escapeIllegalJcrChars(org.exoplatform.services.cms.impl.Utils.cleanString(folder));
+      String cleanFolderName = Text.escapeIllegalJcrChars(org.exoplatform.services.cms.impl.Utils.cleanString(folder));
       if (node.hasNode(folder)) {
         node = node.getNode(folder);
+      } else if (node.hasNode(cleanFolderName)) {
+        node = node.getNode(cleanFolderName);
       } else {
         // create new folder
         String name = Text.escapeIllegalJcrChars(org.exoplatform.services.cms.impl.Utils.cleanString(folder));


### PR DESCRIPTION
before this change, when trying to retrieve a folder with its name that contains an accent, the name is cleaned and an attempt is made to find it if the file is not found, a new folder with the cleaned name is created after this change, when retrieving a node by its name, the uncleaned name will be checked first, then the cleaned name.

(cherry picked from commit dc2ff33247a47deae7ec256626919326f05d5630)