### PR TITLE
fix: fix error log after creating an activity - EXO-67398

### DIFF
--- a/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/ActivityListener.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/wcm/ext/component/activity/listener/ActivityListener.java
@@ -1,5 +1,6 @@
 package org.exoplatform.wcm.ext.component.activity.listener;
 
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.ecm.webui.utils.PermissionUtil;
 import org.exoplatform.services.jcr.RepositoryService;
 import org.exoplatform.services.jcr.access.PermissionType;
@@ -70,8 +71,11 @@ public class ActivityListener extends ActivityListenerPlugin {
   private void shareActivityFilesToSpace(ActivityLifeCycleEvent activityLifeCycleEvent) {
     ExoSocialActivity activity = activityLifeCycleEvent.getActivity();
     List<ActivityFile> filesToShare = activity.getFiles();
-    String[] uuidNodes = activity.getTemplateParams().get(NODE_UUID_PARAM).split(SEPARATOR_REGEX);
-
+    String ids = activity.getTemplateParams().get(NODE_UUID_PARAM);
+    if (StringUtils.isBlank(ids)){
+      return;
+    }
+    String[] uuidNodes = ids.split(SEPARATOR_REGEX);
     String streamOwner = activity.getStreamOwner();
     Space targetSpace = spaceService.getSpaceByPrettyName(streamOwner);
 


### PR DESCRIPTION
before this change, after adding an activity without attachments an NPE is thrown since the activity params there is no UUID for saved attachments
after this change, a check if the ID is saved and not null before sharing the file