### PR TITLE
fix: Error when create new resource storage dw - EXO-62334 (#2001)

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/wcm/portal/listener/CreateLivePortalEventListener.java
+++ b/core/services/src/main/java/org/exoplatform/services/wcm/portal/listener/CreateLivePortalEventListener.java
@@ -28,6 +28,7 @@ import org.exoplatform.portal.config.model.PortalConfig;
 import org.exoplatform.services.cms.drives.DriveData;
 import org.exoplatform.services.cms.drives.ManageDriveService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
 import org.exoplatform.services.log.ExoLogger;
@@ -39,7 +40,6 @@ import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 
 import javax.jcr.Node;
 import javax.jcr.Session;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -60,10 +60,14 @@ public class CreateLivePortalEventListener extends Listener<DataStorageImpl, Por
 
   private WCMConfigurationService wcmConfigService;
 
+  private NodeHierarchyCreator nodeHierarchyCreator;
+
+
   @SuppressWarnings("unchecked")
-  public CreateLivePortalEventListener(ManageDriveService manageDriveService, WCMConfigurationService configurationService, InitParams params) throws Exception {
+  public CreateLivePortalEventListener(ManageDriveService manageDriveService, WCMConfigurationService configurationService, NodeHierarchyCreator nodeHierarchyCreator, InitParams params) throws Exception {
     this.manageDriveService = manageDriveService;
     this.wcmConfigService = configurationService;
+    this.nodeHierarchyCreator = nodeHierarchyCreator;
     if(params != null) {
       ValueParam autoCreated = params.getValueParam(AUTO_CREATE_DRIVE);
       if(autoCreated != null)
@@ -89,6 +93,7 @@ public class CreateLivePortalEventListener extends Listener<DataStorageImpl, Por
     SessionProvider sessionProvider = SessionProvider.createSystemProvider();
     try {
       try {
+        initNodeHierarchyCreator();
         livePortalManagerService.getLivePortal(sessionProvider, portalConfig.getName());
         return;//portal already exists
       } catch (Exception e) {
@@ -177,5 +182,18 @@ public class CreateLivePortalEventListener extends Listener<DataStorageImpl, Por
       portalConfigService = ExoContainerContext.getService(UserPortalConfigService.class);
     }
     return portalConfigService;
+  }
+
+  private void initNodeHierarchyCreator() {
+    if (!nodeHierarchyCreator.isNodeHierarchyCreatorInitialized()) {
+      LOG.info("init nodeHierarchyCreator ...");
+      try {
+        this.nodeHierarchyCreator.init();
+        LOG.info("nodeHierarchyCreator initialized");
+
+      } catch (Exception e) {
+        LOG.error("error when initializing nodeHierarchyCreator", e);
+      }
+    }
   }
 }


### PR DESCRIPTION
before this change, when initializing portal configurations, an error is detected when creating a new DW resource storage because its portal storage "/sites" is not yet created after this modification, we should avoid creating a new resource storage when its portal storage is not yet created