### PR TITLE
fix : Enable to uploading an image with a title containing a # character - EXO-68379

### DIFF
--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/UISelectImage.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/UISelectImage.js
@@ -575,7 +575,7 @@
               + "managedocument/uploadFile/control?workspaceName=collaboration&driveName=" + driveName
               + "&currentPortal=" + eXo.env.portal.portalName + "&language="
               + eXo.env.portal.language + "&currentFolder=" + imagesDownloadFolder
-              + "&uploadId=" + status.uploadId + "&fileName=" + status.name + "&action=save";
+              + "&uploadId=" + status.uploadId + "&fileName=" + encodeURIComponent(status.name) + "&action=save";
           fetch(restURL, {
             credentials: 'include',
             method: 'GET',


### PR DESCRIPTION
Before this change, we were unable to upload an image with a title containing a # character by inserting it into the body of the news/note. The issue was that all characters after the # were removed in the rest URL. This modification will encode the file name when constructing the upload rest URL