### PR TITLE
fix: select the drive of the current space in attachment drawer - EXO-67230

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
@@ -522,7 +522,13 @@ export default {
     },
     entityId() {
       this.initDestinationFolderPath();
-    }
+    },
+    defaultFolder() {
+      this.initDestinationFolderPath();
+    },
+    defaultDrive() {
+      this.initDestinationFolderPath();
+    },
   },
   created() {
     this.initDestinationFolderPath();


### PR DESCRIPTION
Select correctly the drive of the current space when selecting a document to attach