### PR TITLE
fix: Fix displaying content explorer portlet - EXO-68919

### DIFF
--- a/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/UIWorkingArea.gtmpl
+++ b/apps/portlet-explorer/src/main/webapp/groovy/webui/component/explorer/UIWorkingArea.gtmpl
@@ -63,7 +63,7 @@
   def nodePathDelete = uicomponent.getNodePathDelete();
   def deleteNotice = uicomponent.getDeleteNotice();
   def wcmNotice = uicomponent.getWCMNotice();
-  def undo = StringEscapeUtils.escapeJavaScript(_ctx.appRes('UIWorkingArea.msg.undo-delete'));
+  def undo = StringEscapeUtils.escapeEcmaScript(_ctx.appRes('UIWorkingArea.msg.undo-delete'));
   uicomponent.setNodePathDelete("");
   uicomponent.setDeleteNotice("");
   uicomponent.setWCMNotice("");


### PR DESCRIPTION
Prior to this change, the content explorer portlet is no more displayed. This is due to org.apache.commons.lang.StringEscapeUtils package replaced by org.apache.commons.lang3.StringEscapeUtils after Spring migration which not has the method escapeJavaScript() already called into UIWorkingArea.gtmpl used by the content explorer portlet. After this commit, we ensure to replace escapeJavaScript() method by escapeEcmaScript() method in order to fix the display problem of content explorer portlet.