### PR TITLE
fix: Cannot use existing uploads when folder contains a document with name that includes the  % character - EXO-62908

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
@@ -436,7 +436,13 @@ export default {
       }
       files.forEach(file => {
         file.isSelected = this.attachedFiles.some(f => f.id === file.id);
-        file.name = decodeURI(file.name);
+        try {
+          file.name = decodeURI(file.name);
+        }
+        catch (error) {
+          // Nothing to do, name contains % character , but it represents not an encoded character
+          // No need to decode the file name
+        }
       });
       return files;
     },


### PR DESCRIPTION
Before to this change when we try to use existing upload to attach document we cannot open folders including document with name contains % character , and an console error would appear stating malformed URI , This change is going to catch this error when no need to decode the file name .