### PR TITLE
fix : [AD Sync] After modification of a property, old value are regularly displayed in user profil - EXO-68774 - meeds/meeds-io#1533

### DIFF
--- a/ecms-social-integration/src/test/resources/conf/portal-configuration.xml
+++ b/ecms-social-integration/src/test/resources/conf/portal-configuration.xml
@@ -620,11 +620,6 @@
       <set-method>addListenerPlugin</set-method>
       <type>org.exoplatform.social.core.listeners.SocialMembershipListenerImpl</type>
     </component-plugin>
-    <component-plugin>
-      <name>social.update.profile.event.listener</name>
-      <set-method>addListenerPlugin</set-method>
-      <type>org.exoplatform.social.core.listeners.SocialUserProfileEventListenerImpl</type>
-    </component-plugin>
   </external-component-plugins>
 
   <external-component-plugins>


### PR DESCRIPTION
Before this fix, when the platform was run with eXo 6.4.3, custom ad attributes synchronized are store in gatein profile and in social profile In 6.4.4, the sync change, and attributes are directly stored in social profile. But, when the value exists in gatein profile, we can observe this problem : If attribute change in AD, the synchronization put it in social profile only. The correct new value is visible in user profile
When the user logs in, the social profile is synced, then the gatein profile is synced. As the gatein profile contains old values, the old values are pushed in the social profile This fix remove the listener SocialUserProfileEventListener, which is no more necessary as all ad attribute are directly pushed in social profile.