### PR TITLE
fix : Attached elements aren't saved - EXO-68689

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoAttachments.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoAttachments.vue
@@ -521,6 +521,7 @@ export default {
     this.getCloudDriveStatus();
     document.addEventListener('extension-AttachmentsComposer-attachments-composer-action-updated', () => this.attachmentsComposerActions = getAttachmentsComposerExtensions());
     this.attachmentsComposerActions = getAttachmentsComposerExtensions();
+    this.attachedFiles = this.value;
   },
   methods: {
     toggleAttachmentsDrawer: function() {


### PR DESCRIPTION
Before this change, the list of attached files was not linked to the news attachment. This issue due to the uninitialized state of the attachment files list. This change will initialize the attached files list , addressing this issue.