### PR TITLE
fix : Add new document version using only office generate no content activity -EXO-63508

### DIFF
--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/ContentUIActivity.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/ContentUIActivity.java
@@ -33,7 +33,7 @@ public class ContentUIActivity {
 
   public static final String  REPOSITORY          = "REPOSITORY";
 
-  public static final String  WORKSPACE           = "WORKSPACE  ";
+  public static final String  WORKSPACE           = "WORKSPACE";
 
   public static final String  CONTENT_NAME        = "contentName";
 


### PR DESCRIPTION
Prior to this change when we create a new document version using only office an empty activity is generated , the problem was a regression caused by this commit https://github.com/exoplatform/ecms/commit/bc309e1725375179f77f102fd52c42704f8eceb9
This change addresses this issue 