### PR TITLE
fix : Decide whether to keep or create a new version of the file when uploading a file with an accented name - EXO-62290

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
@@ -304,7 +304,7 @@ public class FileUploadHandler {
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     DocumentBuilder builder = factory.newDocumentBuilder();
     Document fileExistence = builder.newDocument();
-    fileName = Text.escapeIllegalJcrChars(fileName);
+    fileName = Utils.cleanNameWithAccents(fileName);
     fileName = fileName.replaceAll(FILE_DECODE_REGEX, "%25");
     fileName = URLDecoder.decode(fileName,"UTF-8");
     fileName = fileName.replaceAll(FILE_DECODE_REGEX, "-");


### PR DESCRIPTION

Prior to this change, if we wanted to upload a previously uploaded file with an accented name, the file would be uploaded without the option to either keep or create a new version. The problem was that the node name was cleaned using the method "cleanNameWithAccents" and saved without accents. As a result, if we wanted to check for its existence, we would have to clean the name as well. This change addresses this issue.