### PR TITLE
fix : Adding documents and folders in a read only shared folder should not be possible - EXO-63084

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
@@ -417,8 +417,11 @@ public class ManageDocumentService implements ResourceContainer {
                                          Text.escapeIllegalJcrChars(workspaceName),
                                          Text.escapeIllegalJcrChars(currentFolder));
         String userId = ConversationState.getCurrent().getIdentity().getUserId();
-        return createProcessUploadResponse(Text.escapeIllegalJcrChars(workspaceName),
-                                           currentFolderNode,
+
+        if (!PermissionUtil.canAddNode(currentFolderNode)){
+          return Response.status(Status.UNAUTHORIZED).build();
+        }
+        return createProcessUploadResponse(Text.escapeIllegalJcrChars(workspaceName), currentFolderNode,
                                            currentPortal,
                                            userId,
                                            action,
@@ -833,7 +836,6 @@ public class ManageDocumentService implements ResourceContainer {
     }
     return fileUploadHandler.control(uploadId, action);
   }
-
   private String createTitlePath(String driveName, String workspaceName, String currentFolder) throws Exception {
     String[] folders = currentFolder.split("/");
     StringBuilder sb = new StringBuilder();

--- a/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentServiceImpl.java
@@ -25,6 +25,7 @@ import javax.jcr.*;
 import org.apache.commons.lang.StringUtils;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.ecm.utils.permission.PermissionUtil;
 import org.exoplatform.services.attachments.model.Permission;
 import org.exoplatform.services.attachments.model.Attachment;
 import org.exoplatform.services.attachments.plugin.AttachmentACLPlugin;
@@ -429,6 +430,10 @@ public class AttachmentServiceImpl implements AttachmentService {
       session = Utils.getSession(sessionProviderService, repositoryService);
       Node currentNode =
                        Utils.getParentFolderNode(session, manageDriveService, nodeHierarchyCreator, nodeFinder, pathDrive, path);
+
+      if (!PermissionUtil.canAddNode(currentNode)){
+        throw new IllegalAccessException("Permission to create a new document is missing");
+      }
       if (currentNode.hasNode(cleanNameWithAccents(title))) {
         throw new ItemExistsException("Document with the same name " + title + " already exist in this current path");
       }

--- a/core/services/src/main/java/org/exoplatform/services/rest/AttachmentsRestService.java
+++ b/core/services/src/main/java/org/exoplatform/services/rest/AttachmentsRestService.java
@@ -426,6 +426,8 @@ public class AttachmentsRestService implements ResourceContainer {
       Identity userIdentity = getCurrentUserIdentity();
       Attachment attachment = attachmentService.createNewDocument(userIdentity, title, path, pathDrive, templateName);
       return Response.ok(EntityBuilder.fromAttachment(identityManager, attachment)).build();
+    } catch (IllegalAccessException e) {
+      return Response.status(Status.UNAUTHORIZED).entity("Unauthorized to create a new document").build();
     } catch (ItemExistsException e) {
       return Response.status(Status.CONFLICT).entity("Document with the same name already exist in this current path").build();
     } catch (Exception e) {


### PR DESCRIPTION

 This change is going to disallow the ability to add a new folder inside a shared folder with read only permission