### PR TITLE
fix: upload existing documents + infinite loading - EXO-69948.

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
@@ -231,9 +231,7 @@ export default {
         if (actions.length > 0) {
           file.actions = actions;
           file.waitAction = true;
-          if (this.$i18n) {
-            this.$root.$emit('alert-message', this.$t('attachments.upload.conflict.message'), 'warning');
-          }
+          this.$root.$emit('alert-message', this.$root.$t('attachments.upload.conflict.message'), 'warning');
           this.$root.$emit('start-loading-attachment-drawer');
         }
         this.$root.$emit('add-new-uploaded-file', file);


### PR DESCRIPTION
Before this change, when In spaceX Doc app upload files twice, on the second drawer displays infinite loading even if choice selected and times only one uploaded file is displayed on drawer. After this change, the contents of the drawer are displayed correctly.