### PR TITLE
feat: Add possibility to remove old content from trash

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/documents/job/TrashCleanerJob.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/documents/job/TrashCleanerJob.java
@@ -149,7 +149,8 @@ public class TrashCleanerJob implements Job {
       if (!fixReferentialIntegrityException(node)) {
         LOG.error("ReferentialIntegrityException when removing " + node.getName() + " node from Trash", ref);
         //log nothing if the fix success to deleteNode
-      }    } catch (ConstraintViolationException cons) {
+      }
+    } catch (ConstraintViolationException cons) {
       LOG.error("ConstraintViolationException when removing " + node.getName() + " node from Trash", cons);
     } catch (Exception ex) {
       LOG.error("Error while removing " + node.getName() + " node from Trash", ex);

--- a/core/services/src/main/java/org/exoplatform/services/cms/documents/job/TrashCleanerJob.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/documents/job/TrashCleanerJob.java
@@ -209,11 +209,11 @@ public class TrashCleanerJob implements Job {
       for (NodeIterator it = versionHistory.getNodes(); it.hasNext(); ) {
         Node child = it.nextNode();
         long nbRef = child.getReferences().getSize();
-        LOG.info("Version history child node {} have {} references",child.getPath(),nbRef);
+        LOG.debug("Version history child node {} have {} references",child.getPath(),nbRef);
         for (PropertyIterator iter = child.getReferences(); iter.hasNext(); ) {
           // if there is a reference, move it
           String relationPath = iter.nextProperty().getPath();
-          LOG.info("Node " + child.getPath() + " is referenced by " + relationPath);
+          LOG.debug("Node " + child.getPath() + " is referenced by " + relationPath);
           if (!relationPath.startsWith(node.getPath())) {
             Node relation = node.getSession().getItem(relationPath).getParent();
             cleanPublication(relation);


### PR DESCRIPTION
Theses content could generate a referentialIntegrityException after a copy paste : Create a web content in 5.2.x or 5.3.x
Modify it then publish it few times
Copy paste the web content, 
Drop the initial content
When trying to remove it from trash, a ReferentialIntegrityException is thrown

This fix will allow to flush liveRevision in the pasted content, and so, delete the node in trash