### PR TITLE
fix: display missing change location link for the first uploded item - EXO-63466

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
@@ -178,6 +178,7 @@ export default {
           title: file.name,
           size: file.size,
           mimetype: file.type,
+          acl: file.acl,
           uploadId: this.getNewUploadId(),
           uploadProgress: 0,
           destinationFolder: this.pathDestinationFolder,


### PR DESCRIPTION

To display the change location link for the uploaded items we need to check if the uploader has the permission to move each item . This permission is a computed value based on the item's access list , however the access list is messing for the first uploaded item ,after this change we will add the access list to the first uploaded item to display the missing change location link .