### PR TITLE
fix: Adjust the document preview style mode on the single content view template - EXO-69505

### DIFF
--- a/apps/resources-wcm/src/main/webapp/skin/less/ecms/portlets/presentation/ecms-presentation-singlecontentviewer.less
+++ b/apps/resources-wcm/src/main/webapp/skin/less/ecms/portlets/presentation/ecms-presentation-singlecontentviewer.less
@@ -346,10 +346,15 @@
   margin-right: 20px;
 }
 
-.UIPresentationContainer .DateAndMail {
-    color: @baseColorLight;
-    font-size: @baseFontSize - 3;
+.UIPresentationContainer .document-preview-default {
+  height: 100vh !important;
 }
+
+.UIPresentationContainer .DateAndMail {
+  color: @baseColorLight;
+  font-size: @baseFontSize - 3;
+}
+
 .UISingleContentViewerPortlet .UIContainerConfigOptions {
   border: 1px solid @borderColor;
 }


### PR DESCRIPTION

Prior to this change, the preview document mode was displayed with a small height, making it difficult to read the document correctly, This change is going to adjust the document preview style mode on the single content view template