### PR TITLE
fix : Do not allow uploading more than the defined maximum number of documents - EXO-61841

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
@@ -199,15 +199,16 @@ export default {
         });
       }
 
-      newAttachedFiles.filter(file => !this.attachments.some(f => f.title === file.title)).forEach((newFile, index) => {
-        if (index === this.maxFilesCount || this.maxFilesCount === 0) {
+      newAttachedFiles.filter(file => !this.attachments.some(f => f.title === file.title)).every((newFile, index) => {
+        if (index === 3 || this.maxFilesCount === 0) {
           this.$root.$emit('attachments-notification-alert', {
             message: this.maxFileCountErrorLabel,
             type: 'error',
           });
-          return;
+          return false;
         } else {
           this.queueUpload(newFile);
+          return true;
         }
       });
       this.$refs.uploadInput.value = null;

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
@@ -200,7 +200,7 @@ export default {
       }
 
       newAttachedFiles.filter(file => !this.attachments.some(f => f.title === file.title)).every((newFile, index) => {
-        if (index === 3 || this.maxFilesCount === 0) {
+        if (index === this.maxFilesCount || this.maxFilesCount === 0) {
           this.$root.$emit('attachments-notification-alert', {
             message: this.maxFileCountErrorLabel,
             type: 'error',

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
@@ -200,13 +200,11 @@ export default {
       }
 
       newAttachedFiles.filter(file => !this.attachments.some(f => f.title === file.title)).forEach((newFile, index) => {
-        if (this.attachments.length === this.maxFilesCount) {
-          if (this.newUploadedFiles[index - 1] || index === 0) {
-            this.$root.$emit('attachments-notification-alert', {
-              message: this.maxFileCountErrorLabel,
-              type: 'error',
-            });
-          }
+        if (index === this.maxFilesCount || this.maxFilesCount === 0) {
+          this.$root.$emit('attachments-notification-alert', {
+            message: this.maxFileCountErrorLabel,
+            type: 'error',
+          });
           return;
         } else {
           this.queueUpload(newFile);

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/snackbar/AttachmentsNotificationAlerts.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/snackbar/AttachmentsNotificationAlerts.vue
@@ -45,9 +45,7 @@ export default {
   },
   methods: {
     addAlert(alert) {
-      //check if the alert is already displayed
-      const alertExists = this.alerts.some((existingAlert) => existingAlert.message === alert.message && existingAlert.type === alert.type);
-      if (alert && !alertExists) {
+      if (alert) {
         this.alerts.push(alert);
         // eslint-disable-next-line no-magic-numbers
         window.setTimeout(() => this.deleteAlert(alert), 5000);

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/snackbar/AttachmentsNotificationAlerts.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/snackbar/AttachmentsNotificationAlerts.vue
@@ -45,7 +45,9 @@ export default {
   },
   methods: {
     addAlert(alert) {
-      if (alert) {
+      //check if the alert is already displayed
+      const alertExists = this.alerts.some((existingAlert) => existingAlert.message === alert.message && existingAlert.type === alert.type);
+      if (alert && !alertExists) {
         this.alerts.push(alert);
         // eslint-disable-next-line no-magic-numbers
         window.setTimeout(() => this.deleteAlert(alert), 5000);


### PR DESCRIPTION
Before this change, we were able to upload more documents than the defined maximum limit.
The problem was the incorrect check for the uploaded file number.
With this change, it will not be possible to upload more than the defined maximum number.