### PR TITLE
fix: upload files in a folder containing % character - EXO-62200

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
@@ -418,7 +418,7 @@ public class ManageDocumentService implements ResourceContainer {
       if ((workspaceName != null) && (driveName != null) && (currentFolder != null)) {
         Node currentFolderNode = getNode(Text.escapeIllegalJcrChars(driveName),
                                          Text.escapeIllegalJcrChars(workspaceName),
-                                         Text.escapeIllegalJcrChars(currentFolder));
+                                         org.exoplatform.services.jcr.util.Text.escapeIllegalJcrChars(currentFolder));
         String userId = ConversationState.getCurrent().getIdentity().getUserId();
         return createProcessUploadResponse(Text.escapeIllegalJcrChars(workspaceName),
                                            currentFolderNode,

--- a/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentServiceImpl.java
@@ -47,6 +47,8 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.manager.IdentityManager;
 
+import static org.exoplatform.services.cms.impl.Utils.cleanNameWithAccents;
+
 public class AttachmentServiceImpl implements AttachmentService {
 
   private static final Log                 LOG        = ExoLogger.getExoLogger(AttachmentServiceImpl.class);
@@ -427,7 +429,7 @@ public class AttachmentServiceImpl implements AttachmentService {
       session = Utils.getSession(sessionProviderService, repositoryService);
       Node currentNode =
                        Utils.getParentFolderNode(session, manageDriveService, nodeHierarchyCreator, nodeFinder, pathDrive, path);
-      if (currentNode.hasNode(title)) {
+      if (currentNode.hasNode(cleanNameWithAccents(title))) {
         throw new ItemExistsException("Document with the same name " + title + " already exist in this current path");
       }
       List<NewDocumentTemplate> documentTemplates = getDocumentTemplateList(userIdentity);

--- a/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImpl.java
@@ -82,6 +82,8 @@ import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.web.CacheUserProfileFilter;
 
+import static org.exoplatform.services.cms.impl.Utils.cleanNameWithAccents;
+
 /**
  * Created by The eXo Platform SAS Author : eXoPlatform exo@exoplatform.com Mar
  * 22, 2011
@@ -565,8 +567,10 @@ public class DocumentServiceImpl implements DocumentService {
         LOG.warn("Couldn't find appropriate metadata plugin for the {} extension.", template.getExtension());
       }
     }
+    // Clean document name
+    String cleanedName = cleanNameWithAccents(title);
     // Add node
-    Node addedNode = currentNode.addNode(title, NT_FILE);
+    Node addedNode = currentNode.addNode(cleanedName, NT_FILE);
 
     // Set title
     if (!addedNode.hasProperty(EXO_TITLE_PROP)) {

--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -673,7 +673,7 @@ public class Utils {
       if (c == '/' || c == ':' || c == '[' || c == ']' || c == '*' || c == '\'' || c == '"' || c == '|' || c == 'ʿ' || c == 'ˇ') {
         cleanedStr.deleteCharAt(i);
         cleanedStr.insert(i, '_');
-      } else if (!(Character.isLetterOrDigit(c) || Character.isWhitespace(c) || c == '.' || c == '-' || c == '_')) {
+      } else if (!(Character.isLetterOrDigit(c) || Character.isWhitespace(c) || c == '.' || c == '-' || c == '_' || c == '%')) {
         cleanedStr.deleteCharAt(i);
         strLength = cleanedStr.length();
         continue;

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <org.exoplatform.platform-ui.version>6.5.x-exo-SNAPSHOT</org.exoplatform.platform-ui.version>
     <addon.exo.analytics.version>1.4.x-exo-SNAPSHOT</addon.exo.analytics.version>
     <!-- **************************************** -->
-    <!-- Apache Chemistry (OpencCMIS) API -->
+    <!-- Apache Chemistry (OpenCMIS) API -->
     <!-- **************************************** -->
     <org.apache.chemistry.opencmis.version>1.1.0</org.apache.chemistry.opencmis.version>
     <!-- **************************************** -->


### PR DESCRIPTION
Priori to this fix, uploading a file in a folder with % character do create another folder with the folder's name minus the percentage character. Thus the file is uploaded in another folder than the choosen one The fix makes sure to avoid deleting % character and selects the correct folder when uploading.