### PR TITLE
fix: Fix Permissions for space notes node - EXO-68358 (#2274)

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
@@ -744,7 +744,7 @@ public class ManageDocumentService implements ResourceContainer {
         }
         String groupId = driveData.getParameters().get(ManageDriveServiceImpl.DRIVE_PARAMATER_GROUP_ID);
         if(StringUtils.isNotBlank(groupId) && groupId.startsWith("/spaces/")) {
-          ((ExtendedNode) newNode).setPermission(groupId, new String[]{PermissionType.READ, PermissionType.ADD_NODE, PermissionType.SET_PROPERTY});
+          ((ExtendedNode) newNode).setPermission("*:" + groupId, new String[]{PermissionType.READ, PermissionType.ADD_NODE, PermissionType.SET_PROPERTY});
         }
 
         node.save();


### PR DESCRIPTION
Prior to this change , note images was not accessible for space members , this issue was due to the incorrect permissions set on the space notes node during the creation process , This change is going to set the correct space permission for the notes node during the creation process .