### PR TITLE
fix: fix ellipsis in long Breadcrump of file path nor file name - EXO-69737

### DIFF
--- a/apps/resources-wcm/src/main/webapp/skin/less/ecms/skin/UIDocumentPreview/Style.less
+++ b/apps/resources-wcm/src/main/webapp/skin/less/ecms/skin/UIDocumentPreview/Style.less
@@ -706,9 +706,13 @@
 			height: 0;
 
 			.ellipsis {
-				display: contents;
+				display: inline-block;
 				color: @white;
 				font-weight: bold;
+				width: 400px;
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
 			}
 
 			.label {
@@ -811,11 +815,20 @@
 				display: none;
 			}
 		    a {
-		    	color: @btnPrimaryColor;
+				text-overflow: ellipsis !important;
+				max-width: 200px;
+				width: min-content;
+				display: inline-block;
+				overflow: hidden;
+				white-space: nowrap;
+				color: @btnPrimaryColor;
 		    	&:hover i, &:active i, &.active i, {
                     color: @colorIconSecondary;
 		    	}
 		    }
+			.ellipsis-reverse-apply {
+				direction: unset !important;
+			}
 		}
 	}
 }

--- a/apps/resources-wcm/src/main/webapp/skin/less/ecms/skin/UIDocumentPreview/Style.less
+++ b/apps/resources-wcm/src/main/webapp/skin/less/ecms/skin/UIDocumentPreview/Style.less
@@ -828,6 +828,10 @@
 		    }
 			.ellipsis-reverse-apply {
 				direction: unset !important;
+				display: contents !important;
+			}
+			.ellipsis-reverse-apply-content {
+				margin-top: 6px !important;
 			}
 		}
 	}


### PR DESCRIPTION
before this change, when a document has a long name or breadcrumbs contained a long name: the File name superposes with the file path in the breadcrumb
after this change, the ellipsis is added for the document file name and the document breadcrumbs path so they are well displayed!