### PR TITLE
fix: Fix change location option issue when uploading file - EXO-62498

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
@@ -528,8 +528,11 @@ export default {
       this.openAttachmentsDriveExplorerDrawer();
     });
     this.$root.$on('open-select-from-drives-drawer', () => this.openSelectFromDrivesDrawer());
-    this.$root.$on('change-attachment-destination-path', (file, currentDrive) => {
-      this.currentDrive = currentDrive;
+    this.$root.$on('change-attachment-destination-path', (file) => {
+      this.currentDrive = file.fileDrive;
+      if (file.pathDestinationFolderForFile !== '') {
+        this.defaultFolder = file.pathDestinationFolderForFile;
+      }
       this.initHistoryTree();
       this.openSelectDestinationFolderForFile(file);
     });

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
@@ -528,22 +528,22 @@ export default {
       this.openAttachmentsDriveExplorerDrawer();
     });
     this.$root.$on('open-select-from-drives-drawer', () => this.openSelectFromDrivesDrawer());
-    this.$root.$on('change-attachment-destination-path', (file) => {
-      this.currentDrive = file.fileDrive;
+    this.$root.$on('change-attachment-destination-path', (file, currentDrive) => {
+      this.currentDrive = currentDrive;
       this.initHistoryTree();
       this.openSelectDestinationFolderForFile(file);
     });
   },
   methods: {
     initHistoryTree(){
+      this.foldersHistory = [];
       this.resetExplorer();
-      this.destinationFolder = this.selectedFolderPath ? this.selectedFolderPath : this.defaultFolder;
-      if (this.destinationFolder !== '/'){
+      if (this.defaultFolder !== '/'){
         this.folderPath = '';
-        this.currentAbsolutePath = this.destinationFolder;
-        this.selectedFolderPath = this.destinationFolder;
-        this.schemaFolder = this.currentDrive.title.concat('/', this.destinationFolder);
-        const folderNames = this.destinationFolder.split('/');
+        this.currentAbsolutePath = this.defaultFolder;
+        this.selectedFolderPath = this.defaultFolder;
+        this.schemaFolder = this.currentDrive.title.concat('/', this.defaultFolder);        
+        const folderNames = this.defaultFolder.split('/');
         folderNames.forEach(folderName => {
           this.folderPath = `${this.folderPath}/${folderName}`;
           const folder = {
@@ -554,7 +554,7 @@ export default {
           this.generateHistoryTree(folder);
         });
       }
-      this.fetchChildrenContents(this.destinationFolder); 
+      this.fetchChildrenContents(this.defaultFolder); 
     },
     openAttachmentsDriveExplorerDrawer() {
       this.modeFolderSelection = true;

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
@@ -524,33 +524,37 @@ export default {
     this.attachmentsComposerActions = getAttachmentsComposerExtensions();
     this.$root.$on('open-drive-explorer-drawer', (currentDrive) => {
       this.currentDrive = currentDrive;
-      this.destinationFolder = this.selectedFolderPath ? this.selectedFolderPath : this.defaultFolder;
-      if (this.destinationFolder !== '/'){
-        this.initHistoryTree();
-      }
-      this.fetchChildrenContents(this.destinationFolder);
+      this.initHistoryTree();
       this.openAttachmentsDriveExplorerDrawer();
     });
     this.$root.$on('open-select-from-drives-drawer', () => this.openSelectFromDrivesDrawer());
-    this.$root.$on('change-attachment-destination-path', this.openSelectDestinationFolderForFile);
+    this.$root.$on('change-attachment-destination-path', (file) => {
+      this.currentDrive = file.fileDrive;
+      this.initHistoryTree();
+      this.openSelectDestinationFolderForFile(file);
+    });
   },
   methods: {
     initHistoryTree(){
       this.resetExplorer();
-      this.folderPath = '';
-      this.currentAbsolutePath = this.destinationFolder;
-      this.selectedFolderPath = this.destinationFolder;
-      this.schemaFolder = this.currentDrive.title.concat('/', this.destinationFolder);
-      const folderNames = this.destinationFolder.split('/');
-      folderNames.forEach(folderName => {
-        this.folderPath = `${this.folderPath}/${folderName}`;
-        const folder = {
-          name: folderName,
-          title: folderName,
-          path: this.folderPath
-        };
-        this.generateHistoryTree(folder);
-      });
+      this.destinationFolder = this.selectedFolderPath ? this.selectedFolderPath : this.defaultFolder;
+      if (this.destinationFolder !== '/'){
+        this.folderPath = '';
+        this.currentAbsolutePath = this.destinationFolder;
+        this.selectedFolderPath = this.destinationFolder;
+        this.schemaFolder = this.currentDrive.title.concat('/', this.destinationFolder);
+        const folderNames = this.destinationFolder.split('/');
+        folderNames.forEach(folderName => {
+          this.folderPath = `${this.folderPath}/${folderName}`;
+          const folder = {
+            name: folderName,
+            title: folderName,
+            path: this.folderPath,
+          };
+          this.generateHistoryTree(folder);
+        });
+      }
+      this.fetchChildrenContents(this.destinationFolder); 
     },
     openAttachmentsDriveExplorerDrawer() {
       this.modeFolderSelection = true;

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
@@ -409,6 +409,9 @@ export default {
       modeFolderSelectionForFile: false,
       movedFile: {},
       driveExplorerInitializing: false,
+      currentFolder: {},
+      folderPath: '',
+      destinationFolder: ''
     };
   },
   computed: {
@@ -519,11 +522,36 @@ export default {
     this.initDestinationFolderPath();
     document.addEventListener('extension-AttachmentsComposer-attachments-composer-action-updated', () => this.attachmentsComposerActions = getAttachmentsComposerExtensions());
     this.attachmentsComposerActions = getAttachmentsComposerExtensions();
-    this.$root.$on('open-drive-explorer-drawer', () => this.openAttachmentsDriveExplorerDrawer());
+    this.$root.$on('open-drive-explorer-drawer', (currentDrive) => {
+      this.currentDrive = currentDrive;
+      this.destinationFolder = this.selectedFolderPath ? this.selectedFolderPath : this.defaultFolder;
+      if (this.destinationFolder !== '/'){
+        this.initHistoryTree();
+      }
+      this.fetchChildrenContents(this.destinationFolder);
+      this.openAttachmentsDriveExplorerDrawer();
+    });
     this.$root.$on('open-select-from-drives-drawer', () => this.openSelectFromDrivesDrawer());
     this.$root.$on('change-attachment-destination-path', this.openSelectDestinationFolderForFile);
   },
   methods: {
+    initHistoryTree(){
+      this.resetExplorer();
+      this.folderPath = '';
+      this.currentAbsolutePath = this.destinationFolder;
+      this.selectedFolderPath = this.destinationFolder;
+      this.schemaFolder = this.currentDrive.title.concat('/', this.destinationFolder);
+      const folderNames = this.destinationFolder.split('/');
+      folderNames.forEach(folderName => {
+        this.folderPath = `${this.folderPath}/${folderName}`;
+        const folder = {
+          name: folderName,
+          title: folderName,
+          path: this.folderPath
+        };
+        this.generateHistoryTree(folder);
+      });
+    },
     openAttachmentsDriveExplorerDrawer() {
       this.modeFolderSelection = true;
       this.$refs.driveExplorerDrawer.open();

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
@@ -295,7 +295,7 @@ export default {
       }
     },
     openSelectDestinationFolderForFile(attachment) {
-      this.$root.$emit('change-attachment-destination-path', attachment);
+      this.$root.$emit('change-attachment-destination-path', attachment, this.currentDrive);
     },
     absoluteDateModified(options) {
       const lang = eXo && eXo.env && eXo.env.portal && eXo.env.portal.language || 'en';

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
@@ -295,7 +295,7 @@ export default {
       }
     },
     openSelectDestinationFolderForFile(attachment) {
-      this.$root.$emit('change-attachment-destination-path', attachment, this.currentDrive);
+      this.$root.$emit('change-attachment-destination-path', attachment);
     },
     absoluteDateModified(options) {
       const lang = eXo && eXo.env && eXo.env.portal && eXo.env.portal.language || 'en';

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadedFiles.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadedFiles.vue
@@ -13,7 +13,10 @@
       </div>
       <span>{{ $t('no.attachments') }}</span>
     </div>
-    <div v-if="attachments.length > 0" class="destinationFolder d-flex justify-space-between mb-4 ms-5">
+    <!-- we hide the possibility to select a folder for all files
+    There a lot of problem with this feature and need a rework to make it work.
+    To be able to release 6.4.0 we hide it -->
+    <div v-if="false && attachments.length > 0" class="destinationFolder d-flex justify-space-between mb-4 ms-5">
       <div v-if="!displayMessageDestinationFolder && schemaFolder.length" class="destinationFolderBreadcrumb d-flex">
         <div
           :title="schemaFolder[0]"

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadedFiles.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadedFiles.vue
@@ -169,7 +169,7 @@ export default {
   },
   methods: {
     openSelectDestinationFolderDrawer() {
-      this.$root.$emit('open-drive-explorer-drawer');
+      this.$root.$emit('open-drive-explorer-drawer', this.currentDrive);
     }
   }
 };


### PR DESCRIPTION
Prior to this change, when we upload a file and change the location option, all accessible drives are displayed.
After this fix, if I have not changed the location of any of the uploaded documents, the current location is proposed to change the location of the uploaded file, otherwise the location where the upload was initially done is proposed.