### PR TITLE
fix: Ensure Case-Insensitive file existence check -EXO-66043

### DIFF
--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps</artifactId>
   <packaging>pom</packaging>

--- a/apps/portlet-administration/pom.xml
+++ b/apps/portlet-administration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-administration</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-clouddrives/package-lock.json
+++ b/apps/portlet-clouddrives/package-lock.json
@@ -5224,9 +5224,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",

--- a/apps/portlet-clouddrives/pom.xml
+++ b/apps/portlet-clouddrives/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-clouddrives</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-documents/pom.xml
+++ b/apps/portlet-documents/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-documents</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-editors/package-lock.json
+++ b/apps/portlet-editors/package-lock.json
@@ -5224,9 +5224,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",

--- a/apps/portlet-editors/pom.xml
+++ b/apps/portlet-editors/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-editors</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-explorer/pom.xml
+++ b/apps/portlet-explorer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-explorer</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-presentation/pom.xml
+++ b/apps/portlet-presentation/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-presentation</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-search/pom.xml
+++ b/apps/portlet-search/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-search</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-seo/pom.xml
+++ b/apps/portlet-seo/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-seo</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-transferrules/pom.xml
+++ b/apps/portlet-transferrules/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-transferrules</artifactId>
   <packaging>war</packaging>

--- a/apps/resources-wcm/pom.xml
+++ b/apps/resources-wcm/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-resources-wcm</artifactId>
   <packaging>war</packaging>

--- a/core/connector/pom.xml
+++ b/core/connector/pom.xml
@@ -12,7 +12,7 @@
   <name>eXo PLF:: ECMS Connector</name>
   <description>eXo ECMS REST Services</description>
   <properties>
-    <exo.test.coverage.ratio>0.0</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.10</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <!--swagger-->
@@ -204,17 +204,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
+      <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/core/connector/pom.xml
+++ b/core/connector/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-connector</artifactId>
   <packaging>jar</packaging>

--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
@@ -51,6 +51,7 @@ import org.w3c.dom.Element;
 
 import javax.jcr.ItemExistsException;
 import javax.jcr.Node;
+import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.CacheControl;
@@ -306,13 +307,21 @@ public class FileUploadHandler {
     fileName = fileName.replaceAll(FILE_DECODE_REGEX, "%25");
     fileName = URLDecoder.decode(fileName,"UTF-8");
     fileName = fileName.replaceAll(FILE_DECODE_REGEX, "-");
-    Element rootElement = fileExistence.createElement(
-                              parent.hasNode(fileName) ? "Existed" : "NotExisted");
-    if(parent.hasNode(fileName)){
-      Node existNode = parent.getNode(fileName);
-      if(existNode.isNodeType(NodetypeConstant.MIX_VERSIONABLE)){
-        rootElement.appendChild(fileExistence.createElement("Versioned"));
+    Node existNode = null;
+    if (parent.hasNodes()) {
+      NodeIterator iterator = parent.getNodes();
+      while (iterator.hasNext()) {
+        Node childNode = iterator.nextNode();
+        if (childNode.getName().equalsIgnoreCase(fileName)) {
+          existNode = childNode;
+          break;
+        }
       }
+    }
+    Element rootElement = fileExistence.createElement(
+                              existNode !=null ? "Existed" : "NotExisted");
+    if(existNode != null && existNode.isNodeType(NodetypeConstant.MIX_VERSIONABLE)){
+        rootElement.appendChild(fileExistence.createElement("Versioned"));
     }
     if(parent.isNodeType(NodetypeConstant.NT_FILE) && 
         resolver.getMimeType(parent.getName()).equals(resolver.getMimeType(fileName))){

--- a/core/connector/src/test/java/org/exoplatform/BaseConnectorTestSuite.java
+++ b/core/connector/src/test/java/org/exoplatform/BaseConnectorTestSuite.java
@@ -20,6 +20,7 @@ import org.exoplatform.commons.testing.BaseExoContainerTestSuite;
 import org.exoplatform.commons.testing.ConfigTestCase;
 //import org.exoplatform.wcm.connector.authoring.TestCopyContentFile;
 //import org.exoplatform.wcm.connector.authoring.TestLifecycleConnector;
+import org.exoplatform.ecm.connector.platform.ManageDocumentServiceTest;
 import org.exoplatform.wcm.connector.collaboration.TestDownloadConnector;
 import org.exoplatform.wcm.connector.collaboration.TestFavoriteRESTService;
 import org.exoplatform.wcm.connector.collaboration.TestOpenInOfficeConnector;
@@ -47,7 +48,8 @@ import org.junit.runners.Suite.SuiteClasses;
   TestDownloadConnector.class,
   TestOpenInOfficeConnector.class,
   TestThumbnailRESTService.class,
-  TestFavoriteRESTService.class
+  TestFavoriteRESTService.class,
+  ManageDocumentServiceTest.class
 })
 @ConfigTestCase(BaseConnectorTestCase.class)
 public class BaseConnectorTestSuite extends BaseExoContainerTestSuite {

--- a/core/connector/src/test/java/org/exoplatform/ecm/connector/platform/ManageDocumentServiceTest.java
+++ b/core/connector/src/test/java/org/exoplatform/ecm/connector/platform/ManageDocumentServiceTest.java
@@ -23,8 +23,10 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.jcr.Node;
+import javax.jcr.NodeIterator;
 import javax.jcr.Session;
 import javax.ws.rs.core.Response;
+import javax.xml.transform.dom.DOMSource;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -122,5 +124,25 @@ public class ManageDocumentServiceTest {
 
     response = this.manageDocumentService.checkFileExistence("collaboration", ".spaces.space_one", "DRIVE_ROOT_NODE/Documents", "test.docx");
     assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    //
+    String fileName = "lowercase.docx";
+    response = this.manageDocumentService.checkFileExistence("collaboration", ".testspace", "/", fileName);
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    DOMSource domSource = (DOMSource) response.getEntity();
+    assertEquals("NotExisted", domSource.getNode().getFirstChild().getNodeName());
+    //
+    Node existingNode = mock(Node.class);
+    when(node.hasNodes()).thenReturn(true);
+    NodeIterator nodeIterator = mock(NodeIterator.class);
+    when(node.getNodes()).thenReturn(nodeIterator);
+    when(nodeIterator.hasNext()).thenReturn(true);
+    when(nodeIterator.nextNode()).thenReturn(existingNode);
+    when(existingNode.getName()).thenReturn(fileName);
+    String existingFileName = fileName.toUpperCase();
+    //
+    response = this.manageDocumentService.checkFileExistence("collaboration", "testspace", "/", existingFileName);
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    domSource = (DOMSource) response.getEntity();
+    assertEquals("Existed", domSource.getNode().getFirstChild().getNodeName());
   }
 }

--- a/core/core-configuration/pom.xml
+++ b/core/core-configuration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webapp</artifactId>
   <packaging>war</packaging>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core</artifactId>
   <packaging>pom</packaging>

--- a/core/publication-plugins/pom.xml
+++ b/core/publication-plugins/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-publication-plugins</artifactId>
   <packaging>jar</packaging>

--- a/core/publication/pom.xml
+++ b/core/publication/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-publication</artifactId>
   <packaging>jar</packaging>

--- a/core/search/pom.xml
+++ b/core/search/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-search</artifactId>
   <name>eXo PLF:: WCM Search Service</name>

--- a/core/services/pom.xml
+++ b/core/services/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-services</artifactId>
   <name>eXo PLF:: CMS Service</name>

--- a/core/services/src/main/java/org/exoplatform/services/cms/drives/impl/ManageDriveServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/drives/impl/ManageDriveServiceImpl.java
@@ -332,7 +332,7 @@ public class ManageDriveServiceImpl implements ManageDriveService, Startable {
       DriveData drive = groupDriveTemplate.clone();
       drive.setHomePath(groupDriveTemplate.getHomePath().replace("${groupId}", groupName));
       drive.setName(name);
-      drive.getParameters().put(ManageDriveServiceImpl.DRIVE_PARAMATER_GROUP_ID, name);
+      drive.getParameters().put(ManageDriveServiceImpl.DRIVE_PARAMATER_GROUP_ID, groupName);
       drive.setPermissions("*:" + groupName);
       return drive;
     }

--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -704,7 +704,7 @@ public class Utils {
     return replaceSpecialChars(title, "[<\\>:\"/|?*]");
   }
   
-  private static String replaceSpecialChars(String name, String specialChars) {
+  public static String replaceSpecialChars(String name, String specialChars) {
     return replaceSpecialChars(name, specialChars, NodetypeConstant.NT_FILE);
   }
   public static String replaceSpecialChars(String name, String specialChars, String nodeType) {

--- a/core/viewer/pom.xml
+++ b/core/viewer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-viewer</artifactId>
   <name>eXo PLF:: DMS Document Viewer</name>

--- a/core/webui-administration/pom.xml
+++ b/core/webui-administration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webui-administration</artifactId>
   <packaging>jar</packaging>

--- a/core/webui-clouddrives/pom.xml
+++ b/core/webui-clouddrives/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webui-clouddrives</artifactId>
   <packaging>jar</packaging>

--- a/core/webui-explorer/pom.xml
+++ b/core/webui-explorer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webui-explorer</artifactId>
   <packaging>jar</packaging>

--- a/core/webui-fcc/pom.xml
+++ b/core/webui-fcc/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webui-fcc</artifactId>
   <name>eXo PLF:: Fast Content Creator webui component</name>

--- a/core/webui-presentation/pom.xml
+++ b/core/webui-presentation/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webui-presentation</artifactId>
   <packaging>jar</packaging>

--- a/core/webui-seo/pom.xml
+++ b/core/webui-seo/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webui-seo</artifactId>
   <packaging>jar</packaging>

--- a/core/webui/pom.xml
+++ b/core/webui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webui</artifactId>
   <name>eXo PLF:: DMS webui component</name>

--- a/ecm-wcm-extension/pom.xml
+++ b/ecm-wcm-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecm-wcm-extension</artifactId>
   <packaging>war</packaging>

--- a/ecms-packaging/pom.xml
+++ b/ecms-packaging/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.exoplatform.ecms</groupId>
     <artifactId>ecms</artifactId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-packaging</artifactId>
   <packaging>pom</packaging>

--- a/ecms-social-integration/pom.xml
+++ b/ecms-social-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.ecms</groupId>
     <artifactId>ecms</artifactId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-social-integration</artifactId>
   <packaging>jar</packaging>

--- a/ext/authoring/apps/pom.xml
+++ b/ext/authoring/apps/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-ext-authoring</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext-authoring-apps</artifactId>
   <packaging>war</packaging>

--- a/ext/authoring/pom.xml
+++ b/ext/authoring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-ext</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext-authoring</artifactId>
   <packaging>pom</packaging>

--- a/ext/authoring/services/pom.xml
+++ b/ext/authoring/services/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-ext-authoring</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext-authoring-services</artifactId>
   <packaging>jar</packaging>

--- a/ext/authoring/webui/pom.xml
+++ b/ext/authoring/webui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-ext-authoring</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext-authoring-webui</artifactId>
   <packaging>jar</packaging>

--- a/ext/fastcontentcreator/pom.xml
+++ b/ext/fastcontentcreator/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-ext</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext-fastcontentcreator</artifactId>
   <packaging>pom</packaging>

--- a/ext/fastcontentcreator/portlet/pom.xml
+++ b/ext/fastcontentcreator/portlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-ext-fastcontentcreator</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext-fastcontentcreator-portlet</artifactId>
   <packaging>war</packaging>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext</artifactId>
   <packaging>pom</packaging>

--- a/ext/webui/pom.xml
+++ b/ext/webui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-ext</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-ext-webui</artifactId>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.exoplatform.ecms</groupId>
   <artifactId>ecms</artifactId>
-  <version>6.5.x-SNAPSHOT</version>
+  <version>6.5.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo PLF:: ECM Suite</name>
   <description>eXo Entreprise Content Management Suite</description>
@@ -40,7 +40,7 @@
     <!-- **************************************** -->
     <!-- Project Dependencies                     -->
     <!-- **************************************** -->
-    <addon.exo.jcr.version>6.5.x-SNAPSHOT</addon.exo.jcr.version>
+    <addon.exo.jcr.version>6.5.x-maintenance-SNAPSHOT</addon.exo.jcr.version>
 
     <!-- **************************************** -->
     <!-- Apache Chemistry (OpenCMIS) API -->

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-testsuite</artifactId>
   <packaging>pom</packaging>

--- a/testsuite/test/pom.xml
+++ b/testsuite/test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-testsuite</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>6.5.x-SNAPSHOT</version>
+    <version>6.5.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-testsuite-test</artifactId>
   <name>eXo PLF:: ECMS Testing</name>


### PR DESCRIPTION
Before this change, when we migrated from EXO 6.2.x to EXO 6.4.x or EXO 6.5.x and attempted to upload a new file with an existing file name starting with a uppercase character, no conflict alert was displayed. This issue occurred because the old uploaded document names weren't created in lowercase. 
This change will ensure a case-insensitive file existence check.