### PR TITLE
fix: add attachment app to Notes edition page - EXO-64149

### DIFF
--- a/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/wcm-extension/dynamic-container-configuration.xml
+++ b/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/wcm-extension/dynamic-container-configuration.xml
@@ -285,6 +285,54 @@
         </object-param>
       </init-params>
     </component-plugin>
+    <!-- Add attachment app to the Notes edition page -->
+    <component-plugin>
+      <name>addPlugin</name>
+      <set-method>addPlugin</set-method>
+      <type>org.exoplatform.commons.addons.AddOnPluginImpl</type>
+      <description>add application Config</description>
+      <init-params>
+        <value-param>
+          <name>priority</name>
+          <value>10</value>
+        </value-param>
+        <value-param>
+          <name>containerName</name>
+          <value>bottom-notes-editor-container</value>
+        </value-param>
+        <object-param>
+          <name>attachment-app-portlet</name>
+          <description></description>
+          <object type="org.exoplatform.commons.addons.PortletModel">
+            <field name="contentId">
+              <string>documents/AttachmentApp</string>
+            </field>
+            <field name="permissions">
+              <collection type="java.util.ArrayList">
+                <value>
+                  <string>*:/platform/users</string>
+                </value>
+                <value>
+                  <string>*:/platform/externals</string>
+                </value>
+              </collection>
+            </field>
+            <field name="title">
+              <string>>Attachments App Portlet</string>
+            </field>
+            <field name="showInfoBar">
+              <boolean>false</boolean>
+            </field>
+            <field name="showApplicationState">
+              <boolean>false</boolean>
+            </field>
+            <field name="showApplicationMode">
+              <boolean>false</boolean>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 
 </configuration>


### PR DESCRIPTION
Attachment app was not added to the page of Notes edition, thus the attachment drawer was not initiated and the attach image popup does not appear when we click on attach image button when editing a Note.
the fix adds the configuration that will inject dynamically the attachmentApp to the page of Notes edition.