### PR TITLE
fix : Enable to create a news with title contains a '.' character followed by a special character - EXO-66277

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -705,8 +705,11 @@ public class Utils {
   }
   
   private static String replaceSpecialChars(String name, String specialChars) {
+    return replaceSpecialChars(name, specialChars, NodetypeConstant.NT_FILE);
+  }
+  public static String replaceSpecialChars(String name, String specialChars, String nodeType) {
     String extension = "";
-    if (name.lastIndexOf(".") != -1) {
+    if (nodeType.equals(NodetypeConstant.NT_FILE) && name.lastIndexOf(".") != -1) {
       extension = name.substring(name.lastIndexOf("."));
       name = name.substring(0, name.lastIndexOf("."));
     }
@@ -733,10 +736,13 @@ public class Utils {
    */
 
   public static String cleanName(String oldName) {
+    return cleanName(oldName, NodetypeConstant.NT_FILE);
+  }
+  public static String cleanName(String oldName, String nodeType) {
     if (StringUtils.isEmpty(oldName)) {
       return oldName;
     }
-    return replaceSpecialChars(oldName, "&#*?!@.'\"\t\r\n$\\><:;[]/|’");
+    return replaceSpecialChars(oldName, "&#*?!@.'\"\t\r\n$\\><:;[]/|’", nodeType);
   }
 
   /** Return name after cleaning

--- a/core/services/src/main/java/org/exoplatform/services/wcm/core/NodetypeConstant.java
+++ b/core/services/src/main/java/org/exoplatform/services/wcm/core/NodetypeConstant.java
@@ -158,6 +158,8 @@ public class NodetypeConstant {
 
   public static final String EXO_NEWSLETTER_ENTRY             = "exo:newsletterEntry";
 
+  public static final String EXO_NEWS                         = "exo:news";
+
   public static final String EXO_LINKABLE                     = "exo:linkable";
 
   public static final String EXO_LINKS                        = "exo:links";

--- a/core/services/src/test/java/org/exoplatform/services/cms/impl/UtilsTest.java
+++ b/core/services/src/test/java/org/exoplatform/services/cms/impl/UtilsTest.java
@@ -1,6 +1,7 @@
 package org.exoplatform.services.cms.impl;
 
 import junit.framework.TestCase;
+import org.exoplatform.services.wcm.core.NodetypeConstant;
 
 public class UtilsTest extends TestCase {
 
@@ -70,5 +71,10 @@ public class UtilsTest extends TestCase {
     assertEquals(titleClean19,"test_test");
     assertEquals(titleClean20,"test.test");
     assertEquals(titleClean21,"test_test.pdf");
+    //
+    String newsTitle = "news.title";
+    String newsTitleWithSpecialCharacter  = "news.title/test";
+    assertEquals(Utils.cleanName(newsTitle, NodetypeConstant.EXO_NEWS), "news_title");
+    assertEquals(Utils.cleanName(newsTitleWithSpecialCharacter, NodetypeConstant.EXO_NEWS), "news.title_test");
   }
 }


### PR DESCRIPTION
Before this change we were unable to create a news with a title containing a '.' character followed by another special character , this issue was due to the clean name method which used the '.' to identify the file's extension and did not clean the last part of the name .
This fix will update the clean name method to check the node type before cleaning the node name .  