### PR TITLE
fix: Click on uploading from existings invokes the creation of new process work draft - EXO-62961

### DIFF
--- a/apps/portlet-documents/src/main/resources/locale/portlet/attachments_en.properties
+++ b/apps/portlet-documents/src/main/resources/locale/portlet/attachments_en.properties
@@ -20,6 +20,7 @@ attachments.drawer.sameFiles.error={0} files have already been uploaded. Please 
 attachments.drawer.title=Attachments
 attachments.drawer.delete=Delete
 attachments.drawer.existingUploads=Use existing uploads
+attachments.drawer.selectFromExistingUploads=Select on server
 attachments.drawer.apply=Apply
 attachments.upload=Upload
 attachments.drawer.documents=Documents

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsSelectFromDrive.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsSelectFromDrive.vue
@@ -5,20 +5,22 @@
       <v-divider />
     </div>
     <div class="lastContent d-flex align-center justify-center">
-      <a
-        title="Select on server"
-        class="uploadButton d-flex align-center"
-        href="#"
-        rel="tooltip"
-        data-placement="bottom"
-        @click="openSelectFromDrivesDrawer()">
-        <i class="uiIcon32x32FolderDefault uiIcon32x32LightGray"></i>
-        <v-icon
-          color="#fff"
-          x-small
-          class="iconCloud">cloud</v-icon>
-        <span class="text colorText">{{ $t('attachments.drawer.existingUploads') }}</span>
-      </a>
+      <v-tooltip
+        bottom>
+        <template #activator="{ on, attrs }">
+          <v-btn
+            v-bind="attrs"
+            v-on="on"
+            class="uploadButton d-flex align-center"
+            color="primary"
+            text
+            @click="openSelectFromDrivesDrawer()">
+            <i class="uiIcon32x32FolderDefault uiIcon32x32LightGray"></i>
+            <span class="ms-1">{{ $t('attachments.drawer.existingUploads') }}</span>
+          </v-btn>
+        </template>
+        {{ $t('attachments.drawer.selectFromExistingUploads') }}
+      </v-tooltip>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Prior to this change, When during request creation of a process choosing the upload from existing in the attachment drawer triggers the listener of `popstate` in the process app because of used `href=# `in the a tag used to trigger the action of browse server files, which leads of the open of the work drawer and the creation of new request draft. 
This PR should use a `v-btn` instead of using a tag with empty unneeded href attribute.