### PR TITLE
fix: change the document preview URL with the new pattern - EXO-67548

### DIFF
--- a/core/services/pom.xml
+++ b/core/services/pom.xml
@@ -14,7 +14,7 @@
     <rest.api.doc.version>1.0</rest.api.doc.version>
     <rest.api.doc.description>All used ecms rest endpoints</rest.api.doc.description>
 
-    <exo.test.coverage.ratio>0.33</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.36</exo.test.coverage.ratio>
   </properties>
   <dependencies>
     <dependency>
@@ -67,10 +67,6 @@
     <dependency>
       <groupId>org.exoplatform</groupId>
       <artifactId>exo-jcr-services</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.commons</groupId>
-      <artifactId>commons-component-common</artifactId>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.commons</groupId>

--- a/core/services/src/main/java/org/exoplatform/services/attachments/utils/EntityBuilder.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/utils/EntityBuilder.java
@@ -123,7 +123,7 @@ public class EntityBuilder {
     String downloadUrl = getDownloadUrl(repositoryService, workspace, attachmentsPath);
     attachment.setDownloadUrl(downloadUrl);
 
-    String openUrl = getUrl(documentService, attachmentsPath);
+    String openUrl = getUrl(documentService, attachmentId);
     attachment.setOpenUrl(openUrl);
 
     String attachmentsVersion = getStringProperty(originalAttachmentNode, "exo:baseVersion");
@@ -178,12 +178,18 @@ public class EntityBuilder {
     return downloadUrl.toString();
   }
 
-  private static String getUrl(DocumentService documentService, String nodePath) {
+  /**
+   * Provides the URL of the document in its Drive
+   * @param documentService
+   * @param nodeIdentifier
+   * @return URL of type String
+   */
+  private static String getUrl(DocumentService documentService, String nodeIdentifier) {
     String url = "";
     try {
-      url = documentService.getLinkInDocumentsApp(nodePath);
+      url = documentService.getLinkInDocumentsAppByIdentifier(nodeIdentifier);
     } catch (Exception e) {
-      LOG.error("Cannot get url of document " + nodePath, e);
+      LOG.error("Cannot get url of document " + nodeIdentifier, e);
     }
     return url;
   }

--- a/core/services/src/main/java/org/exoplatform/services/cms/documents/DocumentService.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/documents/DocumentService.java
@@ -26,6 +26,7 @@ import org.exoplatform.container.component.ComponentPlugin;
 import org.exoplatform.services.cms.documents.exception.DocumentEditorProviderNotFoundException;
 import org.exoplatform.services.cms.documents.model.Document;
 import org.exoplatform.services.cms.drives.DriveData;
+import org.gatein.common.NotYetImplemented;
 
 /**
  * DMS DocumentService interface. Created by The eXo Platform SAS Author : eXoPlatform exo@exoplatform.com Mar 22, 2011
@@ -85,6 +86,10 @@ public interface DocumentService {
    */
   String getLinkInDocumentsApp(String nodePath) throws Exception;
 
+  default String getLinkInDocumentsAppByIdentifier(String nodeIdentifier) throws Exception {
+    throw new UnsupportedOperationException("This is the default function, it should not be used !");
+  }
+
   /**
    * Get the link to display a document in the Documents app in the given drive. It will try to get the best matching context
    * (personal doc, space doc, ...).
@@ -93,8 +98,22 @@ public interface DocumentService {
    * @param drive The drive to use
    * @return The link to open the document
    * @throws Exception the exception
+   * @deprecated use getLinkInDocumentsAppByIdentifier(String nodeIdentifier, DriveData drive) instead
    */
   String getLinkInDocumentsApp(String nodePath, DriveData drive) throws Exception;
+
+  /**
+   * Get the link to display a document in the Documents app in the given drive. It will try to get the best matching context
+   * (personal doc, space doc, ...).
+   *
+   * @param nodeIdentifier The path of the node
+   * @param drive    The drive to use
+   * @return The link to open the document
+   * @throws Exception the exception
+   */
+  default String getLinkInDocumentsAppByIdentifier(String nodeIdentifier, DriveData drive) throws Exception {
+    throw new UnsupportedOperationException("This is the default function, it should not be used !");
+  }
 
   /**
    * Get the drive containing the node with the given node path, for the current user. If several drives contain the node, try to
@@ -104,7 +123,13 @@ public interface DocumentService {
    * @return The drive containing the node
    * @throws Exception the exception
    */
-  DriveData getDriveOfNode(String nodePath) throws Exception;
+  default DriveData getDriveOfNode(String nodePath) throws Exception {
+    throw new UnsupportedOperationException("This is the default function, it should not be used !");
+  }
+
+  default DriveData getDriveOfNodeByIdentifier(String nodeIdentifier) throws Exception {
+    throw new UnsupportedOperationException("This is the default function, it should not be used !");
+  }
 
   /**
    * Get the drive containing the node with the given node path. If several drives contain the node, try to find the best

--- a/core/services/src/main/java/org/exoplatform/services/cms/drives/DriveData.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/drives/DriveData.java
@@ -60,6 +60,7 @@ public class DriveData implements Comparable<DriveData>, Serializable {
     driveData.setHomePath(getHomePath());
     driveData.setIcon(getIcon());
     driveData.setName(getName());
+    driveData.setLabel(getLabel());
     driveData.setPermissions(getPermissions());
     driveData.setShowHiddenNode(getShowHiddenNode());
     driveData.setViewNonDocument(getViewNonDocument());

--- a/core/services/src/test/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImplTest.java
+++ b/core/services/src/test/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImplTest.java
@@ -1,0 +1,268 @@
+package org.exoplatform.services.cms.documents.impl;
+
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.container.configuration.ConfigurationManager;
+import org.exoplatform.container.xml.PortalContainerInfo;
+import org.exoplatform.portal.config.UserPortalConfig;
+import org.exoplatform.portal.config.UserPortalConfigService;
+import org.exoplatform.portal.config.model.PortalConfig;
+import org.exoplatform.portal.mop.user.UserPortalContext;
+import org.exoplatform.services.cms.documents.DocumentService;
+import org.exoplatform.services.cms.documents.FavoriteService;
+import org.exoplatform.services.cms.drives.DriveData;
+import org.exoplatform.services.cms.drives.ManageDriveService;
+import org.exoplatform.services.cms.drives.impl.ManageDriveServiceImpl;
+import org.exoplatform.services.cms.impl.Utils;
+import org.exoplatform.services.cms.link.LinkManager;
+import org.exoplatform.services.idgenerator.IDGeneratorService;
+import org.exoplatform.services.jcr.RepositoryService;
+import org.exoplatform.services.jcr.config.RepositoryEntry;
+import org.exoplatform.services.jcr.core.ManageableRepository;
+import org.exoplatform.services.jcr.ext.app.SessionProviderService;
+import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.jcr.ext.hierarchy.NodeHierarchyCreator;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.security.Authenticator;
+import org.exoplatform.services.security.ConversationState;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.services.security.IdentityRegistry;
+import org.exoplatform.services.wcm.utils.WCMCoreUtils;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.gatein.api.Portal;
+import org.gatein.api.navigation.Navigation;
+import org.gatein.api.site.SiteId;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.jcr.Node;
+import javax.jcr.Repository;
+import javax.jcr.Session;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DocumentServiceImplTest {
+  public static final String ROOT_USERNAME = "root";
+  public static final String spaceGroupId = "/spaces/spaceOne";
+  @Mock
+  ManageDriveService manageDriveService;
+  @Mock
+  ConfigurationManager configurationManager;
+  @Mock
+  Portal portal;
+  @Mock
+  SessionProviderService sessionProviderService;
+  @Mock
+  RepositoryService repoService;
+  @Mock
+  NodeHierarchyCreator nodeHierarchyCreator;
+  @Mock
+  LinkManager linkManager;
+  @Mock
+  PortalContainerInfo portalContainerInfo;
+  @Mock
+  OrganizationService organizationService;
+  @Mock
+  SettingService settingService;
+  @Mock
+  IdentityManager identityManager;
+  @Mock
+  IDGeneratorService idGenerator;
+  @Mock
+  FavoriteService favoriteService;
+  @Mock
+  IdentityRegistry identityRegistry;
+
+  @Mock
+  Authenticator authenticator;
+
+  DocumentService documentService;
+  @Mock
+  ManageableRepository repository;
+  @Mock
+  RepositoryEntry repositoryEntry;
+  @Mock
+  SessionProvider sessionProvider;
+
+  @Mock
+  Node documentNode;
+
+  @Mock
+  UserPortalConfig userPortalConfig;
+
+  MockedStatic<Utils> UTILS = mockStatic(Utils.class);
+  MockedStatic<WCMCoreUtils> WCM_CORE_UTILS = mockStatic(WCMCoreUtils.class);
+
+  @Mock
+  Session session;
+  @Mock
+  private UserPortalConfigService userPortalConfigService;
+  private DriveData personalDrive;
+  private DriveData usersDrive;
+  private DriveData spaceGroupDrive;
+  private DriveData generalDrive;
+
+  @Before
+  public void setUp() throws Exception {
+    documentService = new DocumentServiceImpl(manageDriveService,
+                                              configurationManager,
+                                              portal,
+                                              sessionProviderService,
+                                              repoService,
+                                              nodeHierarchyCreator,
+                                              linkManager,
+                                              portalContainerInfo,
+                                              organizationService,
+                                              settingService,
+                                              identityManager,
+                                              idGenerator,
+                                              favoriteService,
+                                              identityRegistry,
+                                              authenticator);
+    when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
+    when(repository.getConfiguration()).thenReturn(repositoryEntry);
+    when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
+    when(repoService.getCurrentRepository()).thenReturn(repository);
+    when(sessionProvider.getSession(any(), any())).thenReturn(session);
+    when(documentNode.getPath()).thenReturn("/path/to/documentNode.txt");
+    when(session.getNodeByUUID(anyString())).thenReturn(documentNode);
+    when(portalContainerInfo.getContainerName()).thenReturn("portal");
+
+
+    Navigation spaceNavigation = mock(Navigation.class);
+    org.gatein.api.navigation.Node rootNode = mock(org.gatein.api.navigation.Node.class);
+    Iterator<org.gatein.api.navigation.Node> iterator = mock(Iterator.class);
+    when(iterator.hasNext()).thenReturn(true);
+    org.gatein.api.navigation.Node navigationNode = mock(org.gatein.api.navigation.Node.class);
+    when(navigationNode.getName()).thenReturn("spaceOne");
+    when(iterator.next()).thenReturn(navigationNode);
+    when(rootNode.iterator()).thenReturn(iterator);
+    when(spaceNavigation.getRootNode(any())).thenReturn(rootNode);
+    when(portal.getNavigation(new SiteId(org.gatein.api.site.SiteType.SPACE, spaceGroupId))).thenReturn(spaceNavigation);
+
+    List<String> memberships = Arrays.asList("","","");
+    UTILS.when(Utils::getMemberships).thenReturn(memberships);
+
+    PortalConfig portalConfig = mock(PortalConfig.class);
+    when(portalConfig.getName()).thenReturn("dw");
+    when(userPortalConfigService.getDefaultPortal()).thenReturn("dw");
+    when(userPortalConfig.getPortalConfig()).thenReturn(portalConfig);
+    when(userPortalConfigService.getUserPortalConfig(anyString(), anyString(), any(UserPortalContext.class))).thenReturn(userPortalConfig);
+    WCM_CORE_UTILS.when(() -> WCMCoreUtils.getService(UserPortalConfigService.class)).thenReturn(userPortalConfigService);
+    personalDrive = new DriveData();
+    personalDrive.setLabel("Personal drive");
+    personalDrive.setName("Personal drive");
+    personalDrive.setHomePath("/Users/r___/ro___/roo___/root/Private");
+    when(manageDriveService.getDriveByName(ManageDriveServiceImpl.PERSONAL_DRIVE_NAME)).thenReturn(personalDrive);
+    usersDrive = new DriveData();
+    usersDrive.setName("Users drive");
+    usersDrive.setLabel("Users drive");
+    usersDrive.setHomePath("/Groups/platform/users/Documents");
+    when(manageDriveService.getDriveByName(ManageDriveServiceImpl.USER_DRIVE_NAME)).thenReturn(usersDrive);
+    spaceGroupDrive = new DriveData();
+    spaceGroupDrive.setName(".spaces.spaceOne");
+    spaceGroupDrive.setLabel("SpaceOne drive");
+    spaceGroupDrive.getParameters().put(ManageDriveServiceImpl.DRIVE_PARAMATER_GROUP_ID, spaceGroupId);
+    spaceGroupDrive.setHomePath("/Groups/spaces/spaceOne/Documents");
+    when(manageDriveService.getDriveByName(".spaces.spaceOne")).thenReturn(spaceGroupDrive);
+    generalDrive = new DriveData();
+    generalDrive.setHomePath("/sites/dw");
+    generalDrive.setLabel("General drive");
+    generalDrive.setName("General drive");
+    when(manageDriveService.getDriveByUserRoles(ROOT_USERNAME, memberships)).thenReturn(Arrays.asList(personalDrive, usersDrive, spaceGroupDrive, generalDrive));
+
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    UTILS.close();
+    WCM_CORE_UTILS.close();
+  }
+
+  @Test
+  public void testGetLinkInDocumentsAppByIdentifier() throws Exception {
+    String identifier = "docIdentifier";
+    String link = documentService.getLinkInDocumentsAppByIdentifier(identifier);
+    assertEquals("/portal/dw/documents?path=doc-not-found",link);
+    Identity identity = new Identity(ROOT_USERNAME);
+    ConversationState.setCurrent(new ConversationState(identity));
+
+    when(documentNode.getPath()).thenReturn("/Users/r___/ro___/roo___/root");
+      link = documentService.getLinkInDocumentsAppByIdentifier(identifier);
+    assertNotNull(link);
+    assertEquals("/portal/dw/documents?documentPreviewId=docIdentifier", link);
+
+    when(documentNode.getPath()).thenReturn("/Groups/spaces/spaceOne/Documents");
+    link = documentService.getLinkInDocumentsAppByIdentifier(identifier);
+    assertNotNull(link);
+    assertEquals("/portal/g/:spaces:spaceOne/spaceOne/documents?documentPreviewId=docIdentifier", link);
+
+    when(documentNode.getPath()).thenReturn("/path/to/an/undefined/drive");
+    link = documentService.getLinkInDocumentsAppByIdentifier(identifier);
+    assertNotNull(link);
+    assertEquals("/portal/dw/documents?path=doc-not-found", link);
+  }
+
+  @Test
+  public void testGetLinkInDocumentsAppByIdentifierAndDrive() throws Exception {
+    String identifier = "docIdentifier";
+    String link = documentService.getLinkInDocumentsAppByIdentifier(null, null);
+    assertNull(link);
+
+    Identity identity = new Identity(ROOT_USERNAME);
+    ConversationState.setCurrent(new ConversationState(identity));
+
+    link = documentService.getLinkInDocumentsAppByIdentifier(identifier, null);
+    assertNotNull(link);assertEquals("/portal/dw/documents?path=doc-not-found", link);
+
+    link = documentService.getLinkInDocumentsAppByIdentifier(identifier, personalDrive);
+    assertNotNull(link);
+    assertEquals("/portal/dw/documents?documentPreviewId=docIdentifier", link);
+
+    link = documentService.getLinkInDocumentsAppByIdentifier(identifier, spaceGroupDrive);
+    assertNotNull(link);
+    assertEquals("/portal/g/:spaces:spaceOne/spaceOne/documents?documentPreviewId=docIdentifier", link);
+  }
+
+  @Test
+  public void testGetDriveOfNodeByIdentifier() throws Exception {
+    String identifier = "docIdentifier";
+    DriveData drive = documentService.getDriveOfNodeByIdentifier(identifier);
+    assertNull(drive);
+    Identity identity = new Identity(ROOT_USERNAME);
+    ConversationState.setCurrent(new ConversationState(identity));
+
+    when(documentNode.getPath()).thenReturn("/Users/r___/ro___/roo___/root");
+    drive = documentService.getDriveOfNodeByIdentifier(identifier);
+    assertNotNull(drive);
+    assertEquals("Personal drive", drive.getLabel());
+
+    when(documentNode.getPath()).thenReturn("/Users/r___/ro___/roo___/anotherUser");
+    drive = documentService.getDriveOfNodeByIdentifier(identifier);
+    assertNotNull(drive);
+    assertEquals("Users drive", drive.getLabel());
+
+    when(documentNode.getPath()).thenReturn("/Groups/spaces/spaceOne/Documents");
+    drive = documentService.getDriveOfNodeByIdentifier(identifier);
+    assertNotNull(drive);
+    assertEquals("SpaceOne drive", drive.getLabel());
+
+    when(documentNode.getPath()).thenReturn("/sites/dw/parentFolder/folder/myDocument.txt");
+    drive = documentService.getDriveOfNodeByIdentifier(identifier);
+    assertNotNull(drive);
+    assertEquals("General drive", drive.getLabel());
+
+  }
+}

--- a/core/services/src/test/java/org/exoplatform/services/rest/AttachmentsRestServiceTest.java
+++ b/core/services/src/test/java/org/exoplatform/services/rest/AttachmentsRestServiceTest.java
@@ -1,0 +1,60 @@
+package org.exoplatform.services.rest;
+
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.download.DownloadService;
+import org.exoplatform.services.attachments.model.Attachment;
+import org.exoplatform.services.attachments.service.AttachmentService;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AttachmentsRestServiceTest {
+
+  @Mock
+  private AttachmentService attachmentService;
+
+  private AttachmentsRestService attachmentsRestService;
+
+  @Mock
+  private IdentityManager identityManager;
+  @Mock
+  private DownloadService downloadService;
+
+  @Mock
+  private Attachment attachment;
+
+  @Before
+  public void setUp() throws Exception {
+    when(attachmentService.getAttachmentById(anyString())).thenReturn(attachment);
+    attachmentsRestService = new AttachmentsRestService(attachmentService, identityManager, downloadService);
+  }
+
+  @Test
+  public void getAttachmentById() throws Exception {
+    String attachmentId = "1";
+    Response response = attachmentsRestService.getAttachmentById(null);
+    assertEquals(400, response.getStatus());
+
+    response = attachmentsRestService.getAttachmentById(attachmentId);
+    assertEquals(200, response.getStatus());
+
+    when(attachmentService.getAttachmentById(anyString())).thenReturn(null);
+    response = attachmentsRestService.getAttachmentById(attachmentId);
+    assertEquals(404, response.getStatus());
+
+    when(attachmentService.getAttachmentById(anyString())).thenThrow(new ObjectNotFoundException("attachment is missing"));
+    response = attachmentsRestService.getAttachmentById(attachmentId);
+    assertEquals(404, response.getStatus());
+  }
+}

--- a/core/services/src/test/java/org/exoplatform/services/wcm/BaseWCMTestSuite.java
+++ b/core/services/src/test/java/org/exoplatform/services/wcm/BaseWCMTestSuite.java
@@ -23,6 +23,7 @@ import org.exoplatform.services.cms.clipboard.TestClipboardService;
 import org.exoplatform.services.cms.documents.TestCustomizeViewService;
 import org.exoplatform.services.cms.documents.TestDocumentService;
 import org.exoplatform.services.cms.documents.TestDocumentTypeService;
+import org.exoplatform.services.cms.documents.impl.DocumentServiceImplTest;
 import org.exoplatform.services.cms.lock.impl.TestLockService;
 import org.exoplatform.services.deployment.TestWCMContentInitializerService;
 import org.exoplatform.services.ecm.dms.cms.TestCmsService;
@@ -51,6 +52,7 @@ import org.exoplatform.services.ecm.dms.watchdocument.TestWatchDocumentService;
 import org.exoplatform.services.pdfviewer.TestPDFViewerService;
 import org.exoplatform.services.portletcache.TestFragmentCacheService;
 import org.exoplatform.services.portletcache.TestPortletFutureCache;
+import org.exoplatform.services.rest.AttachmentsRestServiceTest;
 import org.exoplatform.services.rest.TestDocumentsAppRedirectService;
 import org.exoplatform.services.seo.TestSEOService;
 import org.exoplatform.services.wcm.core.TestWCMConfigurationService;
@@ -115,11 +117,13 @@ import org.junit.runners.Suite.SuiteClasses;
   TestSEOService.class,
   TestClipboardService.class,
   TestPDFViewerService.class,
+  AttachmentsRestServiceTest.class,
   TestDocumentsAppRedirectService.class,
   TestDocumentService.class,
   TestCustomizeViewService.class,
   TestXSkinService.class,
-  AttachmentServiceTest.class
+  AttachmentServiceTest.class,
+  DocumentServiceImplTest.class
 })
 @ConfigTestCase(BaseWCMTestCase.class)
 public class BaseWCMTestSuite extends BaseExoContainerTestSuite {


### PR DESCRIPTION
Before this fix, the document service was creating links based on the old Documents application URLs. This is no more needed the preview URLs of document become of pattern :
 - space documents : "/portal/g/:spaces:spaceName/spaceName/documents?documentPreviewId=docIdentifier"
 - other documents out of spaces : "/portal/dw/documents?documentPreviewId=docIdentifier"