### PR TITLE
Attach image to an article from connected one/google personal drive -EXO-63936

### DIFF
--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/UISelectFromDrives.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/UISelectFromDrives.js
@@ -2,6 +2,7 @@
   var UISelectFromDrives = {
       personalDriveName : "Personal Documents",
       defaultPrivateLocation : "Public",
+      thumbnailUrl : '',
       init : function(imageDialogWindowCnt, spaceGroupId, callback) {
         this.driveDatas = null;
         this.callback = callback;
@@ -71,7 +72,11 @@
           this.selectBTN.on("click", function() {
             self.imageDialogWindowCnt.find(" > *").removeClass("hidden");
             self.selectExistingDriveCnt.addClass("hidden");
-            self.callback(window.location.origin + self.selectedFileURL);
+            if (self.thumbnailUrl && self.thumbnailUrl !== 'undefined') {
+              self.callback(self.thumbnailUrl);
+            } else {
+              self.callback(window.location.origin + self.selectedFileURL);
+            }
             self.selectExistingDriveCnt.find(".fileSelection").removeClass("selected");
             self.setSelectedFile();
           });
@@ -205,15 +210,23 @@
               filesArray.each(function() {
                 var relativePath = $(this).attr("path").replace(self.selectedDriveData.attr("path") + "/", "");
                 $('<div class="fileSelection">' +
-                  '<a href="javascript:void(0);" rel="tooltip" data-placement="bottom" title="" data-original-title="' + $(this).attr("title") + '" data-name="' + $(this).attr("name") + '" data-url="' + $(this).attr("url") + '">' +
+                  '<a href="javascript:void(0);" rel="tooltip" data-placement="bottom" title="" data-original-title="' + $(this).attr("title") + '" data-name="' + $(this).attr("name") + '" data-url="' + $(this).attr("url") + '" thumbnail-url="' + $(this).attr("thumbnailUrl") + '">' +
                     '<div class="' + $(this).attr("nodeTypeCssClass") + ' selectionIcon center"></div>' +
                     '<div class="selectionLabel truncate center">' + $(this).attr("title") + '</div>' +
                   '</a>' +
                 '</div>').insertAfter(".selectExistingDriveDialog .filesTitle");
               });
               this.selectExistingDriveCnt.find(".fileSelection a").on("click", function() {
+                var fileURL = '';
                 self.selectExistingDriveCnt.find(".fileSelection").removeClass("selected");
-                self.setSelectedFile($(this).attr("data-url"));
+                if ($(this).attr("thumbnail-url") && $(this).attr("thumbnail-url") !== 'undefined') {
+                  self.thumbnailUrl = $(this).attr("thumbnail-url");
+                  fileURL = self.thumbnailUrl;
+                } else {
+                  self.thumbnailUrl = '';
+                  fileURL = $(this).attr("data-url");
+                }
+                self.setSelectedFile(fileURL);
                 $(this).parent().addClass("selected");
               });
             }

--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/handler/FCKFileHandler.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/handler/FCKFileHandler.java
@@ -20,6 +20,8 @@ import org.w3c.dom.Element;
 import javax.jcr.Node;
 import java.text.SimpleDateFormat;
 
+import static org.exoplatform.wcm.connector.fckeditor.DriverConnector.FILE_TYPE_SIMPLE_IMAGE;
+
 public class FCKFileHandler {
 
   public static Element createFileElement(Document document,
@@ -40,6 +42,9 @@ public class FCKFileHandler {
     Element file = document.createElement("File");
     AutoVersionService autoVersionService=WCMCoreUtils.getService(AutoVersionService.class);
     file.setAttribute("name", Utils.getTitle(displayNode));
+    if (sourceNode.hasProperty("ecd:thumbnailUrl") && fileType.equals(FILE_TYPE_SIMPLE_IMAGE)) {
+      file.setAttribute("thumbnailUrl", sourceNode.getProperty("ecd:thumbnailUrl").getString());
+    }
     if (childRelativePath != null) {
       file.setAttribute("currentFolder", childRelativePath);
     }


### PR DESCRIPTION
Prior to this change, when connecting a personal drive/Google Drive that contains an image in the body of the article, click the Insert Image button, then select the Select from existing uploads option, in the body of the article, click the insert image button, then select the select from existing uploads option and add an image from the one/google personal drive. An error message displays: Could not load the image using that URL and the image isn't uploaded .To fix this problem, add a property thumbnailUrl to retrieve the image url from google drive. After this change, The image should be well uploaded and added in the article body.