### PR TITLE
fix: Attachments - display of video files for .log & .class icons - EXO-69215

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/mimetype/DMSMimeTypeResolver.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/mimetype/DMSMimeTypeResolver.java
@@ -87,6 +87,10 @@ public class DMSMimeTypeResolver {
     if (ext.equals("")) {
       ext = filename;
     }
+    if (!dmsmimeTypes.containsKey("log")) {
+      dmsmimeTypes.setProperty("log", "text/x-log");
+      dmsmimeTypes.setProperty("class", "application/java-vm");
+    }
     String mimeType = dmsmimeTypes.getProperty(ext.toLowerCase(), mimeTypes.getDefaultMimeType());
     if (mimeType == null || mimeType.length() == 0) return mimeTypes.getMimeType(filename);
     return mimeType;


### PR DESCRIPTION
Before this change, when create task and add attachments with .log & .class extensions and check the related files extensions, the files are uploaded as video files. After this change, the correct icon is displayed.

(cherry picked from commit 932a5ef942ae447e8170baa02d621e331c34eea1)