### PR TITLE
fix: Display file size including version size in DocumentsSizeGadget - EXO-70223

### DIFF
--- a/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-search-configuration.xml
+++ b/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-search-configuration.xml
@@ -107,7 +107,9 @@
                 <properties-param>
                     <name>constructor.params</name>
                     <property name="index_alias" value="file_alias"/>
-                    <property name="index_current" value="file_v3"/>
+                    <property name="index_current" value="file_v4"/>
+                    <property name="index_previous" value="file_v3" />
+                    <property name="reindexOnUpgrade" value="true" />
                 </properties-param>
             </init-params>
         </component-plugin>

--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/connector/FileindexingConnector.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/connector/FileindexingConnector.java
@@ -112,6 +112,7 @@ public class FileindexingConnector extends ElasticIndexingServiceConnector {
                                                .append("    \"lastModifier\" : {\"type\" : \"text\"},\n")
                                                .append("    \"fileType\" : {\"type\" : \"keyword\"},\n")
                                                .append("    \"fileSize\" : {\"type\" : \"long\"},\n")
+                                               .append("    \"fileSizeWithVersions\" : {\"type\" : \"long\"},\n")
                                                .append("    \"drive\" : {\"type\" : \"text\"},\n")
                                                .append("    \"version\" : {\"type\" : \"long\"},\n")
                                                .append("    \"name\" : {\"type\" : \"text\", \"analyzer\": \"letter_lowercase_asciifolding\"},\n")
@@ -220,6 +221,7 @@ public class FileindexingConnector extends ElasticIndexingServiceConnector {
 
         Property dataProperty = contentNode.getProperty(NodetypeConstant.JCR_DATA);
         long fileSize = dataProperty.getLength();
+        long fileSizeWithVersion = VersionHistoryUtils.computeVersionsSize(node);
         canIndexContent = canIndexContent && fileSize < this.contentMaxSizeToIndexInBytes;
 
         if (canIndexContent) {
@@ -227,10 +229,13 @@ public class FileindexingConnector extends ElasticIndexingServiceConnector {
           byte[] fileBytes = IOUtils.toByteArray(fileStream);
           fields.put("file", Base64.getEncoder().encodeToString(fileBytes));
           fields.put("fileSize", String.valueOf(fileBytes.length));
+          fileSizeWithVersion+=fileBytes.length;
         } else {
           fields.put("file", "");
           fields.put("fileSize", String.valueOf(fileSize));
+          fileSizeWithVersion+=fileSize;
         }
+        fields.put("fileSizeWithVersions", String.valueOf(fileSizeWithVersion));
 
         // Dublin Core metadata
         Map<String, String> dublinCoreMetadata = extractDublinCoreMetadata(contentNode);

--- a/core/services/src/main/java/org/exoplatform/services/cms/documents/VersionHistoryUtils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/documents/VersionHistoryUtils.java
@@ -176,13 +176,35 @@ public class VersionHistoryUtils {
     return Integer.parseInt(currentVersion);
   }
 
-  /**
-   * Remove redundant version
-   * - Remove versions has been expired
-   * - Remove versions over max allow
-   * @param nodeVersioning
-   * @throws Exception
-   */
+  public static long computeVersionsSize(Node node) {
+    long versionSize=0;
+    try {
+      if (node.isNodeType(VersionHistoryUtils.MIX_VERSIONABLE)) {
+        VersionHistory versionHistory = node.getVersionHistory();
+        VersionIterator iterator = versionHistory.getAllVersions();
+        while (iterator.hasNext()) {
+          Version version = iterator.nextVersion();
+          if (version.hasNode("jcr:frozenNode")) {
+            Node frozen= version.getNode("jcr:frozenNode");
+            if (frozen.hasNode("jcr:content")) {
+              long currentVersionSize = frozen.getNode("jcr:content").getProperty("jcr:data").getLength();
+              versionSize+=currentVersionSize;
+            }
+          }
+        }
+      }
+    }catch (Exception e) {
+      versionSize=0;
+    }
+    return versionSize;
+  }
+    /**
+     * Remove redundant version
+     * - Remove versions has been expired
+     * - Remove versions over max allow
+     * @param nodeVersioning
+     * @throws Exception
+     */
   private static void removeRedundant(Node nodeVersioning) throws Exception{
     VersionHistory versionHistory = nodeVersioning.getVersionHistory();
     String baseVersion = nodeVersioning.getBaseVersion().getName();


### PR DESCRIPTION
Before this modification, the document size gadget compute size without take care of file versions This change add a field in file index to store fileSizeWithVersion