### PR TITLE
fix: fix ellipsis in long Breadcrump of file path nor file name - EXO-69737

### DIFF
--- a/apps/resources-wcm/src/main/webapp/skin/less/ecms/skin/UIDocumentPreview/Style.less
+++ b/apps/resources-wcm/src/main/webapp/skin/less/ecms/skin/UIDocumentPreview/Style.less
@@ -828,6 +828,10 @@
 		    }
 			.ellipsis-reverse-apply {
 				direction: unset !important;
+				display: contents !important;
+			}
+			.ellipsis-reverse-apply-content {
+				margin-top: 6px !important;
 			}
 		}
 	}


### PR DESCRIPTION
before this change, when a document has a long name or breadcrumbs contained a long name: the File name superposes with the file path in the breadcrumb
after this change, the ellipsis is added for the document file name and the document breadcrumbs path so they are well displayed!