### PR TITLE
fix: change default folder for attachments in spaces - EXO-61872

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/Attachment.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/Attachment.vue
@@ -117,7 +117,7 @@ export default {
         };
       }
       this.defaultFolder = config.defaultFolder
-        || (eXo.env.portal.spaceId && 'Documents') || 'Public';
+        || (eXo.env.portal.spaceId && '/') || 'Public';
       this.sourceApp = config.sourceApp || null;
       this.files = config.files || null;
       this.attachments = config.attachments || [];


### PR DESCRIPTION
Space default folder was set to Documents, but this folder is not created automatically and causes issues when new files are created/uploaded. This fix will set the default folder to / which is the folder that the space Documents is opened on by default