### PR TITLE
fix: fix Error message and endless progress bar in drawer when adding a new version to a file - EXO-67382

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
@@ -277,14 +277,14 @@ export default {
         this.uploadingCount--;
         this.processNextQueuedUpload();
       } else {
-        window.setTimeout(() => {
-          if (file.uploadId) {
+        if (file.uploadId) {
+          window.setTimeout(() => {
             this.$uploadService.getUploadProgress(file.uploadId)
               .then(percent => {
                 if (this.abortUploading) {
                   return;
                 } else {
-                  file.uploadProgress = Number(percent);
+                  file.uploadProgress = file.inProcess && 100 || Number(percent);
                   if (!file.uploadProgress || file.uploadProgress < 100) {
                     this.controlUpload(file);
                   } else {
@@ -303,8 +303,8 @@ export default {
                 this.removeAttachedFile(file);
                 this.$root.$emit('alert-message', this.$t('attachments.link.failed'), 'error');
               });
-          }
-        }, 200);
+          }, 200);
+        }
       }
     },
     processNextQueuedUpload: function () {

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
@@ -290,7 +290,8 @@ export default {
                   this.uploadingCount--;
                   this.processNextQueuedUpload();
                 }
-                if (file.uploadProgress === 100 && continueAction) {
+                if (file.uploadProgress === 100 && continueAction && !file.inProcess) {
+                  file.inProcess = true;
                   this.$root.$emit('continue-upload-to-destination-path', file);
                   const index = this.newUploadedFiles.findIndex(f => f.id === file.id);
                   this.newUploadedFiles.splice(index, 1);

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
@@ -278,30 +278,32 @@ export default {
         this.processNextQueuedUpload();
       } else {
         window.setTimeout(() => {
-          this.$uploadService.getUploadProgress(file.uploadId)
-            .then(percent => {
-              if (this.abortUploading) {
-                return;
-              } else {
-                file.uploadProgress = Number(percent);
-                if (!file.uploadProgress || file.uploadProgress < 100) {
-                  this.controlUpload(file);
+          if (file.uploadId) {
+            this.$uploadService.getUploadProgress(file.uploadId)
+              .then(percent => {
+                if (this.abortUploading) {
+                  return;
                 } else {
-                  this.uploadingCount--;
-                  this.processNextQueuedUpload();
+                  file.uploadProgress = Number(percent);
+                  if (!file.uploadProgress || file.uploadProgress < 100) {
+                    this.controlUpload(file);
+                  } else {
+                    this.uploadingCount--;
+                    this.processNextQueuedUpload();
+                  }
+                  if (file.uploadProgress === 100 && continueAction && !file.inProcess) {
+                    file.inProcess = true;
+                    this.$root.$emit('continue-upload-to-destination-path', file);
+                    const index = this.newUploadedFiles.findIndex(f => f.id === file.id);
+                    this.newUploadedFiles.splice(index, 1);
+                  }
                 }
-                if (file.uploadProgress === 100 && continueAction && !file.inProcess) {
-                  file.inProcess = true;
-                  this.$root.$emit('continue-upload-to-destination-path', file);
-                  const index = this.newUploadedFiles.findIndex(f => f.id === file.id);
-                  this.newUploadedFiles.splice(index, 1);
-                }
-              }
-            })
-            .catch(() => {
-              this.removeAttachedFile(file);
-              this.$root.$emit('alert-message', this.$t('attachments.link.failed'), 'error');
-            });
+              })
+              .catch(() => {
+                this.removeAttachedFile(file);
+                this.$root.$emit('alert-message', this.$t('attachments.link.failed'), 'error');
+              });
+          }
         }, 200);
       }
     },


### PR DESCRIPTION
Before this change, When creating a new version of a file the controlUpload emit too many times events to re-upload the same file which had been removed from the upload handler from the first time
After this change, the controlUpload emits the event when the file is not in process