### PR TITLE
fix: uploading file with & char in its name is truncated - EXO-63446

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
@@ -323,7 +323,7 @@ export default {
           file.destinationFolder,
           eXo.env.portal.portalName,
           file.uploadId,
-          file.title,
+          encodeURIComponent(file.title),
           eXo.env.portal.language,
           this.saveMode,
           'save'


### PR DESCRIPTION
Prior to this change, when uploading a file while its name contains the & char, the file name is truncated because of a non encoded sent param in the URL. This PR ensures to encode the sent file name to prevent this issue

(cherry picked from commit 249041cc76f53ab55e12080db4f724762ebb3015)