### PR TITLE
fix : [OnlyOffice] Edit page does not open - EXO-69002

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/cometd/CometdDocumentsService.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/cometd/CometdDocumentsService.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import javax.jcr.RepositoryException;
 
 import org.cometd.annotation.Param;


### PR DESCRIPTION
Before this fix, the bayeux object was not correctly inject, as the annotation used is the one from kernel (@Inject) This commit changes to use the new jakarta Inject annotation