### PR TITLE
fix : Enable to download document with name contains a + character from chat application - EXO-64667

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/DownloadConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/DownloadConnector.java
@@ -22,6 +22,7 @@ import javax.ws.rs.core.Response;
 import java.io.InputStream;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Enables downloading the content of _nt\:file_.
@@ -61,7 +62,11 @@ public class DownloadConnector implements ResourceContainer{
     if (!path.startsWith("/")) {
       path = "/" + path;
     }
-
+    try {
+      path = URLDecoder.decode(path, StandardCharsets.UTF_8);
+    }catch (Exception e){
+      LOG.debug("The filePath is already decoded");
+    }
     try {
       node = (Node) session.getItem(path);
       fileName = node.getName();

--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/DownloadConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/DownloadConnector.java
@@ -64,7 +64,7 @@ public class DownloadConnector implements ResourceContainer{
     }
     try {
       path = URLDecoder.decode(path, StandardCharsets.UTF_8);
-    }catch (Exception e){
+    } catch (Exception e) {
       LOG.debug("The filePath is already decoded");
     }
     try {


### PR DESCRIPTION
Not like the document application's download process, where we utilize the webDavService to download documents and decode the path parameter using the "convertRepoPath" method, the chat application employs the download connector. In this case, we need to decode the path parameter if it is encoded. This change addresses this issue