### PR TITLE
fix: warning when loading files - EXO-64092  (#2086)

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/FavoriteServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/FavoriteServiceImpl.java
@@ -102,7 +102,7 @@ public class FavoriteServiceImpl implements org.exoplatform.services.cms.documen
           ret.add(node);
         }
       } catch (RepositoryException repositoryException) {
-        LOG.warn("Can't get Favorite Node with UIID {}",favorite.getObjectId());
+        LOG.warn("Can't get Favorite Node with UUID {}",favorite.getObjectId());
       }
     }
     }
@@ -121,10 +121,13 @@ public class FavoriteServiceImpl implements org.exoplatform.services.cms.documen
   public boolean isFavoriter(String userName, Node node) throws Exception {
     try {
       Identity identity = identityManager.getOrCreateUserIdentity(userName);
-      Favorite favorite = new Favorite("file", node.getUUID(), "", Long.parseLong(identity.getId()));
-      return favoriteService.isFavorite(favorite);
+      if(node.isNodeType(NodetypeConstant.MIX_REFERENCEABLE)) {
+        Favorite favorite = new Favorite("file", node.getUUID(), "", Long.parseLong(identity.getId()));
+        return favoriteService.isFavorite(favorite);
+      }
+      return false;
     } catch (Exception e) {
-      LOG.warn("Cannot get the identifier of the node");
+      LOG.warn("Cannot get the identifier of the node", e.getMessage());
       return false;
     }
   }


### PR DESCRIPTION
When opening personal folder, a warning pops out sometimes indicating that it can not get favorite of a file/folder. The issue is caused by the fact that the file/folder was not a mix:referenceable and thus doesn't have a UUID, thus a check was added to avoid such warning

(cherry picked from commit 9dc7b76341cc14f006bc9d28f76ad998f0043705)