### PR TITLE
feat: Upgrade To Tomcat 10 - Meeds-io/MIPs#76

### DIFF
--- a/apps/portlet-editors/pom.xml
+++ b/apps/portlet-editors/pom.xml
@@ -33,18 +33,8 @@
   <description>eXo DMS Portlet Java Content: Online Editors Admin</description>
   <dependencies>
     <dependency>
-      <groupId>javax.portlet</groupId>
-      <artifactId>portlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.webui.portlet</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/apps/portlet-presentation/pom.xml
+++ b/apps/portlet-presentation/pom.xml
@@ -11,16 +11,8 @@
   <name>eXo PLF:: WCM Presentation Portlet Suites</name>
   <dependencies>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-    </dependency>
-    <dependency>
       <groupId>javax.jcr</groupId>
       <artifactId>jcr</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.portlet</groupId>
-      <artifactId>portlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.ecms</groupId>
@@ -93,11 +85,6 @@
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>

--- a/apps/portlet-search/pom.xml
+++ b/apps/portlet-search/pom.xml
@@ -15,10 +15,6 @@
       <artifactId>jcr</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.portlet</groupId>
-      <artifactId>portlet-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.exoplatform.ecms</groupId>
       <artifactId>ecms-core-publication</artifactId>
     </dependency>
@@ -69,11 +65,6 @@
     <dependency>
       <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.webui.portlet</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.gatein.portal</groupId>

--- a/core/connector/pom.xml
+++ b/core/connector/pom.xml
@@ -134,11 +134,6 @@
       <artifactId>rome</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.exoplatform.core</groupId>
       <artifactId>exo.core.component.organization.api</artifactId>
       <scope>provided</scope>

--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/clouddrives/DriveService.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/clouddrives/DriveService.java
@@ -33,7 +33,6 @@ import javax.jcr.NodeIterator;
 import javax.jcr.PathNotFoundException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
-import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -48,6 +47,7 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
 import org.exoplatform.services.cms.clouddrives.CloudDrive;
+import org.exoplatform.services.cms.clouddrives.CloudDrive.Command;
 import org.exoplatform.services.cms.clouddrives.CloudDriveException;
 import org.exoplatform.services.cms.clouddrives.CloudDriveMessage;
 import org.exoplatform.services.cms.clouddrives.CloudDriveService;
@@ -59,13 +59,14 @@ import org.exoplatform.services.cms.clouddrives.NotCloudFileException;
 import org.exoplatform.services.cms.clouddrives.NotConnectedException;
 import org.exoplatform.services.cms.clouddrives.NotYetCloudFileException;
 import org.exoplatform.services.cms.clouddrives.RefreshAccessException;
-import org.exoplatform.services.cms.clouddrives.CloudDrive.Command;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.ext.app.SessionProviderService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.rest.resource.ResourceContainer;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * REST service providing information about providers. Created by The eXo Platform SAS.

--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/fckeditor/FileUploadHandler.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/fckeditor/FileUploadHandler.java
@@ -23,12 +23,14 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 
 import javax.jcr.Node;
-import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.CacheControl;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 import org.exoplatform.common.http.HTTPStatus;
 import org.exoplatform.commons.utils.IOUtil;
@@ -37,8 +39,8 @@ import org.exoplatform.services.cms.mimetype.DMSMimeTypeResolver;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.upload.UploadResource;
 import org.exoplatform.upload.UploadService;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 /*
  * Created by The eXo Platform SAS

--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
@@ -18,7 +18,11 @@ package org.exoplatform.ecm.connector.platform;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
 
 import javax.annotation.security.RolesAllowed;
 import javax.jcr.AccessDeniedException;
@@ -27,8 +31,12 @@ import javax.jcr.NodeIterator;
 import javax.jcr.PathNotFoundException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.*;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.CacheControl;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
@@ -39,13 +47,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.dom.DOMSource;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.apache.commons.lang.StringUtils;
-import org.exoplatform.services.cms.drives.impl.ManageDriveServiceImpl;
-import org.exoplatform.services.jcr.core.ExtendedNode;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -61,11 +63,13 @@ import org.exoplatform.services.cms.clouddrives.NotYetCloudFileException;
 import org.exoplatform.services.cms.documents.AutoVersionService;
 import org.exoplatform.services.cms.drives.DriveData;
 import org.exoplatform.services.cms.drives.ManageDriveService;
+import org.exoplatform.services.cms.drives.impl.ManageDriveServiceImpl;
 import org.exoplatform.services.cms.impl.Utils;
 import org.exoplatform.services.cms.link.LinkManager;
 import org.exoplatform.services.context.DocumentContext;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.access.PermissionType;
+import org.exoplatform.services.jcr.core.ExtendedNode;
 import org.exoplatform.services.jcr.core.ManageableRepository;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.log.ExoLogger;
@@ -76,6 +80,12 @@ import org.exoplatform.services.security.MembershipEntry;
 import org.exoplatform.services.wcm.core.NodetypeConstant;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.wcm.connector.FileUploadHandler;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * This service is used to perform some actions on a folder or on a file, such as creating,

--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
@@ -16,7 +16,40 @@
  */
 package org.exoplatform.wcm.connector;
 
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.net.URLDecoder;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ResourceBundle;
+import java.util.Set;
+
+import javax.jcr.ItemExistsException;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.ws.rs.core.CacheControl;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.dom.DOMSource;
+
 import org.apache.commons.lang.StringUtils;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.simple.JSONValue;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
 import org.exoplatform.common.http.HTTPStatus;
 import org.exoplatform.ecm.connector.fckeditor.FCKMessage;
 import org.exoplatform.ecm.connector.fckeditor.FCKUtils;
@@ -43,29 +76,8 @@ import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.upload.UploadResource;
 import org.exoplatform.upload.UploadService;
 import org.exoplatform.upload.UploadService.UploadLimit;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.json.simple.JSONValue;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 
-import javax.jcr.ItemExistsException;
-import javax.jcr.Node;
-import javax.jcr.RepositoryException;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.CacheControl;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.transform.dom.DOMSource;
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.net.URLDecoder;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.*;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Created by The eXo Platform SAS

--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/DocumentEditorsRESTService.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/DocumentEditorsRESTService.java
@@ -23,7 +23,6 @@ import javax.annotation.security.RolesAllowed;
 import javax.jcr.AccessDeniedException;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
-import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
@@ -67,6 +66,8 @@ import org.exoplatform.wcm.connector.collaboration.editors.HypermediaLink;
 import org.exoplatform.wcm.connector.collaboration.editors.PreviewInfo;
 import org.exoplatform.ws.frameworks.json.impl.JsonException;
 import org.exoplatform.ws.frameworks.json.impl.JsonGeneratorImpl;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * The Class DocumentEditorsRESTService is REST endpoint for working with editable documents.

--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/OpenInOfficeConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/OpenInOfficeConnector.java
@@ -1,7 +1,34 @@
 package org.exoplatform.wcm.connector.collaboration;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
+import javax.annotation.security.RolesAllowed;
+import javax.jcr.AccessDeniedException;
+import javax.jcr.Node;
+import javax.jcr.PathNotFoundException;
+import javax.jcr.RepositoryException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.CacheControl;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.tika.io.IOUtils;
+import org.json.JSONObject;
+import org.picocontainer.Startable;
+
 import org.exoplatform.ecm.utils.text.Text;
 import org.exoplatform.services.cms.documents.DocumentTypeService;
 import org.exoplatform.services.cms.documents.impl.DocumentType;
@@ -15,25 +42,7 @@ import org.exoplatform.services.wcm.core.NodetypeConstant;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.social.rest.api.RestUtils;
 
-import org.json.JSONObject;
-import org.picocontainer.Startable;
-
-import javax.annotation.security.RolesAllowed;
-import javax.jcr.*;
-import javax.jcr.lock.LockException;
-import javax.jcr.nodetype.ConstraintViolationException;
-import javax.jcr.nodetype.NoSuchNodeTypeException;
-import javax.jcr.version.VersionException;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.*;
-import javax.ws.rs.core.*;
-import javax.ws.rs.core.Response.Status;
-
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.util.Locale;
-import java.util.MissingResourceException;
-import java.util.ResourceBundle;
+import jakarta.servlet.http.HttpServletRequest;
 
 
 /**

--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/fckeditor/DriverConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/fckeditor/DriverConnector.java
@@ -36,7 +36,6 @@ import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
-import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -50,7 +49,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.dom.DOMSource;
 
 import org.apache.commons.lang.StringUtils;
-import org.exoplatform.services.cms.clouddrives.CloudDrive;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -59,6 +57,7 @@ import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.ecm.connector.fckeditor.FCKUtils;
 import org.exoplatform.ecm.utils.text.Text;
 import org.exoplatform.services.cms.BasePath;
+import org.exoplatform.services.cms.clouddrives.CloudDrive;
 import org.exoplatform.services.cms.clouddrives.CloudDriveService;
 import org.exoplatform.services.cms.documents.DocumentService;
 import org.exoplatform.services.cms.drives.DriveData;
@@ -87,6 +86,8 @@ import org.exoplatform.services.wcm.webcontent.WebContentSchemaHandler;
 import org.exoplatform.wcm.connector.BaseConnector;
 import org.exoplatform.wcm.connector.FileUploadHandler;
 import org.exoplatform.wcm.connector.handler.FCKFileHandler;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Returns a list of drives/folders/documents in a specified location for a given user. Also, it processes the file uploading action.

--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/fckeditor/PortalLinkConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/fckeditor/PortalLinkConnector.java
@@ -24,7 +24,6 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
-import javax.servlet.ServletContext;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
@@ -35,6 +34,9 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.dom.DOMSource;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 import org.exoplatform.commons.utils.ISO8601;
 import org.exoplatform.commons.utils.PageList;
@@ -53,14 +55,14 @@ import org.exoplatform.portal.mop.user.UserNavigation;
 import org.exoplatform.portal.mop.user.UserNode;
 import org.exoplatform.portal.mop.user.UserPortal;
 import org.exoplatform.portal.mop.user.UserPortalContext;
+import org.exoplatform.portal.webui.util.NavigationUtils;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.rest.resource.ResourceContainer;
 import org.exoplatform.services.security.ConversationState;
-import org.exoplatform.portal.webui.util.NavigationUtils;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
+
+import jakarta.servlet.ServletContext;
 
 /**
  * Returns a page URI for a given location.

--- a/core/search/pom.xml
+++ b/core/search/pom.xml
@@ -13,20 +13,8 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-    </dependency>
-    <dependency>
       <groupId>javax.jcr</groupId>
       <artifactId>jcr</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.portlet</groupId>
-      <artifactId>portlet-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.commons</groupId>
-      <artifactId>commons-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.commons</groupId>

--- a/core/services/pom.xml
+++ b/core/services/pom.xml
@@ -22,10 +22,6 @@
       <artifactId>icu4j</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-chain</groupId>
-      <artifactId>commons-chain</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-httpclient</groupId>
       <artifactId>commons-httpclient</artifactId>
       <exclusions>
@@ -37,16 +33,8 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-    </dependency>
-    <dependency>
       <groupId>javax.jcr</groupId>
       <artifactId>jcr</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.portlet</groupId>
-      <artifactId>portlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.ws.rs</groupId>
@@ -209,11 +197,6 @@
     <dependency>
       <groupId>org.exoplatform.ecms</groupId>
       <artifactId>ecms-testsuite-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.tool</groupId>
-      <artifactId>exo.tool.framework.junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/core/services/src/main/java/org/exoplatform/services/filters/sessionProvider/ThreadLocalACLSessionProviderInitializedFilter.java
+++ b/core/services/src/main/java/org/exoplatform/services/filters/sessionProvider/ThreadLocalACLSessionProviderInitializedFilter.java
@@ -18,14 +18,14 @@ package org.exoplatform.services.filters.sessionProvider;
 
 import java.io.IOException;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-
 import org.exoplatform.services.jcr.sessions.ACLSessionProviderService;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.web.filter.Filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
 
 /**
  * Created by The eXo Platform SAS
@@ -48,10 +48,4 @@ public class ThreadLocalACLSessionProviderInitializedFilter implements Filter {
     }
   }
 
-  /*
-   * (non-Javadoc)
-   * @see javax.servlet.Filter#destroy()
-   */
-  public void destroy() {
-  }
 }

--- a/core/services/src/main/java/org/exoplatform/services/handler/RobotsHandler.java
+++ b/core/services/src/main/java/org/exoplatform/services/handler/RobotsHandler.java
@@ -2,15 +2,15 @@ package org.exoplatform.services.handler;
 
 import java.io.PrintWriter;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.exoplatform.services.seo.SEOService;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.web.ControllerContext;
 import org.exoplatform.web.WebAppController;
 import org.exoplatform.web.WebRequestHandler;
 import org.exoplatform.web.controller.QualifiedName;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public class RobotsHandler extends WebRequestHandler {
 

--- a/core/services/src/main/java/org/exoplatform/services/handler/SiteJavascriptHandler.java
+++ b/core/services/src/main/java/org/exoplatform/services/handler/SiteJavascriptHandler.java
@@ -19,7 +19,6 @@ package org.exoplatform.services.handler;
 import java.io.PrintWriter;
 
 import javax.jcr.Node;
-import javax.servlet.http.HttpServletResponse;
 
 import org.exoplatform.ecm.utils.MessageDigester;
 import org.exoplatform.services.cache.CacheService;
@@ -32,6 +31,8 @@ import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.web.ControllerContext;
 import org.exoplatform.web.WebRequestHandler;
 import org.exoplatform.web.controller.QualifiedName;
+
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Created by The eXo Platform SAS

--- a/core/services/src/main/java/org/exoplatform/services/handler/SitemapHandler.java
+++ b/core/services/src/main/java/org/exoplatform/services/handler/SitemapHandler.java
@@ -2,15 +2,15 @@ package org.exoplatform.services.handler;
 
 import java.io.PrintWriter;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.exoplatform.services.seo.SEOService;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.web.ControllerContext;
 import org.exoplatform.web.WebAppController;
 import org.exoplatform.web.WebRequestHandler;
 import org.exoplatform.web.controller.QualifiedName;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public class SitemapHandler extends WebRequestHandler {
 

--- a/core/services/src/main/java/org/exoplatform/services/rest/DocumentsAppRedirectService.java
+++ b/core/services/src/main/java/org/exoplatform/services/rest/DocumentsAppRedirectService.java
@@ -6,7 +6,6 @@ import java.net.URI;
 import javax.annotation.security.RolesAllowed;
 import javax.jcr.ItemNotFoundException;
 import javax.jcr.Node;
-import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -15,7 +14,6 @@ import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang.StringUtils;
 
-import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.services.cms.documents.DocumentService;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.core.ExtendedSession;
@@ -24,7 +22,8 @@ import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.rest.resource.ResourceContainer;
-import org.exoplatform.services.wcm.utils.WCMCoreUtils;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Web service to redirect to the Documents app to display the document with the given workspace and the given id

--- a/core/services/src/main/java/org/exoplatform/services/wcm/friendly/impl/FriendlyFilter.java
+++ b/core/services/src/main/java/org/exoplatform/services/wcm/friendly/impl/FriendlyFilter.java
@@ -16,16 +16,17 @@
  */
 package org.exoplatform.services.wcm.friendly.impl;
 
+import java.io.IOException;
+
 import org.exoplatform.services.wcm.friendly.FriendlyService;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.web.filter.Filter;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import java.io.IOException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Created by The eXo Platform SAS

--- a/core/services/src/main/java/org/exoplatform/services/wcm/skin/XSkinService.java
+++ b/core/services/src/main/java/org/exoplatform/services/wcm/skin/XSkinService.java
@@ -27,7 +27,7 @@ import java.util.Map.Entry;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
-import javax.servlet.ServletContext;
+import jakarta.servlet.ServletContext;
 
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.lang.StringUtils;

--- a/core/services/src/test/java/org/exoplatform/services/rest/TestDocumentsAppRedirectService.java
+++ b/core/services/src/test/java/org/exoplatform/services/rest/TestDocumentsAppRedirectService.java
@@ -1,23 +1,23 @@
 package org.exoplatform.services.rest;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import javax.jcr.ItemNotFoundException;
+import javax.jcr.Node;
+import javax.ws.rs.core.Response;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
 import org.exoplatform.services.cms.documents.DocumentService;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.core.ExtendedSession;
 import org.exoplatform.services.jcr.ext.app.SessionProviderService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
-import org.exoplatform.services.jcr.impl.core.ItemImpl;
-import org.exoplatform.services.jcr.impl.core.NodeImpl;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
 
-import javax.jcr.ItemNotFoundException;
-import javax.jcr.Node;
-import javax.jcr.Session;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.Response;
-
-import static org.junit.Assert.*;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Tests for DocumentsAppRedirectService

--- a/core/services/src/test/java/org/exoplatform/services/wcm/skin/TestXSkinService.java
+++ b/core/services/src/test/java/org/exoplatform/services/wcm/skin/TestXSkinService.java
@@ -29,8 +29,6 @@ import java.util.Map;
 
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
-import javax.jcr.RepositoryException;
-import javax.servlet.ServletContext;
 
 import org.exoplatform.commons.xml.DocumentSource;
 import org.exoplatform.component.test.web.ServletContextImpl;
@@ -38,7 +36,6 @@ import org.exoplatform.component.test.web.WebAppImpl;
 import org.exoplatform.portal.resource.SkinConfig;
 import org.exoplatform.portal.resource.SkinService;
 import org.exoplatform.portal.resource.config.xml.SkinConfigParser;
-import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.wcm.BaseWCMTestCase;
 import org.exoplatform.services.wcm.core.WCMConfigurationService;
@@ -50,6 +47,8 @@ import org.exoplatform.web.controller.QualifiedName;
 import org.exoplatform.web.controller.metadata.DescriptorBuilder;
 import org.exoplatform.web.controller.router.Router;
 import org.exoplatform.web.controller.router.RouterConfigException;
+
+import jakarta.servlet.ServletContext;
 
 /**
  * The Class TestXJavaScriptService.

--- a/core/webui-administration/pom.xml
+++ b/core/webui-administration/pom.xml
@@ -20,10 +20,6 @@
       <artifactId>jcr</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.portlet</groupId>
-      <artifactId>portlet-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.exoplatform.commons</groupId>
       <artifactId>commons-component-common</artifactId>
     </dependency>

--- a/core/webui-clouddrives/src/main/java/org/exoplatform/services/cms/clouddrives/webui/CloudDriveContextFilter.java
+++ b/core/webui-clouddrives/src/main/java/org/exoplatform/services/cms/clouddrives/webui/CloudDriveContextFilter.java
@@ -21,18 +21,17 @@ package org.exoplatform.services.cms.clouddrives.webui;
 
 import java.io.IOException;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-
-import org.exoplatform.services.log.ExoLogger;
-import org.exoplatform.services.log.Log;
-
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.portal.application.PortalApplication;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
 import org.exoplatform.web.WebAppController;
 import org.exoplatform.web.filter.Filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
 
 /**
  * Created by The eXo Platform SAS.

--- a/core/webui-clouddrives/src/main/java/org/exoplatform/services/cms/clouddrives/webui/rest/FileService.java
+++ b/core/webui-clouddrives/src/main/java/org/exoplatform/services/cms/clouddrives/webui/rest/FileService.java
@@ -26,7 +26,6 @@ import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.PathNotFoundException;
 import javax.jcr.RepositoryException;
-import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -61,6 +60,8 @@ import org.exoplatform.services.rest.resource.ResourceContainer;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.MembershipEntry;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * REST service providing information about cloud files in Documents (ECMS) app.<br>

--- a/core/webui-clouddrives/src/main/java/org/exoplatform/services/cms/clouddrives/webui/rest/ResourceService.java
+++ b/core/webui-clouddrives/src/main/java/org/exoplatform/services/cms/clouddrives/webui/rest/ResourceService.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.ResourceBundle;
 
 import javax.annotation.security.RolesAllowed;
-import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -40,6 +39,8 @@ import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.resources.ResourceBundleService;
 import org.exoplatform.services.rest.resource.ResourceContainer;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * REST service providing access to UI resources. Created by The eXo Platform

--- a/core/webui-explorer/pom.xml
+++ b/core/webui-explorer/pom.xml
@@ -15,16 +15,8 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-    </dependency>
-    <dependency>
       <groupId>javax.jcr</groupId>
       <artifactId>jcr</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.portlet</groupId>
-      <artifactId>portlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.ws.commons</groupId>
@@ -150,11 +142,6 @@
       <artifactId>exo.portal.webui.portlet</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>ecs</groupId>
       <artifactId>ecs</artifactId>
     </dependency>
@@ -171,28 +158,6 @@
     <dependency>
       <groupId>org.exoplatform.ecms</groupId>
       <artifactId>ecms-testsuite-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.gatein.portal</groupId>
-      <artifactId>exo.portal.component.identity</artifactId>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.gatein.portal</groupId>
-      <artifactId>exo.portal.component.portal</artifactId>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.gatein.portal</groupId>
-      <artifactId>exo.portal.component.test.core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hsqldb</groupId>
-      <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIDrivesArea.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIDrivesArea.java
@@ -27,8 +27,6 @@ import javax.jcr.AccessDeniedException;
 import javax.jcr.NoSuchWorkspaceException;
 import javax.jcr.Node;
 import javax.jcr.Session;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
 
 import org.exoplatform.container.definition.PortalContainerConfig;
 import org.exoplatform.container.xml.PortalContainerInfo;
@@ -67,6 +65,9 @@ import org.exoplatform.webui.core.UIComponent;
 import org.exoplatform.webui.core.UIContainer;
 import org.exoplatform.webui.event.Event;
 import org.exoplatform.webui.event.EventListener;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Created by The eXo Platform SARL

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIJCRExplorer.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/UIJCRExplorer.java
@@ -16,6 +16,30 @@
  */
 package org.exoplatform.ecm.webui.component.explorer ;
 
+import java.net.URLDecoder;
+import java.security.AccessControlException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import javax.jcr.Item;
+import javax.jcr.ItemNotFoundException;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.PathNotFoundException;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.nodetype.NodeType;
+import javax.portlet.PortletPreferences;
+
 import org.exoplatform.ecm.jcr.TypeNodeComparator;
 import org.exoplatform.ecm.jcr.model.Preference;
 import org.exoplatform.ecm.resolver.JCRResourceResolver;
@@ -61,18 +85,17 @@ import org.exoplatform.web.application.ApplicationMessage;
 import org.exoplatform.webui.application.WebuiRequestContext;
 import org.exoplatform.webui.application.portlet.PortletRequestContext;
 import org.exoplatform.webui.config.annotation.ComponentConfig;
-import org.exoplatform.webui.core.*;
+import org.exoplatform.webui.core.UIApplication;
+import org.exoplatform.webui.core.UIComponent;
+import org.exoplatform.webui.core.UIContainer;
+import org.exoplatform.webui.core.UIPageIterator;
+import org.exoplatform.webui.core.UIPopupContainer;
+import org.exoplatform.webui.core.UIPopupWindow;
 import org.exoplatform.webui.core.lifecycle.UIContainerLifecycle;
 import org.exoplatform.webui.event.Event;
 
-import javax.jcr.*;
-import javax.jcr.nodetype.NodeType;
-import javax.portlet.PortletPreferences;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import java.net.URLDecoder;
-import java.security.AccessControlException;
-import java.util.*;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Created by The eXo Platform SARL

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/UIPreferencesForm.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/control/UIPreferencesForm.java
@@ -21,13 +21,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
 
-import javax.portlet.PortletRequest;
-import javax.servlet.http.*;
-
 import org.exoplatform.ecm.jcr.model.Preference;
 import org.exoplatform.ecm.webui.component.explorer.UIJCRExplorer;
 import org.exoplatform.ecm.webui.component.explorer.UIJCRExplorerPortlet;
-import org.exoplatform.ecm.webui.component.explorer.sidebar.UIAllItems;
 import org.exoplatform.portal.webui.util.Util;
 import org.exoplatform.services.wcm.core.NodetypeConstant;
 import org.exoplatform.web.application.RequestContext;
@@ -45,6 +41,9 @@ import org.exoplatform.webui.event.EventListener;
 import org.exoplatform.webui.form.UIForm;
 import org.exoplatform.webui.form.UIFormSelectBox;
 import org.exoplatform.webui.form.input.UICheckBoxInput;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Created by The eXo Platform SARL

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/documents/DocumentEditorsFilter.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/documents/DocumentEditorsFilter.java
@@ -19,11 +19,6 @@ package org.exoplatform.ecm.webui.component.explorer.documents;
 import java.io.IOException;
 import java.util.List;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -31,6 +26,11 @@ import org.exoplatform.web.WebAppController;
 import org.exoplatform.web.application.ApplicationLifecycle;
 import org.exoplatform.web.filter.Filter;
 import org.exoplatform.webui.application.WebuiApplication;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
 
 /**
  * The Class DocumentEditorsFilter.

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/documents/DocumentEditorsLifecycle.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/documents/DocumentEditorsLifecycle.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
-import javax.servlet.ServletRequest;
 
 import org.exoplatform.ecm.webui.component.explorer.UIJCRExplorer;
 import org.exoplatform.portal.application.PortalRequestContext;
@@ -40,6 +39,8 @@ import org.exoplatform.web.application.RequireJS;
 import org.exoplatform.webui.application.WebuiRequestContext;
 import org.exoplatform.ws.frameworks.json.impl.JsonException;
 import org.exoplatform.ws.frameworks.json.impl.JsonGeneratorImpl;
+
+import jakarta.servlet.ServletRequest;
 
 /**
  * The Class DocumentEditorsLifecycle.

--- a/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/sidebar/UIAllItems.java
+++ b/core/webui-explorer/src/main/java/org/exoplatform/ecm/webui/component/explorer/sidebar/UIAllItems.java
@@ -17,8 +17,7 @@
 package org.exoplatform.ecm.webui.component.explorer.sidebar;
 
 import java.util.Set;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletResponse;
+
 import org.exoplatform.ecm.jcr.model.Preference;
 import org.exoplatform.ecm.webui.component.explorer.UIDocumentWorkspace;
 import org.exoplatform.ecm.webui.component.explorer.UIDrivesArea;
@@ -33,6 +32,9 @@ import org.exoplatform.webui.core.UIComponent;
 import org.exoplatform.webui.core.UIPopupContainer;
 import org.exoplatform.webui.event.Event;
 import org.exoplatform.webui.event.EventListener;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Created by The eXo Platform SARL

--- a/core/webui-presentation/pom.xml
+++ b/core/webui-presentation/pom.xml
@@ -11,16 +11,8 @@
   <name>eXo PLF:: WCM Presentation Portlet Webui</name>
   <dependencies>
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-    </dependency>
-    <dependency>
       <groupId>javax.jcr</groupId>
       <artifactId>jcr</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.portlet</groupId>
-      <artifactId>portlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.ecms</groupId>
@@ -85,15 +77,6 @@
     <dependency>
       <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.webui.portlet</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>

--- a/core/webui-presentation/src/main/java/org/exoplatform/wcm/webui/category/UICategoryNavigationTreeBase.java
+++ b/core/webui-presentation/src/main/java/org/exoplatform/wcm/webui/category/UICategoryNavigationTreeBase.java
@@ -24,9 +24,9 @@ import java.util.List;
 import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.portlet.PortletPreferences;
-import javax.servlet.http.HttpServletRequestWrapper;
 
 import org.apache.commons.lang.StringUtils;
+
 import org.exoplatform.ecm.resolver.JCRResourceResolver;
 import org.exoplatform.ecm.webui.utils.Utils;
 import org.exoplatform.portal.mop.SiteType;
@@ -46,6 +46,8 @@ import org.exoplatform.webui.config.annotation.ComponentConfig;
 import org.exoplatform.webui.config.annotation.EventConfig;
 import org.exoplatform.webui.core.UIRightClickPopupMenu;
 import org.exoplatform.webui.core.UITree;
+
+import jakarta.servlet.http.HttpServletRequestWrapper;
 
 /**
  * Created by The eXo Platform SAS

--- a/core/webui-seo/pom.xml
+++ b/core/webui-seo/pom.xml
@@ -12,10 +12,6 @@
   <description>eXo SEO Portlet Java Content</description>
   <dependencies>
     <dependency>
-      <groupId>javax.jcr</groupId>
-      <artifactId>jcr</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.exoplatform.ecms</groupId>
       <artifactId>ecms-core-services</artifactId>
     </dependency>
@@ -58,11 +54,6 @@
     <dependency>
       <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.webui.portlet</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/core/webui/pom.xml
+++ b/core/webui/pom.xml
@@ -26,10 +26,6 @@
       <artifactId>jcr</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.portlet</groupId>
-      <artifactId>portlet-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.exoplatform</groupId>
       <artifactId>exo-jcr-services</artifactId>
     </dependency>
@@ -121,31 +117,5 @@
       <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.webui.portlet</artifactId>
     </dependency>    
-    <dependency>
-      <groupId>org.quartz-scheduler</groupId>
-      <artifactId>quartz</artifactId>
-      <exclusions>
-        <exclusion>
-          <!-- commons-logging is forbidden and must be replaced by org.slf4j:jcl-over-slf4j -->
-          <artifactId>commons-logging</artifactId>
-          <groupId>commons-logging</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/core/webui/src/main/java/org/exoplatform/ecm/jcr/RssServlet.java
+++ b/core/webui/src/main/java/org/exoplatform/ecm/jcr/RssServlet.java
@@ -23,20 +23,21 @@ import java.util.List;
 import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.Session;
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
-import org.exoplatform.services.log.Log;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.RootContainer;
 import org.exoplatform.services.cms.templates.TemplateService;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @SuppressWarnings({"serial","unused"})
 public class RssServlet extends HttpServlet {

--- a/core/webui/src/main/java/org/exoplatform/ecm/webui/utils/Utils.java
+++ b/core/webui/src/main/java/org/exoplatform/ecm/webui/utils/Utils.java
@@ -22,18 +22,31 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.security.AccessControlException;
 import java.text.DecimalFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.MissingResourceException;
+import java.util.Optional;
+import java.util.ResourceBundle;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.ZipInputStream;
 
 import javax.imageio.ImageIO;
-import javax.jcr.*;
+import javax.jcr.ItemNotFoundException;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.PathNotFoundException;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Value;
 import javax.jcr.nodetype.NodeDefinition;
 import javax.jcr.nodetype.NodeType;
 import javax.jcr.nodetype.NodeTypeManager;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
@@ -83,6 +96,9 @@ import org.exoplatform.webui.core.UIPopupContainer;
 import org.exoplatform.webui.event.Event;
 import org.exoplatform.webui.ext.UIExtension;
 import org.exoplatform.webui.ext.UIExtensionManager;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Created by The eXo Platform SARL Author : Dang Van Minh

--- a/core/webui/src/main/java/org/exoplatform/wcm/webui/friendly/FriendlyServlet.java
+++ b/core/webui/src/main/java/org/exoplatform/wcm/webui/friendly/FriendlyServlet.java
@@ -2,14 +2,14 @@ package org.exoplatform.wcm.webui.friendly;
 
 import java.io.IOException;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.exoplatform.services.wcm.friendly.FriendlyService;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public class FriendlyServlet extends HttpServlet {
 

--- a/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/wcm-artifacts/application-templates/wcm-search/search-result/Results.gtmpl
+++ b/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/wcm-artifacts/application-templates/wcm-search/search-result/Results.gtmpl
@@ -5,7 +5,7 @@
 
  import javax.jcr.Node;
  import javax.jcr.Value;
- import javax.servlet.http.HttpServletRequest;
+ import jakarta.servlet.http.HttpServletRequest;
 
  import org.exoplatform.portal.application.PortalRequestContext;
  import org.exoplatform.portal.webui.portal.UIPortal;

--- a/ecm-wcm-extension/src/main/webapp/groovy/portal/webui/workspace/UIECMSPortalApplicationEndBody.gtmpl
+++ b/ecm-wcm-extension/src/main/webapp/groovy/portal/webui/workspace/UIECMSPortalApplicationEndBody.gtmpl
@@ -3,7 +3,7 @@
   import org.exoplatform.web.application.JavascriptManager;
   import org.exoplatform.portal.webui.util.Util;
   import org.exoplatform.portal.webui.util.NavigationUtils;
-  import javax.servlet.http.HttpSession;
+  import jakarta.servlet.http.HttpSession;
   import org.exoplatform.services.wcm.publication.WCMComposer;
   import org.exoplatform.wcm.webui.Utils;
   import org.apache.commons.lang.StringUtils;

--- a/ecms-social-integration/pom.xml
+++ b/ecms-social-integration/pom.xml
@@ -19,10 +19,6 @@
       <artifactId>jcr</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.portlet</groupId>
-      <artifactId>portlet-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.exoplatform.commons</groupId>
       <artifactId>commons-component-common</artifactId>
     </dependency>
@@ -119,11 +115,6 @@
     <dependency>
       <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.webui.portlet</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.gatein.portal</groupId>

--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/document/service/rest/ContentViewerRESTService.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/document/service/rest/ContentViewerRESTService.java
@@ -20,10 +20,11 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Locale;
 
-import javax.jcr.*;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.*;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
@@ -55,6 +56,9 @@ import org.exoplatform.web.ControllerContext;
 import org.exoplatform.web.WebAppController;
 import org.exoplatform.webui.application.WebuiRequestContext;
 import org.exoplatform.webui.core.UIComponent;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  *

--- a/ext/authoring/apps/pom.xml
+++ b/ext/authoring/apps/pom.xml
@@ -15,10 +15,6 @@
       <artifactId>jcr</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.portlet</groupId>
-      <artifactId>portlet-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.exoplatform.ecms</groupId>
       <artifactId>ecms-core-services</artifactId>
     </dependency>

--- a/ext/fastcontentcreator/portlet/pom.xml
+++ b/ext/fastcontentcreator/portlet/pom.xml
@@ -16,10 +16,6 @@
       <artifactId>jcr</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.portlet</groupId>
-      <artifactId>portlet-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.exoplatform.ecms</groupId>
       <artifactId>ecms-core-services</artifactId>
     </dependency>

--- a/testsuite/test/pom.xml
+++ b/testsuite/test/pom.xml
@@ -13,14 +13,6 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>javax.jcr</groupId>
-      <artifactId>jcr</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>jsr311-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.exoplatform.commons</groupId>
       <artifactId>commons-testing</artifactId>
     </dependency>
@@ -39,12 +31,6 @@
     <dependency>
       <groupId>org.exoplatform.jcr</groupId>
       <artifactId>exo.jcr.component.ext</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.exoplatform.gatein.portal</groupId>
-      <artifactId>exo.portal.component.identity</artifactId>
-      <type>test-jar</type>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.kernel</groupId>
@@ -69,11 +55,6 @@
     <dependency>
       <groupId>org.exoplatform.gatein.portal</groupId>
       <artifactId>exo.portal.component.test.core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <scope>provided</scope>
     </dependency>
     <!-- need for test -->
     <dependency>
@@ -100,19 +81,9 @@
     </dependency>
     <!-- need for test -->
     <dependency>
-      <groupId>org.hsqldb</groupId>
-      <artifactId>hsqldb</artifactId>
-      <scope>test</scope>
+      <groupId>org.exoplatform.social</groupId>
+      <artifactId>social-component-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-      <dependency>
-          <groupId>org.exoplatform.social</groupId>
-          <artifactId>social-component-api</artifactId>
-      </dependency>
   </dependencies>
   <build>
     <resources>

--- a/testsuite/test/src/main/java/org/exoplatform/ecms/test/BaseECMSResourceTestCase.java
+++ b/testsuite/test/src/main/java/org/exoplatform/ecms/test/BaseECMSResourceTestCase.java
@@ -21,7 +21,6 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.MultivaluedMap;
 
 import org.exoplatform.services.rest.ContainerResponseWriter;
@@ -32,6 +31,8 @@ import org.exoplatform.services.rest.impl.InputHeadersMap;
 import org.exoplatform.services.rest.impl.MultivaluedMapImpl;
 import org.exoplatform.services.rest.tools.DummyContainerResponseWriter;
 import org.exoplatform.services.test.mock.MockHttpServletRequest;
+
+import jakarta.servlet.http.HttpServletRequest;
 /**
  * Created by The eXo Platform SAS
  * Author : Lai Trung Hieu


### PR DESCRIPTION
This change will upgrade Java Servlet API 6.0 packages to be compatible with Tomcat 10 and will delete third party libraries  declaration from `pom.xml` files to load it in transitive way.