### PR TITLE
fix: Document warning snack bar during document upload conflict is not in the foreground - EXO-62942 

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/snackbar/AttachmentsNotificationAlerts.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/snackbar/AttachmentsNotificationAlerts.vue
@@ -4,7 +4,6 @@
     color="transparent"
     elevation="0"
     app
-    absolute
     bottom
     left>
     <attachments-notification-alert


### PR DESCRIPTION
After this fix, the snack bar will be displayed in the foreground in front of the grey overlay by removing absolute property in order to get the right z-index value.