### PR TITLE
fix: remove the extra margins so the settings blocks will be aligned - EXO-62228 (#2020)

### DIFF
--- a/apps/portlet-clouddrives/src/main/webapp/vue-app/cloudDriveSettings/components/CloudDriveSettings.vue
+++ b/apps/portlet-clouddrives/src/main/webapp/vue-app/cloudDriveSettings/components/CloudDriveSettings.vue
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
   <v-app>
     <template v-if="displayed">
       <v-card
-        class="border-radius ma-4"
+        class="border-radius my-4"
         flat>
         <v-list>
           <v-list-item>


### PR DESCRIPTION
this fix is added to remove the extra margins in the documents settings block so the settings blocks will be aligned