### PR TITLE
fix: Process&Task-Upload issue on task and process - EXO-62638 (#2012)

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/Attachment.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/Attachment.vue
@@ -158,7 +158,7 @@ export default {
       if (this.entityType && this.entityId) {
         return this.$attachmentService.getEntityAttachments(this.entityType, this.entityId).then(attachments => {
           attachments.forEach(attachment => attachment.name = attachment.title);
-          this.attachments = attachments;
+          Object.assign(this.attachments, attachments);
         });
       }
     },


### PR DESCRIPTION
prior to this change, After the loading of a document in a task or a request with no attachment, the first uploaded file is no more displayed in the attachment list and the loader of the drawer is running infinitely after this change, force assigning the list to the attachments to detect th changes