### PR TITLE
fix : Enable liking/disliking an activity from attachment preview - EXO-64824

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityAttachment.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityAttachment.vue
@@ -204,7 +204,7 @@ export default {
             author: this.author,
             activity: {
               id: this.previewActivity.id,
-              liked: !!this.previewActivity.likes.length,
+              liked: this.previewActivity.hasLiked,
               likes: this.previewActivity.likes.length,
               status: this.previewActivity.title,
               postTime: this.relativePostTime,

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityAttachment.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityAttachment.vue
@@ -204,7 +204,8 @@ export default {
             author: this.author,
             activity: {
               id: this.previewActivity.id,
-              liked: this.previewActivity.hasLiked,
+              //Has liked property value is a string
+              liked: this.previewActivity.hasLiked === 'true',
               likes: this.previewActivity.likes.length,
               status: this.previewActivity.title,
               postTime: this.relativePostTime,

--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -196,7 +196,7 @@
       } else {
         return $.ajax({
             type: 'DELETE',
-            url: '/portal/rest/v1/social/activities/' + this.settings.activity.id + '/likes/' + eXo.env.portal.userName
+            url: '/portal/rest/v1/social/activities/' + this.settings.activity.id + '/likes'
           }).done(function (data) {
             self.settings.activity.liked = false;
             self.settings.activity.likes--;

--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -179,9 +179,9 @@
       });
     },
 
-    like: function(like) {
+    like: function(liked) {
       var self = this;
-      if(like) {
+      if(liked === 'false') {
         return $.post('/portal/rest/v1/social/activities/' + this.settings.activity.id + '/likes', {liker: eXo.env.portal.userName})
           .done(function (data) {
             self.settings.activity.liked = true;
@@ -453,7 +453,7 @@
                         '</a>' +
                       '</li>' +
                       '<li>' +
-                        '<a href="javascript:void(0);" id="previewLikeLink" onclick="documentPreview.like(!documentPreview.settings.activity.liked)" rel="tooltip" data-placement="bottom" title="${UIActivity.label.Like}">' +
+                        '<a href="javascript:void(0);" id="previewLikeLink" onclick="documentPreview.like(documentPreview.settings.activity.liked)" rel="tooltip" data-placement="bottom" title="${UIActivity.label.Like}">' +
                           '<i class="uiIconThumbUp uiIconLightGray"></i>&nbsp;<span class="nbOfLikes"></span>' +
                         '</a>' +
                       '</li>' +

--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -181,7 +181,7 @@
 
     like: function(liked) {
       var self = this;
-      if(liked === 'false') {
+      if(!liked) {
         return $.post('/portal/rest/v1/social/activities/' + this.settings.activity.id + '/likes', {liker: eXo.env.portal.userName})
           .done(function (data) {
             self.settings.activity.liked = true;


### PR DESCRIPTION
Before this change, we were unable to like or dislike an activity from the activity attachment preview due to two issues:

1. Incorrect REST URL on the document preview.
2. Incorrect check for the status of the activity (liked or disliked).

This change will enable liking/disliking an activity from the attachment preview.