### PR TITLE
fix : preventing users from re-uploading documents to the same attachment drawer after reaching the maximum limit - EXO-64261

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
@@ -200,7 +200,7 @@ export default {
       }
 
       newAttachedFiles.filter(file => !this.attachments.some(f => f.title === file.title)).every((newFile, index) => {
-        if (index === this.maxFilesCount || this.maxFilesCount === 0) {
+        if (index === this.maxFilesCount || this.maxFilesCount === 0 || this.uploadingCount === this.maxFilesCount) {
           this.$root.$emit('attachments-notification-alert', {
             message: this.maxFileCountErrorLabel,
             type: 'error',


### PR DESCRIPTION
This fix is going to prevent users from re-uploading documents to the same attachment drawer after reaching the maximum limit.