### PR TITLE
fix: Prevent the preview when selecing an article attachment - EXO-70170

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoAttachmentItem.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoAttachmentItem.vue
@@ -36,6 +36,13 @@ export default {
       default: function () {
         return new Object();
       }
+    },
+    preventPreview: {
+      type: Boolean,
+      required: false,
+      default: function () {
+        return false;
+      }
     }
   },
   data() {
@@ -54,6 +61,9 @@ export default {
   },
   methods: {
     openPreview() {
+      if (this.preventPreview) {
+        return;
+      }
       Vue.prototype.$attachmentService.getAttachmentById(this.file.id).then(attachment => {
         documentPreview.init({
           doc: {

--- a/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoFoldersFilesSelector.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/legacy-composer-attachments/components/ExoFoldersFilesSelector.vue
@@ -194,7 +194,7 @@
           :class="file.selected? 'selected' : ''"
           class="fileSelection"
           @click="selectFile(file)">
-          <exo-attachment-item :file="file" />
+          <exo-attachment-item :file="file" :prevent-preview="true" />
         </div>
       </div>
       <div v-else class="categorizedDrives">


### PR DESCRIPTION
Prior this change, selecting an article attachment from the existing upload would open the preview mode. This change will prevent the preview from opening when selecting an article attachment.

(cherry picked from commit efaa2b9f3794b95f1ee1231143785c00db6d6a9a)