### PR TITLE
fix: Activity stream documents folder creation issue - EXO-68612 (#2321)

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
@@ -620,7 +620,7 @@ export default {
               }).finally(() => this.driveExplorerInitializing = false);
             // create a default folder for activity attachments if it doesn't exist
           } else if (!defaultFolder && self.defaultFolder === 'Activity Stream Documents') {
-            this.$attachmentService.createFolder(self.currentDrive.name, self.workspace, this.currentAbsolutePath, self.defaultFolder, 'nt:unstructured', true).then(() => {
+            this.$attachmentService.createFolder(self.currentDrive.name, self.workspace, this.currentAbsolutePath, self.defaultFolder, 'nt:folder', true).then(() => {
               this.initDestinationFolderPath();
             });
             //else if no default folder create file in root folder
@@ -912,7 +912,7 @@ export default {
       }
       this.$nextTick(() => this.$refs.newFolder[0].focus());
     },
-    createNewFolder() {
+    createNewFolder(isSystem) {
       if (this.creatingNewFolder) {
         if (this.newFolderName) {
           const folderNameExists = this.folders.some(folder => folder.title === this.newFolderName);
@@ -923,7 +923,7 @@ export default {
             this.popupBodyMessage = `${this.$t('attachments.filesFoldersSelector.popup.folderNameExists')}`;
           } else {
             const self = this;
-            return this.$attachmentService.createFolder(this.currentDrive.name, this.workspace, this.currentAbsolutePath, this.newFolderName).then(xml => {
+            return this.$attachmentService.createFolder(this.currentDrive.name, this.workspace, this.currentAbsolutePath, this.newFolderName, 'nt:folder',isSystem).then(xml => {
               const createdNewFolder = xml.childNodes[0];
               if (createdNewFolder) {
                 const folderType = createdNewFolder.getAttribute('nodeType');
@@ -1079,7 +1079,7 @@ export default {
       if (!defaultFolder) {
         this.newFolderName = entityForlder;
         this.creatingNewFolder = true;
-        this.createNewFolder().then((newFolder) => {
+        this.createNewFolder(true).then((newFolder) => {
           this.openFolder(newFolder).then(() => {
             this.newFolderName = this.entityId;
             this.creatingNewFolder = true;


### PR DESCRIPTION
Before this change, "System" folder created by the attachement drawer for entities like task, activity, process was created by the user session, and having the same permissions of other folders, so any user member of the space have the ability to rename, delete, or move this folders that can lead to loose attachements.
The proper way to fix this issue is to set the appropriate permissions to avoid this problem, but this cannot be possible with what we have as access management in the document app (we have only edit and view permissions).
As a temporary solution in this commit, all this folders will be created by a system session, so in the document app level we can recognize them and don't allow simple users to edit/move/delete them