### PR TITLE
fix : Do not allow uploading more than the defined maximum number of documents - EXO-61841 (#2085)

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
@@ -199,17 +199,16 @@ export default {
         });
       }
 
-      newAttachedFiles.filter(file => !this.attachments.some(f => f.title === file.title)).forEach((newFile, index) => {
-        if (this.attachments.length === this.maxFilesCount) {
-          if (this.newUploadedFiles[index - 1] || index === 0) {
-            this.$root.$emit('attachments-notification-alert', {
-              message: this.maxFileCountErrorLabel,
-              type: 'error',
-            });
-          }
-          return;
+      newAttachedFiles.filter(file => !this.attachments.some(f => f.title === file.title)).every((newFile, index) => {
+        if (index === this.maxFilesCount || this.maxFilesCount === 0) {
+          this.$root.$emit('attachments-notification-alert', {
+            message: this.maxFileCountErrorLabel,
+            type: 'error',
+          });
+          return false;
         } else {
           this.queueUpload(newFile);
+          return true;
         }
       });
       this.$refs.uploadInput.value = null;


### PR DESCRIPTION
Before this change, we were able to upload more documents than the defined maximum limit. The problem was the incorrect check for the uploaded file number. With this change, it will not be possible to upload more than the defined maximum number.