### PR TITLE
fix: Enable to preview a file containing an '+' character in its name- EXO-64192

### DIFF
--- a/core/webui/src/main/java/org/exoplatform/wcm/webui/Utils.java
+++ b/core/webui/src/main/java/org/exoplatform/wcm/webui/Utils.java
@@ -831,7 +831,7 @@ public class Utils {
              .append(repository)
              .append("/")
              .append(workspace)
-             .append(originalNodePath);
+             .append(originalNodePath.replace("%", "%25"));
     if (withTimeParam) {
       if (imagePath.indexOf("?") > 0) {
         imagePath.append("&time=");


### PR DESCRIPTION
Before this change, when we uploaded a file with a name containing the '+' character, we were unable to preview or download it. The problem was that the '+' character in the file's path was being replaced by a space.
With this change, we will encode the node name part on the document's download url.