### PR TITLE
fix : Enable the preview of imported documents from Google Drive - EXO-65281

### DIFF
--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -412,7 +412,7 @@
         docPreviewContainer.find(".previewBtn").html(html);
 
       } else {
-        var authorFullName = XSSUtils.sanitizeString(this.settings.author.fullname != null ? this.settings.author.fullname : '');
+        var authorFullName = XSSUtils.sanitizeString(this.settings.author?.fullname != null ? this.settings.author.fullname : '');
         let html = '<div class="uiDocumentPreview' + (this.settings.showComments ? '' : ' collapsed') + '" id="uiDocumentPreview">' +
           '<div class="exitWindow">' +
             '<a class="uiIconClose uiIconWhite" title="${UIActivity.comment.close}" onclick="documentPreview.hide()"></a>' +


### PR DESCRIPTION

Before this change, when we cloned a document from Google Drive, the document wouldn't be visualized. This issue occurred because we were trying to access the "author full name" property, which was currently null. This change is going to add a check to ensure the value property is not null before using it.