### PR TITLE
fix: error when loading ckedito config in documents preview - EXO-65351

### DIFF
--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -1180,7 +1180,7 @@
         CKEDITOR.basePath = '/commons-extension/ckeditor/';
         var toolbarHeight = 39;
         commentInput.ckeditor({
-          customConfig: `${eXo.env.portal.context}/${eXo.env.portal.rest}/richeditor/configuration?type=document-preview&v=${eXo.env.client.assetsVersion}`,
+          customConfig: eXo.env.portal.context + '/' + eXo.env.portal.rest + '/richeditor/configuration?type=document-preview&v=' + eXo.env.client.assetsVersion,
           extraPlugins: extraPlugins,
           typeOfRelation: 'mention_comment',
           spaceURL: this.settings.activity.spaceURL,


### PR DESCRIPTION
The property customConfig was not interpreted correctly causing issues to display the rich text editor of comments. The fix creates the config link with String concatenation istead of String interpolation with variables.