### PR TITLE
fix: after adding a document version, allow to create a new activity when the original is deleted - EXO-65154

### DIFF
--- a/ecms-social-integration/pom.xml
+++ b/ecms-social-integration/pom.xml
@@ -11,7 +11,7 @@
   <name>eXo PLF:: ECMS - Social Activities</name>
   <description>ECMS with Social activity</description>
   <properties>
-    <exo.test.coverage.ratio>0.05</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.1</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>
@@ -172,17 +172,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
+      <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/ecms-social-integration/src/test/java/org/exoplatform/ecms/activity/processor/ActivityAttachmentProcessorTest.java
+++ b/ecms-social-integration/src/test/java/org/exoplatform/ecms/activity/processor/ActivityAttachmentProcessorTest.java
@@ -7,10 +7,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import javax.jcr.Node;
 import java.util.HashMap;
@@ -18,9 +16,7 @@ import java.util.HashMap;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(NodeLocation.class)
-@PowerMockIgnore({ "javax.management.*", "javax.xml.*", "org.apache.xerces.*", "org.xml.*" })
+@RunWith(MockitoJUnitRunner.class)
 public class ActivityAttachmentProcessorTest {
 
     @Mock
@@ -47,8 +43,8 @@ public class ActivityAttachmentProcessorTest {
                 templateParams.get("nodePath"), templateParams.get("nodeUUID"), true);
         Node currentNode = mock(Node.class);
         doCallRealMethod().when(activityAttachmentProcessor).processActivity(activity);
-        PowerMockito.mockStatic(NodeLocation.class);
-        when(NodeLocation.getNodeByLocation(ArgumentMatchers.refEq(nodeLocation))).thenReturn(currentNode);
+        MockedStatic<NodeLocation> NODE_LOCATION = mockStatic(NodeLocation.class);
+        NODE_LOCATION.when(() -> NodeLocation.getNodeByLocation(ArgumentMatchers.refEq(nodeLocation))).thenReturn(currentNode);
         activityAttachmentProcessor.processActivity(activity);
         assertEquals(1, activity.getFiles().size());
     }

--- a/ecms-social-integration/src/test/java/org/exoplatform/services/attachments/plugins/TaskAttachmentEntityTypePluginTest.java
+++ b/ecms-social-integration/src/test/java/org/exoplatform/services/attachments/plugins/TaskAttachmentEntityTypePluginTest.java
@@ -32,7 +32,6 @@ import org.exoplatform.task.dto.StatusDto;
 import org.exoplatform.task.dto.TaskDto;
 import org.exoplatform.task.service.ProjectService;
 import org.exoplatform.task.service.TaskService;
-import org.powermock.api.mockito.PowerMockito;
 
 import javax.jcr.nodetype.NodeType;
 import java.util.Arrays;
@@ -49,14 +48,14 @@ public class TaskAttachmentEntityTypePluginTest extends TestCase {
     long entityId = 1;
 
     // Mock services
-    TaskService taskService = PowerMockito.mock(TaskService.class);
-    ProjectService projectService = PowerMockito.mock(ProjectService.class);
-    NodeHierarchyCreator nodeHierarchyCreator = PowerMockito.mock(NodeHierarchyCreator.class);
-    RepositoryService repositoryService = PowerMockito.mock(RepositoryService.class);
-    SessionProviderService sessionProviderService = PowerMockito.mock(SessionProviderService.class);
+    TaskService taskService = mock(TaskService.class);
+    ProjectService projectService = mock(ProjectService.class);
+    NodeHierarchyCreator nodeHierarchyCreator = mock(NodeHierarchyCreator.class);
+    RepositoryService repositoryService = mock(RepositoryService.class);
+    SessionProviderService sessionProviderService = mock(SessionProviderService.class);
 
     // Mock SessionProvider
-    SessionProvider sessionProvider = PowerMockito.mock(SessionProvider.class);
+    SessionProvider sessionProvider = mock(SessionProvider.class);
     when(sessionProviderService.getSessionProvider(null)).thenReturn(sessionProvider);
 
     // Mock Repository service and JCR session

--- a/ecms-social-integration/src/test/java/org/exoplatform/social/ckeditor/HTMLUploadImageProcessorTest.java
+++ b/ecms-social-integration/src/test/java/org/exoplatform/social/ckeditor/HTMLUploadImageProcessorTest.java
@@ -3,7 +3,6 @@ package org.exoplatform.social.ckeditor;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 import javax.jcr.Node;
 import javax.jcr.Property;

--- a/ecms-social-integration/src/test/java/org/exoplatform/wcm/ext/component/activity/ECMSActivityFileStoragePluginTest.java
+++ b/ecms-social-integration/src/test/java/org/exoplatform/wcm/ext/component/activity/ECMSActivityFileStoragePluginTest.java
@@ -22,9 +22,7 @@ import org.exoplatform.upload.UploadService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.jcr.Node;
 import javax.jcr.Property;
@@ -36,9 +34,7 @@ import java.io.File;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(NodeLocation.class)
-@PowerMockIgnore({ "javax.management.*", "javax.xml.*", "org.apache.xerces.*", "org.xml.*" })
+@RunWith(MockitoJUnitRunner.class)
 public class ECMSActivityFileStoragePluginTest {
 
   static private String TEXT_PLAIN = "text/plain";
@@ -101,10 +97,10 @@ public class ECMSActivityFileStoragePluginTest {
     uploadResource.setStoreLocation(file.getPath());
     uploadResource.setMimeType(TEXT_PLAIN);
     when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
-    when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
+    lenient().when(sessionProviderService.getSessionProvider(any())).thenReturn(sessionProvider);
     when(repositoryService.getCurrentRepository()).thenReturn(repository);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
-    when(repositoryEntry.getName()).thenReturn("workspace");
+    lenient().when(repositoryEntry.getName()).thenReturn("workspace");
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
     when(sessionProvider.getSession(any(), any())).thenReturn(session);
     Node userNode = mock(Node.class);


### PR DESCRIPTION
When a new document version is created, an activity is created too and the text associated to the version is added as a comment. When this activity is removed and a new version is created, nothing happens. this fix allows to create a new activity when the original one is deleted, it also removes the usage of PowerMockito in Tests and replaces it with Mockito framework.