### PR TITLE
fix: attchment list is not updated in sent request - EXO-62876

### DIFF
--- a/ecms-social-integration/src/main/java/org/exoplatform/services/attachments/plugins/TaskAttachmentEntityTypePlugin.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/services/attachments/plugins/TaskAttachmentEntityTypePlugin.java
@@ -128,6 +128,9 @@ public class TaskAttachmentEntityTypePlugin extends AttachmentEntityTypePlugin {
         ((ExtendedNode) attachmentNode).setPermission(permittedIdentity, new String[]{PermissionType.READ});
         attachmentNode.save();
       }
+      if(linkNodes.isEmpty()) {
+        return Collections.singletonList(attachmentId);
+      }
       return linkNodes;
     } catch (Exception e) {
       LOG.error("Error getting linked documents {}", attachmentId, e);

--- a/ecms-social-integration/src/test/java/org/exoplatform/services/attachments/plugins/TaskAttachmentEntityTypePluginTest.java
+++ b/ecms-social-integration/src/test/java/org/exoplatform/services/attachments/plugins/TaskAttachmentEntityTypePluginTest.java
@@ -103,6 +103,11 @@ public class TaskAttachmentEntityTypePluginTest extends TestCase {
     when(extendedSession.getNodeByIdentifier(anyString())).thenReturn(node);
     when(extendedSession.itemExists(anyString())).thenReturn(true);
 
+    // Return original node ID if it is not under space and user can not access the group's target folder
+    when(node.getPath()).thenReturn("/Users/user1/documents/testFile.docx");
+    assertEquals(1, taskAttachmentEntityTypePlugin.getlinkedAttachments("task", 1, attachmentId).size());
+    assertEquals(attachmentId, taskAttachmentEntityTypePlugin.getlinkedAttachments("task", 1, attachmentId).get(0));
+
     // Create different nodes
     NodeImpl rootNode = mock(NodeImpl.class);
     NodeImpl taskParentNode = mock(NodeImpl.class);


### PR DESCRIPTION
Priori to this fix, when the user session could not create nor access the target group folder, the document link could not be created and the attachment is not linked to the entity. The fix manages this case and adds the original attachment ID if a link if it is not possible to create a link for the document in the target space.