### PR TITLE
 fix: breadcrumb folder links are broken - EXO-67575

### DIFF
--- a/core/services/src/test/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImplTest.java
+++ b/core/services/src/test/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImplTest.java
@@ -157,7 +157,7 @@ public class DocumentServiceImplTest {
 
     PortalConfig portalConfig = mock(PortalConfig.class);
     when(portalConfig.getName()).thenReturn("dw");
-    when(userPortalConfigService.getDefaultPortal()).thenReturn("dw");
+    when(userPortalConfigService.getMetaPortal()).thenReturn("dw");
     when(userPortalConfig.getPortalConfig()).thenReturn(portalConfig);
     when(userPortalConfigService.getUserPortalConfig(anyString(), anyString(), any(UserPortalContext.class))).thenReturn(userPortalConfig);
     WCM_CORE_UTILS.when(() -> WCMCoreUtils.getService(UserPortalConfigService.class)).thenReturn(userPortalConfigService);


### PR DESCRIPTION
Before this fix, when checking the breadcrumb of a previewed file, the links of the parent folders of the documents inside a space were broken. The fix ensures that the folder gets its proper link and fiwes the error in the space group id that didn't convert / characters into : characters while used in URLs