### PR TITLE
fix: fix create a new version during an upload conflict don't update the last modification date - EXO-62828

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
@@ -566,6 +566,7 @@ public class FileUploadHandler {
       jcrContent.setProperty("jcr:lastModified", new GregorianCalendar());
       jcrContent.setProperty("jcr:data", new BufferedInputStream(new FileInputStream(new File(location))));
       jcrContent.setProperty("jcr:mimeType", mimetype);
+      file.setProperty(NodetypeConstant.EXO_DATE_MODIFIED, new GregorianCalendar());
 
       if(parent.hasNode(nodeName) && CREATE_VERSION.equals(existenceAction)) {
         file.save();


### PR DESCRIPTION
Prior to this change, when we create a new version document, the last modification date is not updated. After this change, we update the exo:dateModified property to get the new modification date.