### PR TITLE
fix: fix oform extension can't be searched on unified search - EXO-66819

### DIFF
--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/FileSearchRestService.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/FileSearchRestService.java
@@ -160,6 +160,7 @@ public class FileSearchRestService implements ResourceContainer {
     fileTypesFilter.append(",{\n \"term\" : { \"fileType\" : \"application/vnd.oasis.opendocument.text\" }\n }");
     fileTypesFilter.append(",{\n \"term\" : { \"fileType\" : \"application/msword\" }\n }");
     fileTypesFilter.append(",{\n \"term\" : { \"fileType\" : \"application/vnd.openxmlformats-officedocument.wordprocessingml.document\" }\n }");
+    fileTypesFilter.append(",{\n \"term\" : { \"fileType\" : \"application/vnd.openxmlformats-officedocument.wordprocessingml.document.form\" }\n }");
     if (!myWork) {
       fileTypesFilter.append(",{\n \"term\" : { \"fileType\" : \"image/jpeg\" }\n }");
       fileTypesFilter.append(",{\n \"term\" : { \"fileType\" : \"image/png\" }\n }");


### PR DESCRIPTION
before this change, the oform file extension couldn't be searched in the unified search since they are not listed in the files search types
After this change, the oform is added to file search types and it can be searched with the unified search