### PR TITLE
fix:Add missing German transaltion in Ckeditor - EXO-63816 (#2078)

### DIFF
--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/acceptInline/lang/de.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/acceptInline/lang/de.js
@@ -1,6 +1,18 @@
 /*
- * Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or http://ckeditor.com/license
+ * Copyright (C) 2023 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 CKEDITOR.plugins.setLang( 'acceptInline', 'de',
 {

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/acceptInline/lang/de.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/acceptInline/lang/de.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'acceptInline', 'de',
+{
+  AcceptUpdateInline        : 'Annehmen'
+} );

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/acceptInline/lang/de.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/acceptInline/lang/de.js
@@ -1,3 +1,7 @@
+/*
+Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or http://ckeditor.com/license
+*/
 CKEDITOR.plugins.setLang( 'acceptInline', 'de',
 {
   AcceptUpdateInline        : 'Annehmen'

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/acceptInline/lang/de.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/acceptInline/lang/de.js
@@ -1,7 +1,7 @@
 /*
-Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
-*/
+ * Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or http://ckeditor.com/license
+ */
 CKEDITOR.plugins.setLang( 'acceptInline', 'de',
 {
   AcceptUpdateInline        : 'Annehmen'

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/acceptInline/plugin.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/acceptInline/plugin.js
@@ -4,7 +4,7 @@ require(['/eXoResources/javascript/jquery-3.2.1.js']);
 
 CKEDITOR.plugins.add('acceptInline',
 	{
-    lang : ['en','fr','vi'],
+    lang : ['en','fr','vi', 'de'],
 		init : function(editor) {
 			var pluginName = 'acceptInline';
 			var mypath = this.path;	

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/attachFile/lang/de.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/attachFile/lang/de.js
@@ -1,6 +1,18 @@
 /*
- * Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or http://ckeditor.com/license
+ * Copyright (C) 2023 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 CKEDITOR.plugins.setLang( 'attachFile', 'de',
     {

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/attachFile/lang/de.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/attachFile/lang/de.js
@@ -1,7 +1,7 @@
 /*
-Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
-*/
+ * Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or http://ckeditor.com/license
+ */
 CKEDITOR.plugins.setLang( 'attachFile', 'de',
     {
       buttonTooltip                 : 'Fügen Sie ein Dokument oder ein Bild hinzu',

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/attachFile/lang/de.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/attachFile/lang/de.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'attachFile', 'de',
+    {
+      buttonTooltip                 : 'Fügen Sie ein Dokument oder ein Bild hinzu',
+    } );

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/attachFile/lang/de.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/attachFile/lang/de.js
@@ -1,3 +1,7 @@
+/*
+Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or http://ckeditor.com/license
+*/
 CKEDITOR.plugins.setLang( 'attachFile', 'de',
     {
       buttonTooltip                 : 'Fügen Sie ein Dokument oder ein Bild hinzu',

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/attachFile/plugin.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/attachFile/plugin.js
@@ -2,7 +2,7 @@ CKEDITOR.plugins.add( 'attachFile', {
 
   // Register the icons. They must match command names.
   icons: 'attachFile',
-  lang : ['en','fr'],
+  lang : ['en','fr','de'],
 
   // The plugin initialization logic goes inside this method.
   init: function( editor ) {

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/cancelInline/lang/de.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/cancelInline/lang/de.js
@@ -1,6 +1,18 @@
 /*
- * Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or http://ckeditor.com/license
+ * Copyright (C) 2023 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 CKEDITOR.plugins.setLang( 'cancelInline', 'de',
 {

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/cancelInline/lang/de.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/cancelInline/lang/de.js
@@ -1,0 +1,4 @@
+CKEDITOR.plugins.setLang( 'cancelInline', 'de',
+{
+  CancelUpdateInline        : 'Abbrechen'
+} );

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/cancelInline/lang/de.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/cancelInline/lang/de.js
@@ -1,3 +1,7 @@
+/*
+Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or http://ckeditor.com/license
+*/
 CKEDITOR.plugins.setLang( 'cancelInline', 'de',
 {
   CancelUpdateInline        : 'Abbrechen'

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/cancelInline/lang/de.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/cancelInline/lang/de.js
@@ -1,7 +1,7 @@
 /*
-Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
-*/
+ * Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or http://ckeditor.com/license
+ */
 CKEDITOR.plugins.setLang( 'cancelInline', 'de',
 {
   CancelUpdateInline        : 'Abbrechen'

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/cancelInline/plugin.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/cancelInline/plugin.js
@@ -3,7 +3,7 @@ require(['/eXoResources/javascript/jquery-3.2.1.js']);
 
 CKEDITOR.plugins.add('cancelInline',
 	{
-    lang : ['en','fr','vi'],
+    lang : ['en','fr','vi','de'],
 		init : function(editor) {
 			var pluginName = 'cancelInline';
 			var mypath = this.path;	

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/content/lang/de.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/content/lang/de.js
@@ -1,8 +1,8 @@
 /*
-Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
-*/
-var UserLanguage = {
+ * Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or http://ckeditor.com/license
+ */
+let UserLanguage = {
 	Filter							:	"Filter",
 	All									:"Alles",
 	WebContents						:   "Web-Inhalte",

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/content/lang/de.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/content/lang/de.js
@@ -1,0 +1,56 @@
+var UserLanguage = {
+	Filter							:	"Filter",
+	All									:"Alles",
+	WebContents						:   "Web-Inhalte",
+	DMSDocuments					:	"Document DMS",
+	Medias							:	"Medien",
+	UploadFile						:	"Eine Datei hochladen",
+
+	SettingTitle					: 	"Einstellungen",
+	SetView							: 	"Anzeige",
+	SetSort							: 	"Sortieren",
+
+	SortName						:	"Dateiname",
+	SortDate						: 	"Datum",
+	SortSize						: 	"Grösse",
+
+	ViewThumbnail						: 	"Thumbnail",
+	ViewList						: 	"Liste",
+
+	ViewThumbnailLabel  					:	"Thumbnailansicht",
+	ViewListLabel       					:	"Liste ansehen",
+
+	Home							:	"Startseite",
+
+	FileName						:	"Name",
+	CreateDate						:	"Datum",
+	FileSize						:	"Grösse",
+
+	NoContent						:	"Es ist kein Inhalt vorhanden",
+
+	BtnCancel						: 	"abbrechen",
+	BtnUpload						: 	"senden",
+	BtnSetting						: 	"Einstellung",
+	BtnClose						: 	"schliessen",
+	BtnSave							: 	"speichern",
+	BtnAbort						: 	"abbrechen",
+	BtnDelete						: 	"löschen",
+
+	LabelFolder						: 	"Datei",
+	LabelAlert						: 	"Bitte wählen Sie eine Datei zum hochladen aus",
+	LabelName						: 	"Name",
+	SelectFile						:	"Datei",
+
+	//Document Auto Versioning
+	DocumentAuto_label_existing:"Existierende Datei",
+	DocumentAuto_label_keepBoth:"Beide Dateien behalten",
+	DocumentAuto_label_createVersion:"Eine neue Version erstellen",
+	DocumentAuto_label_replace:"Ersetzen",
+	DocumentAuto_label_or:"oder",
+	DocumentAuto_label_cancel:"abbrechen"
+}
+
+CKEDITOR.plugins.setLang( 'content', 'de',
+{
+  WCMInsertContentPlugins        : 'Einen Link einfügen'
+} );

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/content/lang/de.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/content/lang/de.js
@@ -1,3 +1,7 @@
+/*
+Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or http://ckeditor.com/license
+*/
 var UserLanguage = {
 	Filter							:	"Filter",
 	All									:"Alles",

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/content/lang/de.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/content/lang/de.js
@@ -1,6 +1,18 @@
 /*
- * Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or http://ckeditor.com/license
+ * Copyright (C) 2023 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 let UserLanguage = {
 	Filter							:	"Filter",

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/content/plugin.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/content/plugin.js
@@ -1,6 +1,6 @@
 CKEDITOR.plugins.add('content',
 	{
-    lang : ['en','fr','vi'],
+    lang : ['en','fr','vi','de'],
 		init : function(editor) {
 			var pluginName = 'content';
 			var mypath = this.path;	

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/insertPortalLink/lang/de.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/insertPortalLink/lang/de.js
@@ -1,0 +1,10 @@
+CKEDITOR.plugins.setLang( 'insertPortalLink', 'de',
+{
+  WCMInsertPortalLinkPlugins        : 'Link in eine Seite einfÃ¼gen',
+  WCMInsertPortalLinkDialogTitle    : 'Link in eine Seite einfÃ¼gen',
+  WCMInsertPortalLinkInputTitle     : 'Titel: ',
+  WCMInsertPortalLinkInputUrl       : 'URL: ',
+  WCMInsertPortalLinkButtonGet      : 'Portallink erhalten',
+  WCMInsertPortalLinkButtonPreview  : 'Vorschau',
+  WCMInsertPortalLinkButtonSave     : 'Speichern'
+} );

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/insertPortalLink/lang/de.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/insertPortalLink/lang/de.js
@@ -1,6 +1,18 @@
 /*
- * Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or http://ckeditor.com/license
+ * Copyright (C) 2023 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 CKEDITOR.plugins.setLang( 'insertPortalLink', 'de',
 {

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/insertPortalLink/lang/de.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/insertPortalLink/lang/de.js
@@ -1,3 +1,7 @@
+/*
+Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or http://ckeditor.com/license
+*/
 CKEDITOR.plugins.setLang( 'insertPortalLink', 'de',
 {
   WCMInsertPortalLinkPlugins        : 'Link in eine Seite einfÃ¼gen',

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/insertPortalLink/lang/de.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/insertPortalLink/lang/de.js
@@ -1,7 +1,7 @@
 /*
-Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
-For licensing, see LICENSE.md or http://ckeditor.com/license
-*/
+ * Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or http://ckeditor.com/license
+ */
 CKEDITOR.plugins.setLang( 'insertPortalLink', 'de',
 {
   WCMInsertPortalLinkPlugins        : 'Link in eine Seite einfÃ¼gen',

--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/insertPortalLink/plugin.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/insertPortalLink/plugin.js
@@ -1,7 +1,7 @@
 CKEDITOR.plugins.add( 'insertPortalLink',
 {
 	requires : [ 'dialog' ],
-	lang : ['en','fr','vi'],
+	lang : ['en','fr','vi','de'],
 	init : function( editor )
 	{
 		editor.ui.addButton( 'insertPortalLink.btn',


### PR DESCRIPTION
Prior to this fix, ckeditor isn't displaying german translated elements. Following this PR(https://github.com/exoplatform/ecms/pull/1671), this fix adds missing German translated elements.

(cherry picked from commit d28fa05c7ad036c81542a5f69cdff5d5001c6b8f)