### PR TITLE
fix :Disabling transition effects on the circular progress bar for file uploads - EXO-63220

### DIFF
--- a/apps/resources-wcm/src/main/webapp/skin/less/ecms/portlets/attachments/attachmentsApp.less
+++ b/apps/resources-wcm/src/main/webapp/skin/less/ecms/portlets/attachments/attachmentsApp.less
@@ -35,6 +35,11 @@
 .attachmentsAppDrawer {
   .drawerContent {
     .uploadedFiles {
+      .fileProgress {
+        .v-progress-circular__overlay {
+          transition: none;
+        }
+      }
       .no-files-attached {
         .uiIconCloseCircled {
           color: @greyColorDefault !important;


### PR DESCRIPTION
Before this change, the circular progress bar did not match the value displayed inside the bar. The issue was caused by the animation applied to the circle. This change will disable transition effects on the circular progress