### PR TITLE
fix: Select from existing uploads filtered space displays empty content - EXO-63848

### DIFF
--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/UISelectFromDrives.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/UISelectFromDrives.js
@@ -289,7 +289,7 @@
           });
         }
         $('*[rel="tooltip"]').tooltip();
-        this.selectExistingDriveCnt.find(".searchBox input").trigger("keyup");
+        this.selectExistingDriveCnt.find(".searchBox input").val('').trigger("keyup");
       },
       initSearchBox : function($parentElement) {
         if($.expr && $.expr.createPseudo) {


### PR DESCRIPTION
Prior to this change, when click the Insert Image button in note editor , then select the Select from existing uploads option, in the body of the article, click the insert image button, then in search box search for a space whose doc app contain images Select from existing uploads show No results. To fix this problem, empty the value of the search input when clicking on the inbox. After this change, select from existing uploads show results.

(cherry picked from commit c543bc293b552cbae5d4411f4097916b01e707c0)