### PR TITLE
ok button disabled when inserting image -EXO-63849

### DIFF
--- a/apps/resources-wcm/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/apps/resources-wcm/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -596,8 +596,10 @@
       <module>base</module>
       <as>gtnbase</as>
     </depends>
+    <depends>
+      <module>portalRequest</module>
+    </depends> 
   </module>
 
 
 </gatein-resources>
-


### PR DESCRIPTION
Prior to this change, when upload image from computer in notes, ok button is disabled . To fix this problem, add the portalRequest dependency in the UISelectFromDrives module. After this change, the image upload in the notes is done correctly.