### PR TITLE
feat: Define load-group for CloudDriveSettingsPortlet portlet - EXO-65110

### DIFF
--- a/apps/portlet-clouddrives/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/apps/portlet-clouddrives/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -27,6 +27,7 @@
   <portlet>
     <name>CloudDriveSettingsPortlet</name>
     <module>
+      <load-group>cloudDriveGRP</load-group>	  
       <script>
         <path>/js/cloudDriveSettings.bundle.js</path>
       </script>

--- a/apps/portlet-clouddrives/src/main/webapp/vue-app/cloudDriveSettings/main.js
+++ b/apps/portlet-clouddrives/src/main/webapp/vue-app/cloudDriveSettings/main.js
@@ -33,7 +33,7 @@ export function init() {
       vuetify,
       i18n
     }, `#${appId}`, 'Cloud Drive Settings');
-  });
+  }).finally(() => Vue.prototype.$utils.includeExtensions('CloudDriveSettingsExtension'));
 }
 // get overridden components if exists
 if (extensionRegistry) {


### PR DESCRIPTION
Prior to this change, we can not extend easily CloudDriveSettings portlet from other modules. We need to define appropriate load group for the CloudDriveSettings portlet in order to easily extend it.