### PR TITLE
fix: Gif animation should displayed in news illustration EXO-64163

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/thumbnail/ThumbnailService.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/thumbnail/ThumbnailService.java
@@ -173,5 +173,5 @@ public interface ThumbnailService {
    * @param targetHeight target resized image height
    * @return byte array of image content
    */
-  byte[] createCustomThumbnail(byte [] imageContent, int targetWidth, int targetHeight) throws Exception;
+  byte[] createCustomThumbnail(byte [] imageContent, int targetWidth, int targetHeight, String mimeType) throws Exception;
 }

--- a/core/services/src/main/java/org/exoplatform/services/cms/thumbnail/impl/ThumbnailServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/thumbnail/impl/ThumbnailServiceImpl.java
@@ -286,8 +286,11 @@ public class ThumbnailServiceImpl implements ThumbnailService {
    * {@inheritDoc}
    */
   @Override
-  public byte[] createCustomThumbnail(byte[] imageContent, int targetWidth, int targetHeight) throws Exception {
-      return imageResizeService.scaleImage(imageContent, targetWidth, targetHeight, false, false);
+  public byte[] createCustomThumbnail(byte[] imageContent, int targetWidth, int targetHeight, String mimeType) throws Exception {
+    if ("image/gif".equalsIgnoreCase(mimeType)){
+      return imageContent;
+    }
+    return imageResizeService.scaleImage(imageContent, targetWidth, targetHeight, false, false);
   }
 
   private BufferedImage toBufferedImage(byte[] imageBytes) throws IOException {

--- a/core/services/src/test/java/org/exoplatform/services/ecm/dms/thumbnail/TestThumbnailService.java
+++ b/core/services/src/test/java/org/exoplatform/services/ecm/dms/thumbnail/TestThumbnailService.java
@@ -35,6 +35,7 @@ import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.services.thumbnail.ImageResizeService;
 import org.exoplatform.services.thumbnail.ImageResizeServiceImpl;
 import org.exoplatform.services.wcm.BaseWCMTestCase;
+import static org.junit.Assert.assertArrayEquals;
 
 /**
  * Created by The eXo Platform SARL
@@ -340,6 +341,21 @@ public class TestThumbnailService extends BaseWCMTestCase {
     assertTrue(session.itemExists("/" + ThumbnailService.EXO_THUMBNAILS_FOLDER + "/" + identifier));
     thumbnailService.processRemoveThumbnail(test);
     assertFalse(session.itemExists("/" + ThumbnailService.EXO_THUMBNAILS_FOLDER + "/" + identifier));
+  }
+
+  public void testCreateCustomThumbnail() throws Exception {
+    byte[] imageContent = new byte[] { 0x12, 0x34, 0x56, 0x78 };
+    int targetWidth = 100;
+    int targetHeight = 100;
+    String mimeType1 = "image/gif";
+    String mimeType2 = "image/png";
+    byte[] expectedResult = new byte[] { 0x12, 0x34, 0x56, 0x78 };
+    byte[]  result1 = thumbnailService.createCustomThumbnail(imageContent, targetWidth, targetHeight, mimeType1);
+    byte[]  result2 = thumbnailService.createCustomThumbnail(imageContent, targetWidth, targetHeight, mimeType2);
+
+    assertArrayEquals(expectedResult, result1);
+    assertArrayEquals(expectedResult, result2);
+
   }
 
   /**


### PR DESCRIPTION
Prior to this change, when create news in space whoose illustration image is a gif and post it, the gif is without animation. To fix this problem, when the image is of type gif, returned this image without doing the resize. After this change, illustration image is animated as it is the case in edit mode.