### PR TITLE
fix: remove unneeded editor resizing after uploading an image - EXO-67793

### DIFF
--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/uploadImage/plugin.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/uploadImage/plugin.js
@@ -169,12 +169,7 @@
               }
             }).then(uuid => {
               if (uploadFinished && !uploadError) {
-                self.replaceWith('<img src="' + eXo.env.server.context + "/" + eXo.env.portal.rest + "/images/repository/collaboration/" + (uuid ? uuid : "") + '" />');
-                if (editor.resizeEditor) {
-                  editor.resizeEditor();
-                } else if (editor.resize) {
-                  editor.resize();
-                }
+                self.replaceWith('<img src="' + eXo.env.server.context + "/" + eXo.env.portal.rest + "/images/repository/collaboration/" + (uuid || "") + '" />');
                 setTimeout(function() {
                   editor.execCommand('autogrow');
                 }, 500);


### PR DESCRIPTION
After copying pasting an image, the content of the note/news is hidden and we have a blank sheet. The fix removes an unneeded resizing instruction of the editor that was setting the height to 0.