### PR TITLE
fix: Replace & char with underscore in file technical name - EXO-62912 (#2058)

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImpl.java
@@ -568,7 +568,7 @@ public class DocumentServiceImpl implements DocumentService {
       }
     }
     // Clean document name
-    String cleanedName = cleanNameWithAccents(title);
+    String cleanedName = Utils.cleanName(cleanNameWithAccents(title));
     // Add node
     Node addedNode = currentNode.addNode(cleanedName.toLowerCase(), NT_FILE);
 

--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -736,7 +736,7 @@ public class Utils {
     if (StringUtils.isEmpty(oldName)) {
       return oldName;
     }
-    return replaceSpecialChars(oldName, "&#*?@.'\"\t\r\n$\\><:;[]/|");
+    return replaceSpecialChars(oldName, "&#*?!@.'\"\t\r\n$\\><:;[]/|");
   }
 
   /** Return name after cleaning


### PR DESCRIPTION
Prior to this change, when create a file will commercial & the char remains the same in the technical name. This PR makes sure to replace the char with undersoce and so prevent any future issue caused by the sepcial char

(cherry picked from commit 727284bcca866699af057d7f59e1684b435395a0)