### PR TITLE
fix: updating a post creates an activity folder if ASD is deleted - EXO-68609

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityComposerAttachments.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/activity/ActivityComposerAttachments.vue
@@ -68,7 +68,7 @@ export default {
     attachmentDrawerParams() {
       return {
         entityType: this.entityType,
-        entityId: this.activityId,
+        entityId: '',
         defaultFolder: 'Activity Stream Documents',
         sourceApp: 'activityStream',
         attachments: this.attachments,

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
@@ -585,6 +585,16 @@ export default {
       this.$refs.driveExplorerDrawer.close();
     },
     initDestinationFolderPath: function () {
+      this.driveRootPath = '';
+      this.drivers = [];
+      this.folders = [];
+      this.files = [];
+      this.space = {};
+      this.folderDestinationForFile = '';
+      this.selectedFolder = {};
+      this.currentFolder = {};
+      this.folderPath = '';
+      this.destinationFolder = '';
       //if default drive exist
       if (this.defaultDrive && this.defaultDrive.name) {
         const self = this;
@@ -599,14 +609,8 @@ export default {
         }
         this.openDrive(this.defaultDrive, null, parentFolder).then(() => {
           const defaultFolder = self.folders.find(folder => folder.name === self.defaultFolder.split('/').pop());
-          if (self.entityType && self.entityId) {
-            if (defaultFolder) {
-              this.openFolder(defaultFolder).then(() => {
-                this.createEntityTypeAndIdFolders(defaultFolder);
-              });
-            } else {
-              this.createEntityTypeAndIdFolders(defaultFolder);
-            }
+          if (self.entityType) {
+            this.createEntityTypeAndIdFolders(defaultFolder);
           }
           //if both default drive and default folder exist
           if (defaultFolder) {
@@ -1065,11 +1069,15 @@ export default {
     getFolderIcon(folder) {
       return `uiIcon-${folder.cloudProvider}`;
     },
-    createEntityTypeAndIdFolders(defaultFolder) {
-      defaultFolder = this.folders.find(folder => folder.title === this.entityType);
+    createEntityTypeAndIdFolders() {
+      let entityForlder = this.entityType;
+      if (this.entityType === 'activity'){
+        entityForlder = 'Activity Stream Documents';
+      }
+      let defaultFolder = this.folders.find(folder => folder.title === entityForlder);
       //if entityType (tasks, event, ..) folder not found
       if (!defaultFolder) {
-        this.newFolderName = this.entityType;
+        this.newFolderName = entityForlder;
         this.creatingNewFolder = true;
         this.createNewFolder().then((newFolder) => {
           this.openFolder(newFolder).then(() => {
@@ -1084,7 +1092,7 @@ export default {
             });
           });
         });
-      } else { //if entityType (tasks, event, ..) folder exist, we create directly entityId folder
+      } else if (this.entityId){ //if entityType (tasks, event, ..) folder exist, we create directly entityId folder
         this.openFolder(defaultFolder).then(() => {
           defaultFolder = this.folders.find(folder => parseInt(folder.title) === parseInt(this.entityId));
           if (!defaultFolder) {

--- a/core/connector/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
+++ b/core/connector/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
@@ -322,6 +322,12 @@ public class ManageDocumentService implements ResourceContainer {
       // Set default name if new title contain no valid character
       name = (StringUtils.isEmpty(name)) ? DEFAULT_NAME : name;
 
+      if (node.hasNode(name)) {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Folder already exists");
+        }
+        return Response.status(Status.BAD_REQUEST).entity("Folder already exists").cacheControl(cc).build();
+      }
       Node newNode = node.addNode(name, folderNodeType);
 
       if (!newNode.hasProperty(NodetypeConstant.EXO_TITLE) && newNode.canAddMixin(NodetypeConstant.EXO_RSS_ENABLE)) {


### PR DESCRIPTION
Prior to this fix, attachments of activities were stored under the ASD folder in case of creation and under a folder named with the activity ID in case of edit, and in some cases the asd folder (or Entity folder) are duplicated
This fix ensures that documents are added to the right folder and avoids folder duplication for any entity type. For activities, all documents are stored under the ASD folder in edit or creation cases.

(cherry picked from commit 17de699ad1470b1cb4a76869df887f848179a1f0)