### PR TITLE
fix : Enable to preview and download file with name contains a special character - EXO-64575

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -736,7 +736,7 @@ public class Utils {
     if (StringUtils.isEmpty(oldName)) {
       return oldName;
     }
-    return replaceSpecialChars(oldName, "&#*?!@.'\"\t\r\n$\\><:;[]/|");
+    return replaceSpecialChars(oldName, "&#*?!@.'\"\t\r\n$\\><:;[]/|’");
   }
 
   /** Return name after cleaning


### PR DESCRIPTION
Before this change, we were unable to preview or upload a document with a name that contained the character " ’ ". This change will add this character to the list of special characters that will be replaced by an underscore.