### PR TITLE
fix: Article drafts deletion makes the article displayed on top of the news application - EXO-58132 (#2304)

### DIFF
--- a/ext/authoring/services/src/main/java/org/exoplatform/services/wcm/extensions/publication/lifecycle/authoring/AuthoringPublicationPlugin.java
+++ b/ext/authoring/services/src/main/java/org/exoplatform/services/wcm/extensions/publication/lifecycle/authoring/AuthoringPublicationPlugin.java
@@ -304,8 +304,10 @@ public class AuthoringPublicationPlugin extends  WebpagePublicationPlugin {
       if (!node.isCheckedOut()) {
         node.checkout();
       }
-      node.setProperty(AuthoringPublicationConstant.LIVE_DATE_PROP, new GregorianCalendar());
-      node.save();
+      if (context == null || !context.containsKey("context.action") || !context.get("context.action").equals("delete")) {
+        node.setProperty(AuthoringPublicationConstant.LIVE_DATE_PROP, new GregorianCalendar());
+        node.save();
+      }
       Version liveVersion = node.checkin();
       node.checkout();
       // Change current live revision to unpublished


### PR DESCRIPTION

Prior to this change, after deleting the draft article, the article was displayed at the top of the articles list. This issue arose due to the update of the publication:liveDate property during the change of the current revision state to hide the deleted activity. This modification is going to prevent the publication:liveDate from being updated for the delete action.