### PR TITLE
fix: fix upload progress and endless progress bar in drawer when adding a new version to a file - EXO-67382

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
@@ -277,14 +277,14 @@ export default {
         this.uploadingCount--;
         this.processNextQueuedUpload();
       } else {
-        window.setTimeout(() => {
-          if (file.uploadId) {
+        if (file.uploadId) {
+          window.setTimeout(() => {
             this.$uploadService.getUploadProgress(file.uploadId)
               .then(percent => {
                 if (this.abortUploading) {
                   return;
                 } else {
-                  file.uploadProgress = Number(percent);
+                  file.uploadProgress = file.inProcess && 100 || Number(percent);
                   if (!file.uploadProgress || file.uploadProgress < 100) {
                     this.controlUpload(file);
                   } else {
@@ -303,8 +303,8 @@ export default {
                 this.removeAttachedFile(file);
                 this.$root.$emit('alert-message', this.$t('attachments.link.failed'), 'error');
               });
-          }
-        }, 200);
+          }, 200);
+        }
       }
     },
     processNextQueuedUpload: function () {


### PR DESCRIPTION
before this change, while controlling upload and before finishing the the set timeout, the uploadId is cleared after finishing the upload causing retrieve the uploadProgress for null uploadId which has 0 as progress percent causing upload not finished popup
after this change, the set of the time out to control the upload of the upload progress only when the uploadId is not null