### PR TITLE
fix: Gif without animation in news illustration EXO-64163.

### DIFF
--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps</artifactId>
   <packaging>pom</packaging>

--- a/apps/portlet-administration/pom.xml
+++ b/apps/portlet-administration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-administration</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-clouddrives/package-lock.json
+++ b/apps/portlet-clouddrives/package-lock.json
@@ -5055,9 +5055,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",

--- a/apps/portlet-clouddrives/pom.xml
+++ b/apps/portlet-clouddrives/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-clouddrives</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-documents/package-lock.json
+++ b/apps/portlet-documents/package-lock.json
@@ -5170,9 +5170,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",

--- a/apps/portlet-documents/pom.xml
+++ b/apps/portlet-documents/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-documents</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityAttachment.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityAttachment.vue
@@ -204,7 +204,7 @@ export default {
             author: this.author,
             activity: {
               id: this.previewActivity.id,
-              liked: !!this.previewActivity.likes.length,
+              liked: this.previewActivity.hasLiked,
               likes: this.previewActivity.likes.length,
               status: this.previewActivity.title,
               postTime: this.relativePostTime,

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityAttachment.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityAttachment.vue
@@ -204,7 +204,8 @@ export default {
             author: this.author,
             activity: {
               id: this.previewActivity.id,
-              liked: this.previewActivity.hasLiked,
+              //Has liked property value is a string
+              liked: this.previewActivity.hasLiked === 'true',
               likes: this.previewActivity.likes.length,
               status: this.previewActivity.title,
               postTime: this.relativePostTime,

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
@@ -295,7 +295,7 @@ export default {
       }
     },
     openSelectDestinationFolderForFile(attachment) {
-      this.$root.$emit('change-attachment-destination-path', attachment);
+      this.$root.$emit('change-attachment-destination-path', attachment, this.currentDrive);
     },
     absoluteDateModified(options) {
       const lang = eXo && eXo.env && eXo.env.portal && eXo.env.portal.language || 'en';

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
@@ -295,7 +295,7 @@ export default {
       }
     },
     openSelectDestinationFolderForFile(attachment) {
-      this.$root.$emit('change-attachment-destination-path', attachment, this.currentDrive);
+      this.$root.$emit('change-attachment-destination-path', attachment);
     },
     absoluteDateModified(options) {
       const lang = eXo && eXo.env && eXo.env.portal && eXo.env.portal.language || 'en';

--- a/apps/portlet-editors/package-lock.json
+++ b/apps/portlet-editors/package-lock.json
@@ -5055,9 +5055,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",

--- a/apps/portlet-editors/pom.xml
+++ b/apps/portlet-editors/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-editors</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-explorer/pom.xml
+++ b/apps/portlet-explorer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-explorer</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-presentation/pom.xml
+++ b/apps/portlet-presentation/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-presentation</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-search/pom.xml
+++ b/apps/portlet-search/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-search</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-seo/pom.xml
+++ b/apps/portlet-seo/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-seo</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-transferrules/package-lock.json
+++ b/apps/portlet-transferrules/package-lock.json
@@ -5055,9 +5055,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",

--- a/apps/portlet-transferrules/pom.xml
+++ b/apps/portlet-transferrules/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-transferrules</artifactId>
   <packaging>war</packaging>

--- a/apps/resources-wcm/pom.xml
+++ b/apps/resources-wcm/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-resources-wcm</artifactId>
   <packaging>war</packaging>

--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -196,7 +196,7 @@
       } else {
         return $.ajax({
             type: 'DELETE',
-            url: '/portal/rest/v1/social/activities/' + this.settings.activity.id + '/likes/' + eXo.env.portal.userName
+            url: '/portal/rest/v1/social/activities/' + this.settings.activity.id + '/likes'
           }).done(function (data) {
             self.settings.activity.liked = false;
             self.settings.activity.likes--;

--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -179,9 +179,9 @@
       });
     },
 
-    like: function(like) {
+    like: function(liked) {
       var self = this;
-      if(like) {
+      if(liked === 'false') {
         return $.post('/portal/rest/v1/social/activities/' + this.settings.activity.id + '/likes', {liker: eXo.env.portal.userName})
           .done(function (data) {
             self.settings.activity.liked = true;
@@ -453,7 +453,7 @@
                         '</a>' +
                       '</li>' +
                       '<li>' +
-                        '<a href="javascript:void(0);" id="previewLikeLink" onclick="documentPreview.like(!documentPreview.settings.activity.liked)" rel="tooltip" data-placement="bottom" title="${UIActivity.label.Like}">' +
+                        '<a href="javascript:void(0);" id="previewLikeLink" onclick="documentPreview.like(documentPreview.settings.activity.liked)" rel="tooltip" data-placement="bottom" title="${UIActivity.label.Like}">' +
                           '<i class="uiIconThumbUp uiIconLightGray"></i>&nbsp;<span class="nbOfLikes"></span>' +
                         '</a>' +
                       '</li>' +

--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -181,7 +181,7 @@
 
     like: function(liked) {
       var self = this;
-      if(liked === 'false') {
+      if(!liked) {
         return $.post('/portal/rest/v1/social/activities/' + this.settings.activity.id + '/likes', {liker: eXo.env.portal.userName})
           .done(function (data) {
             self.settings.activity.liked = true;

--- a/core/connector/pom.xml
+++ b/core/connector/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-connector</artifactId>
   <packaging>jar</packaging>

--- a/core/core-configuration/pom.xml
+++ b/core/core-configuration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webapp</artifactId>
   <packaging>war</packaging>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core</artifactId>
   <packaging>pom</packaging>

--- a/core/publication-plugins/pom.xml
+++ b/core/publication-plugins/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-publication-plugins</artifactId>
   <packaging>jar</packaging>

--- a/core/publication/pom.xml
+++ b/core/publication/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-publication</artifactId>
   <packaging>jar</packaging>

--- a/core/search/pom.xml
+++ b/core/search/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-search</artifactId>
   <name>eXo PLF:: WCM Search Service</name>

--- a/core/services/pom.xml
+++ b/core/services/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-services</artifactId>
   <name>eXo PLF:: CMS Service</name>

--- a/core/services/src/main/java/org/exoplatform/services/cms/thumbnail/ThumbnailService.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/thumbnail/ThumbnailService.java
@@ -173,5 +173,5 @@ public interface ThumbnailService {
    * @param targetHeight target resized image height
    * @return byte array of image content
    */
-  byte[] createCustomThumbnail(byte [] imageContent, int targetWidth, int targetHeight) throws Exception;
+  byte[] createCustomThumbnail(byte [] imageContent, int targetWidth, int targetHeight, String mimeType) throws Exception;
 }

--- a/core/services/src/main/java/org/exoplatform/services/cms/thumbnail/impl/ThumbnailServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/thumbnail/impl/ThumbnailServiceImpl.java
@@ -286,8 +286,11 @@ public class ThumbnailServiceImpl implements ThumbnailService {
    * {@inheritDoc}
    */
   @Override
-  public byte[] createCustomThumbnail(byte[] imageContent, int targetWidth, int targetHeight) throws Exception {
-      return imageResizeService.scaleImage(imageContent, targetWidth, targetHeight, false, false);
+  public byte[] createCustomThumbnail(byte[] imageContent, int targetWidth, int targetHeight, String mimeType) throws Exception {
+    if ("image/gif".equalsIgnoreCase(mimeType)){
+      return imageContent;
+    }
+    return imageResizeService.scaleImage(imageContent, targetWidth, targetHeight, false, false);
   }
 
   private BufferedImage toBufferedImage(byte[] imageBytes) throws IOException {

--- a/core/services/src/test/java/org/exoplatform/services/ecm/dms/thumbnail/TestThumbnailService.java
+++ b/core/services/src/test/java/org/exoplatform/services/ecm/dms/thumbnail/TestThumbnailService.java
@@ -35,6 +35,7 @@ import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.services.thumbnail.ImageResizeService;
 import org.exoplatform.services.thumbnail.ImageResizeServiceImpl;
 import org.exoplatform.services.wcm.BaseWCMTestCase;
+import static org.junit.Assert.assertArrayEquals;
 
 /**
  * Created by The eXo Platform SARL
@@ -340,6 +341,21 @@ public class TestThumbnailService extends BaseWCMTestCase {
     assertTrue(session.itemExists("/" + ThumbnailService.EXO_THUMBNAILS_FOLDER + "/" + identifier));
     thumbnailService.processRemoveThumbnail(test);
     assertFalse(session.itemExists("/" + ThumbnailService.EXO_THUMBNAILS_FOLDER + "/" + identifier));
+  }
+
+  public void testCreateCustomThumbnail() throws Exception {
+    byte[] imageContent = new byte[] { 0x12, 0x34, 0x56, 0x78 };
+    int targetWidth = 100;
+    int targetHeight = 100;
+    String mimeType1 = "image/gif";
+    String mimeType2 = "image/png";
+    byte[] expectedResult = new byte[] { 0x12, 0x34, 0x56, 0x78 };
+    byte[]  result1 = thumbnailService.createCustomThumbnail(imageContent, targetWidth, targetHeight, mimeType1);
+    byte[]  result2 = thumbnailService.createCustomThumbnail(imageContent, targetWidth, targetHeight, mimeType2);
+
+    assertArrayEquals(expectedResult, result1);
+    assertArrayEquals(expectedResult, result2);
+
   }
 
   /**

--- a/core/viewer/pom.xml
+++ b/core/viewer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-viewer</artifactId>
   <name>eXo PLF:: DMS Document Viewer</name>

--- a/core/webui-administration/pom.xml
+++ b/core/webui-administration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webui-administration</artifactId>
   <packaging>jar</packaging>

--- a/core/webui-clouddrives/pom.xml
+++ b/core/webui-clouddrives/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webui-clouddrives</artifactId>
   <packaging>jar</packaging>

--- a/core/webui-explorer/pom.xml
+++ b/core/webui-explorer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webui-explorer</artifactId>
   <packaging>jar</packaging>

--- a/core/webui-fcc/pom.xml
+++ b/core/webui-fcc/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webui-fcc</artifactId>
   <name>eXo PLF:: Fast Content Creator webui component</name>

--- a/core/webui-presentation/pom.xml
+++ b/core/webui-presentation/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webui-presentation</artifactId>
   <packaging>jar</packaging>

--- a/core/webui-seo/pom.xml
+++ b/core/webui-seo/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webui-seo</artifactId>
   <packaging>jar</packaging>

--- a/core/webui/pom.xml
+++ b/core/webui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webui</artifactId>
   <name>eXo PLF:: DMS webui component</name>

--- a/core/webui/src/main/java/org/exoplatform/wcm/webui/Utils.java
+++ b/core/webui/src/main/java/org/exoplatform/wcm/webui/Utils.java
@@ -831,7 +831,7 @@ public class Utils {
              .append(repository)
              .append("/")
              .append(workspace)
-             .append(originalNodePath.replace("%", "%25"));
+             .append(originalNodePath.replaceAll("%", "%25"));
     if (withTimeParam) {
       if (imagePath.indexOf("?") > 0) {
         imagePath.append("&time=");

--- a/ecm-wcm-extension/pom.xml
+++ b/ecm-wcm-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecm-wcm-extension</artifactId>
   <packaging>war</packaging>

--- a/ecms-packaging/pom.xml
+++ b/ecms-packaging/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.exoplatform.ecms</groupId>
     <artifactId>ecms</artifactId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-packaging</artifactId>
   <packaging>pom</packaging>

--- a/ecms-social-integration/pom.xml
+++ b/ecms-social-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.ecms</groupId>
     <artifactId>ecms</artifactId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-social-integration</artifactId>
   <packaging>jar</packaging>

--- a/ext/authoring/apps/pom.xml
+++ b/ext/authoring/apps/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-ext-authoring</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext-authoring-apps</artifactId>
   <packaging>war</packaging>

--- a/ext/authoring/pom.xml
+++ b/ext/authoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-ext</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext-authoring</artifactId>
   <packaging>pom</packaging>

--- a/ext/authoring/services/pom.xml
+++ b/ext/authoring/services/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-ext-authoring</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext-authoring-services</artifactId>
   <packaging>jar</packaging>

--- a/ext/authoring/webui/pom.xml
+++ b/ext/authoring/webui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-ext-authoring</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext-authoring-webui</artifactId>
   <packaging>jar</packaging>

--- a/ext/fastcontentcreator/pom.xml
+++ b/ext/fastcontentcreator/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-ext</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext-fastcontentcreator</artifactId>
   <packaging>pom</packaging>

--- a/ext/fastcontentcreator/portlet/pom.xml
+++ b/ext/fastcontentcreator/portlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-ext-fastcontentcreator</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext-fastcontentcreator-portlet</artifactId>
   <packaging>war</packaging>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext</artifactId>
   <packaging>pom</packaging>

--- a/ext/webui/pom.xml
+++ b/ext/webui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-ext</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext-webui</artifactId>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.exoplatform.ecms</groupId>
   <artifactId>ecms</artifactId>
-  <version>6.5.x-SNAPSHOT</version>
+  <version>6.5.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo PLF:: ECM Suite</name>
   <description>eXo Entreprise Content Management Suite</description>
@@ -40,7 +40,7 @@
     <!-- **************************************** -->
     <!-- Project Dependencies                     -->
     <!-- **************************************** -->
-    <addon.exo.jcr.version>6.5.x-SNAPSHOT</addon.exo.jcr.version>
+    <addon.exo.jcr.version>6.5.x-maintenance-SNAPSHOT</addon.exo.jcr.version>
 
     <!-- **************************************** -->
     <!-- Apache Chemistry (OpenCMIS) API -->

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-testsuite</artifactId>
   <packaging>pom</packaging>

--- a/testsuite/test/pom.xml
+++ b/testsuite/test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-testsuite</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-testsuite-test</artifactId>
   <name>eXo PLF:: ECMS Testing</name>


### PR DESCRIPTION
Prior to this change, when create news in space whoose illustration image is a gif and post it, the gif is without animation. To fix this problem, when the image is of type gif, returned this image without doing the resize. After this change, illustration image is animated as it is the case in edit mode.