### PR TITLE
Fix: ok button disabled when inserting image -EXO-63849 (#2098)

### DIFF
--- a/apps/resources-wcm/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/apps/resources-wcm/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -596,8 +596,10 @@
       <module>base</module>
       <as>gtnbase</as>
     </depends>
+    <depends>
+      <module>portalRequest</module>
+    </depends> 
   </module>
 
 
 </gatein-resources>
-


### PR DESCRIPTION
Prior to this change, when upload image from computer in notes, ok button is disabled . To fix this problem, add the portalRequest dependency in the UISelectFromDrives module. After this change, the image upload in the notes is done correctly.

(cherry picked from commit 5ae21807d9b835749113804a6d36f9bd71744f04)