### PR TITLE
fix: activity params keys case insensitivity block activity updates -EXO-62802 (#2046)

### DIFF
--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/ContentUIActivity.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/ContentUIActivity.java
@@ -29,11 +29,11 @@ public class ContentUIActivity {
 
   public static final String  CONTENT_LINK        = "contenLink";
 
-  public static final String  MESSAGE             = "message";
+  public static final String  MESSAGE             = "MESSAGE";
 
-  public static final String  REPOSITORY          = "repository";
+  public static final String  REPOSITORY          = "REPOSITORY";
 
-  public static final String  WORKSPACE           = "workspace";
+  public static final String  WORKSPACE           = "WORKSPACE  ";
 
   public static final String  CONTENT_NAME        = "contentName";
 


### PR DESCRIPTION
Prior to this change, on mysql a primary varchar column is case sensetive by default, this have created an issue when attempting to like a generated onlyoffice version comment activity because of a duplicated entry exception while inserting activity params, because of a different letter case in some params added by the ecms onlyoffice activity poster with those added by the ecmsActivityStoragePlugin. This PR beside this one https://github.com/Meeds-io/social/pull/2421 changes the generated affected params to uppercase to unify its form and prevent this issue in the future

(cherry picked from commit bc309e1725375179f77f102fd52c42704f8eceb9)