### PR TITLE
fix: Paste image stored in unexpected drive EXO-62331 (#2018)

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
@@ -6,7 +6,7 @@
       :confirm-close-labels="confirmAbortUploadLabels"
       class="attachmentsAppDrawer"
       right
-      @closed="resetAttachmentsDrawer">
+      @closed="closeAttachmentsAppDrawer">
       <template slot="title">
         <div class="attachmentsDrawerHeader">
           <span>{{ $t('attachments.upload.document') }}</span>
@@ -210,11 +210,7 @@ export default {
     },
   },
   created() {
-    document.addEventListener('paste', this.onPaste, false);
-    this.$root.$on('open-select-from-drives', () => {
-      this.creationType = this.$t('attachments.uploaded.from.cloud');
-      this.openSelectFromDrivesDrawer();
-    });
+    
     this.$root.$on('open-attachments-app-drawer', () => {
       this.attachmentsChanged = false;
       this.openAttachmentsAppDrawer();
@@ -272,11 +268,17 @@ export default {
       }
     },
     openAttachmentsAppDrawer() {
+      document.addEventListener('paste', this.onPaste, false);
+      this.$root.$on('open-select-from-drives', () => {
+        this.creationType = this.$t('attachments.uploaded.from.cloud');
+        this.openSelectFromDrivesDrawer();
+      });
       this.$refs.attachmentsAppDrawer.open();
       this.$root.$emit('attachments-app-drawer-opened');
       window.setTimeout(() => this.handleProvidedFiles(), 400);
     },
     closeAttachmentsAppDrawer() {
+      this.resetAttachmentsDrawer();
       this.$root.$emit('reset-attachments-upload-input');
       document.removeEventListener('paste', this.onPaste, false);
       this.$refs.attachmentsAppDrawer.close();


### PR DESCRIPTION
Prior to this change, when, open spacex document app recent view then upload a document then open chat drawer and open cat room and copy an image on local computer and paste it in cat room, this image is saved under spacex document. After this change, image is not saved on spacex document app.

(cherry picked from commit db9679483fb029bbba78c3a20ca65c9abfbe0491)