### PR TITLE
fix : Save new version by only office generate no content activity - EXO-63508 

### DIFF
--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/ContentUIActivity.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/ContentUIActivity.java
@@ -33,7 +33,7 @@ public class ContentUIActivity {
 
   public static final String  REPOSITORY          = "REPOSITORY";
 
-  public static final String  WORKSPACE           = "WORKSPACE  ";
+  public static final String  WORKSPACE           = "WORKSPACE";
 
   public static final String  CONTENT_NAME        = "contentName";
 


### PR DESCRIPTION
This change is going to trim the TEMPLATE_PARAM_KEY column of the SOC_TEMPLTATE_PARAMS table after a regression due to this commit https://github.com/exoplatform/ecms/commit/bc309e1725375179f77f102fd52c42704f8eceb9