### PR TITLE
fix: Preview image are not displayed in activity -EXO-60824 (#1997)

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityAttachments.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityAttachments.vue
@@ -47,7 +47,7 @@ export default {
         }
         const repository = attachment.repository;
         const workspace = attachment.workspace;
-        const imageURL = mimeType.includes('image/') && `${eXo.env.portal.context}/${eXo.env.portal.rest}/thumbnailImage/custom/250x250/${repository}/${workspace}${attachment.docPath.replace(/\[/g, '%5b').replace(/\]/g, '%5d').replace(/\+/g, '%2b')}` || null;
+        const imageURL = mimeType.includes('image/') && `${eXo.env.portal.context}/${eXo.env.portal.rest}/thumbnailImage/custom/250x250/${workspace}/${attachment.id}` || null;
 
         attachments.push({
           id: attachment.id,

--- a/core/webui-clouddrives/src/main/java/org/exoplatform/services/cms/clouddrives/webui/thumbnail/CloudDriveThumbnailRESTService.java
+++ b/core/webui-clouddrives/src/main/java/org/exoplatform/services/cms/clouddrives/webui/thumbnail/CloudDriveThumbnailRESTService.java
@@ -161,6 +161,20 @@ public class CloudDriveThumbnailRESTService extends ThumbnailRESTService {
     }
   }
 
+  @Path("/custom/{size}/{workspaceName}/{identifier}")
+  @GET
+  @Override
+  public Response getCustomImage(@PathParam("size") String size,
+                                 @PathParam("workspaceName") String workspaceName,
+                                 @PathParam("identifier") String identifier,
+                                 @HeaderParam("If-Modified-Since") String ifModifiedSince) throws Exception {
+    if (accept(workspaceName, identifier)) {
+      return super.getCustomImage(size, workspaceName, identifier, ifModifiedSince);
+    } else {
+      return ok();
+    }
+  }
+
   /**
    * {@inheritDoc}
    */


### PR DESCRIPTION
Prior to this change, when move image of an activity from Activity Stream Documents to another folder, the image of this activity does not show up in the activities page After this change, the moved image is displayed in the activities page.