### PR TITLE
fix: store files under space root folder - EXO-64344

### DIFF
--- a/apps/portlet-clouddrives/package-lock.json
+++ b/apps/portlet-clouddrives/package-lock.json
@@ -5224,9 +5224,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",

--- a/apps/portlet-editors/package-lock.json
+++ b/apps/portlet-editors/package-lock.json
@@ -5224,9 +5224,7 @@
           "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
           "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
           "dev": true,
-          "requires": {
-            "ajv": "^8.0.0"
-          }
+          "requires": {}
         },
         "ajv-keywords": {
           "version": "5.1.0",

--- a/core/connector/pom.xml
+++ b/core/connector/pom.xml
@@ -12,7 +12,7 @@
   <name>eXo PLF:: ECMS Connector</name>
   <description>eXo ECMS REST Services</description>
   <properties>
-    <exo.test.coverage.ratio>0.0</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.10</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <!--swagger-->
@@ -204,17 +204,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
+      <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/core/connector/src/test/java/org/exoplatform/BaseConnectorTestSuite.java
+++ b/core/connector/src/test/java/org/exoplatform/BaseConnectorTestSuite.java
@@ -20,6 +20,7 @@ import org.exoplatform.commons.testing.BaseExoContainerTestSuite;
 import org.exoplatform.commons.testing.ConfigTestCase;
 //import org.exoplatform.wcm.connector.authoring.TestCopyContentFile;
 //import org.exoplatform.wcm.connector.authoring.TestLifecycleConnector;
+import org.exoplatform.ecm.connector.platform.ManageDocumentServiceTest;
 import org.exoplatform.wcm.connector.collaboration.TestDownloadConnector;
 import org.exoplatform.wcm.connector.collaboration.TestFavoriteRESTService;
 import org.exoplatform.wcm.connector.collaboration.TestOpenInOfficeConnector;
@@ -47,7 +48,8 @@ import org.junit.runners.Suite.SuiteClasses;
   TestDownloadConnector.class,
   TestOpenInOfficeConnector.class,
   TestThumbnailRESTService.class,
-  TestFavoriteRESTService.class
+  TestFavoriteRESTService.class,
+  ManageDocumentServiceTest.class
 })
 @ConfigTestCase(BaseConnectorTestCase.class)
 public class BaseConnectorTestSuite extends BaseExoContainerTestSuite {

--- a/core/services/src/main/java/org/exoplatform/services/cms/drives/impl/ManageDriveServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/drives/impl/ManageDriveServiceImpl.java
@@ -332,7 +332,7 @@ public class ManageDriveServiceImpl implements ManageDriveService, Startable {
       DriveData drive = groupDriveTemplate.clone();
       drive.setHomePath(groupDriveTemplate.getHomePath().replace("${groupId}", groupName));
       drive.setName(name);
-      drive.getParameters().put(ManageDriveServiceImpl.DRIVE_PARAMATER_GROUP_ID, name);
+      drive.getParameters().put(ManageDriveServiceImpl.DRIVE_PARAMATER_GROUP_ID, groupName);
       drive.setPermissions("*:" + groupName);
       return drive;
     }

--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -704,7 +704,7 @@ public class Utils {
     return replaceSpecialChars(title, "[<\\>:\"/|?*]");
   }
   
-  private static String replaceSpecialChars(String name, String specialChars) {
+  public static String replaceSpecialChars(String name, String specialChars) {
     return replaceSpecialChars(name, specialChars, NodetypeConstant.NT_FILE);
   }
   public static String replaceSpecialChars(String name, String specialChars, String nodeType) {


### PR DESCRIPTION
By default images uploaded with Ckeditor image plugin are stored under the folder Documents of the space. This fix allows to choose to store images under a folder outside the default Documents folder.