### PR TITLE
Fix: Lowercase technical names of jcr file nodes - EXO-62912

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
@@ -892,7 +892,7 @@ public class ManageDocumentService implements ResourceContainer {
     }
     Node node = getNode(driveName,workspaceName, currentFolder);
     try {
-      return fileUploadHandler.checkExistence(node, Utils.cleanName(fileName));
+      return fileUploadHandler.checkExistence(node, Utils.cleanName(fileName.toLowerCase()));
     } catch (Exception e) {
       return Response.serverError().entity(e.getMessage()).build();    }
   }

--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
@@ -52,7 +52,6 @@ import org.w3c.dom.Element;
 import javax.jcr.ItemExistsException;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.CacheControl;
 import javax.ws.rs.core.MediaType;
@@ -67,7 +66,6 @@ import java.net.URLDecoder;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * Created by The eXo Platform SAS
@@ -433,9 +431,9 @@ public class FileUploadHandler {
                                String userId,
                                String existenceAction,
                                boolean isNewVersion) throws Exception {
-    String exoTitle = fileName;
+    String exoTitle = Utils.normalizeFileBaseName(fileName);
     fileName = Utils.cleanNameWithAccents(fileName);
-    fileName = Text.escapeIllegalJcrChars(Utils.cleanName(fileName));
+    fileName = Text.escapeIllegalJcrChars(Utils.cleanName(fileName.toLowerCase()));
     try {
       CacheControl cacheControl = new CacheControl();
       cacheControl.setNoCache(true);

--- a/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentServiceImpl.java
@@ -434,7 +434,8 @@ public class AttachmentServiceImpl implements AttachmentService {
       if (!PermissionUtil.canAddNode(currentNode)){
         throw new IllegalAccessException("Permission to create a new document is missing");
       }
-      if (currentNode.hasNode(cleanNameWithAccents(title))) {
+      title = org.exoplatform.services.cms.impl.Utils.normalizeFileBaseName(title);
+      if (currentNode.hasNode(cleanNameWithAccents(title.toLowerCase()))) {
         throw new ItemExistsException("Document with the same name " + title + " already exist in this current path");
       }
       List<NewDocumentTemplate> documentTemplates = getDocumentTemplateList(userIdentity);

--- a/core/services/src/main/java/org/exoplatform/services/attachments/utils/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/utils/Utils.java
@@ -201,8 +201,11 @@ public class Utils {
     }
     return null;
   }
-  
+
   public static boolean isValidDocumentTitle(String name) {
+    if (StringUtils.isBlank(name)) {
+      return false;
+    }
     Pattern regex = Pattern.compile("[<\\\\>:\"/|?*]");
     Matcher matcher = regex.matcher(name);
     return !matcher.find();

--- a/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImpl.java
@@ -570,7 +570,7 @@ public class DocumentServiceImpl implements DocumentService {
     // Clean document name
     String cleanedName = cleanNameWithAccents(title);
     // Add node
-    Node addedNode = currentNode.addNode(cleanedName, NT_FILE);
+    Node addedNode = currentNode.addNode(cleanedName.toLowerCase(), NT_FILE);
 
     // Set title
     if (!addedNode.hasProperty(EXO_TITLE_PROP)) {

--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -18,6 +18,7 @@ package org.exoplatform.services.cms.impl;
 
 import com.ibm.icu.text.Transliterator;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 
@@ -709,6 +710,7 @@ public class Utils {
       extension = name.substring(name.lastIndexOf("."));
       name = name.substring(0, name.lastIndexOf("."));
     }
+    name = name.trim();
     StringBuilder builder = new StringBuilder();
     for (int i = 0; i < name.length(); i++) {
       char currentChar = name.charAt(i);
@@ -751,6 +753,15 @@ public class Utils {
     }
     return Text.escapeIllegalJcrChars(fileName);
 
+  }
+
+  public static String normalizeFileBaseName(String title) {
+    String name = FilenameUtils.getBaseName(title).trim();
+    String extension = FilenameUtils.getExtension(title);
+    if (StringUtils.isNotBlank(extension)) {
+      return name + "." + extension;
+    }
+    return name;
   }
 
   public static List<String> getMemberships() throws Exception {

--- a/core/services/src/test/java/org/exoplatform/services/cms/documents/TestDocumentService.java
+++ b/core/services/src/test/java/org/exoplatform/services/cms/documents/TestDocumentService.java
@@ -61,6 +61,7 @@ public class TestDocumentService extends BaseWCMTestCase {
     Node content = document.getNode("jcr:content");
     assertEquals("Mime-type is not correct", mime, content.getProperty("jcr:mimeType").getString());
     assertEquals("Mime-type is not correct", "", content.getProperty("jcr:data").getString());
+    assertEquals(title.toLowerCase(), document.getName());
     clear();
   }
   
@@ -163,7 +164,7 @@ public class TestDocumentService extends BaseWCMTestCase {
   
   private void clear() throws Exception {
     Node rootNode = session.getRootNode();
-    Node documentNode = rootNode.getNode("Test.docx");
+    Node documentNode = rootNode.getNode("test.docx");
     documentNode.remove();
     session.save();
   }


### PR DESCRIPTION
Prior to this change, created files are case sensitive which affects sometimes the manage conflicts feature due to an inconsistency issue in the letter case.
This PR ensures to make the created file by onlyoffice of by the upload using the lowercase and consider their technical names are lowered case starting from this change.