### PR TITLE
fix: Apply the border radius for the transfer rules application - EXO-67638 

### DIFF
--- a/apps/portlet-transferrules/src/main/webapp/vue-apps/transferRules/components/TransferRulesApp.vue
+++ b/apps/portlet-transferrules/src/main/webapp/vue-apps/transferRules/components/TransferRulesApp.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app id="transferRules">
-    <v-card class="ma-4 border-radius" flat>
+    <v-card class="pa-5 card-border-radius" flat>
       <v-list>
         <v-list-item>
           <v-list-item-content>


### PR DESCRIPTION

Before this modification, no border radius was applied to the transfer rules application. This change will now implement the border radius on the transfer rules application