### PR TITLE
fix: make configuration of PDF viewer services overridable - EXO-68305

### DIFF
--- a/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-connector-configuration.xml
+++ b/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-connector-configuration.xml
@@ -68,6 +68,7 @@
     <type>org.exoplatform.wcm.connector.collaboration.RESTImagesRendererService</type>
   </component>
   <component>
+    <key>org.exoplatform.wcm.connector.viewer.PDFViewerRESTService</key>
     <type>org.exoplatform.wcm.connector.viewer.PDFViewerRESTService</type>
   </component>
   <component>

--- a/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-services-configuration.xml
+++ b/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-services-configuration.xml
@@ -25,6 +25,7 @@
     </component>
 
     <component>
+        <key>org.exoplatform.services.pdfviewer.PDFViewerService</key>
         <type>org.exoplatform.services.pdfviewer.PDFViewerService</type>
         <init-params>
           <value-param>


### PR DESCRIPTION
The fix will help override PDFViewerService and PDFViewerRestService by adding the key tag to their definition in configuration file.