### PR TITLE
fix: fix upload progress and endless progress bar in drawer when adding a new version to a file - EXO-67382

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
@@ -278,30 +278,32 @@ export default {
         this.processNextQueuedUpload();
       } else {
         window.setTimeout(() => {
-          this.$uploadService.getUploadProgress(file.uploadId)
-            .then(percent => {
-              if (this.abortUploading) {
-                return;
-              } else {
-                file.uploadProgress = Number(percent);
-                if (!file.uploadProgress || file.uploadProgress < 100) {
-                  this.controlUpload(file);
+          if (file.uploadId) {
+            this.$uploadService.getUploadProgress(file.uploadId)
+              .then(percent => {
+                if (this.abortUploading) {
+                  return;
                 } else {
-                  this.uploadingCount--;
-                  this.processNextQueuedUpload();
+                  file.uploadProgress = Number(percent);
+                  if (!file.uploadProgress || file.uploadProgress < 100) {
+                    this.controlUpload(file);
+                  } else {
+                    this.uploadingCount--;
+                    this.processNextQueuedUpload();
+                  }
+                  if (file.uploadProgress === 100 && continueAction && !file.inProcess) {
+                    file.inProcess = true;
+                    this.$root.$emit('continue-upload-to-destination-path', file);
+                    const index = this.newUploadedFiles.findIndex(f => f.id === file.id);
+                    this.newUploadedFiles.splice(index, 1);
+                  }
                 }
-                if (file.uploadProgress === 100 && continueAction && !file.inProcess) {
-                  file.inProcess = true;
-                  this.$root.$emit('continue-upload-to-destination-path', file);
-                  const index = this.newUploadedFiles.findIndex(f => f.id === file.id);
-                  this.newUploadedFiles.splice(index, 1);
-                }
-              }
-            })
-            .catch(() => {
-              this.removeAttachedFile(file);
-              this.$root.$emit('alert-message', this.$t('attachments.link.failed'), 'error');
-            });
+              })
+              .catch(() => {
+                this.removeAttachedFile(file);
+                this.$root.$emit('alert-message', this.$t('attachments.link.failed'), 'error');
+              });
+          }
         }, 200);
       }
     },


### PR DESCRIPTION
before this change, while controlling upload and before finishing the the set timeout, the uploadId is cleared after finishing the upload causing retrieve the  uploadProgress for null uploadId which has 0 as progress percent causing upload not finished popup
after this change, the check of the upload progress only when the uploadId is not null