### PR TITLE
fix: upload existing documents + infinite loading - EXO-69948

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
@@ -162,13 +162,20 @@ export default {
   },
   computed: {
     uploadFinished() {
-      return this.attachments.length > 0 && !(this.attachments.some(file => file.waitAction) || this.newUploadedFilesInProgress);
+      return this.attachments.length > 0 && (this.attachments.every(file => !file.uploadId) || this.attachments.every(file => file.waitAction));
     },
     entityHasNewAttachments() {
       return this.uploadedFiles.length > 0;
     },
     newUploadedFilesAdded() {
       return this.newUploadedFiles && this.newUploadedFiles.some(file => file.uploadId);
+    },
+    uploadfilesFinished() {
+      return this.attachments.length > 0 && !(this.attachments.some(file => file.waitAction) || this.newUploadedFilesInProgress) 
+              || this.attachments.length === 0;
+    },
+    attachmentsCount(){
+      return this.attachments.length;
     },
     filesUploadedSuccessLabel() {
       return this.entityType && this.entityId && this.$t('attachments.upload.success') || this.$t('documents.upload.success');
@@ -202,8 +209,11 @@ export default {
         this.$root.$emit('entity-attachments-updated');
         document.dispatchEvent(new CustomEvent('entity-attachments-updated'));
         this.displaySuccessMessage();
-        this.$refs.attachmentsAppDrawer.endLoading();
+        this.endLoading();
       }
+    },
+    attachmentsCount (){
+      this.endLoading();
     },
     defaultDrive() {
       this.initDefaultDestinationFolderPath(this.defaultFolder);
@@ -260,7 +270,7 @@ export default {
       this.$refs.attachmentsAppDrawer.startLoading();
     },
     endLoading() {
-      if (this.uploadFinished) {
+      if (this.uploadfilesFinished) {
         this.$refs.attachmentsAppDrawer.endLoading();
       }
     },

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/AttachmentsDrawer.vue
@@ -162,7 +162,7 @@ export default {
   },
   computed: {
     uploadFinished() {
-      return this.attachments.length > 0 && (this.attachments.every(file => !file.uploadId) || this.attachments.every(file => file.waitAction));
+      return this.attachments.length > 0 && !(this.attachments.some(file => file.waitAction) || this.newUploadedFilesInProgress);
     },
     entityHasNewAttachments() {
       return this.uploadedFiles.length > 0;
@@ -241,7 +241,7 @@ export default {
     this.$root.$on('abort-uploading-new-file', this.abortUploadingNewFile);
     this.$root.$on('remove-attached-file', this.removeAttachedFile);
     this.$root.$on('start-loading-attachment-drawer', () => this.$refs.attachmentsAppDrawer.startLoading());
-    this.$root.$on('end-loading-attachment-drawer', () => this.$refs.attachmentsAppDrawer.endLoading());
+    this.$root.$on('end-loading-attachment-drawer', () => this.endLoading());
     this.$root.$on('add-new-created-document', (doc) =>{
       this.creationType = this.$t('attachments.added.by.platform');
       this.addNewCreatedDocument(doc);
@@ -260,7 +260,9 @@ export default {
       this.$refs.attachmentsAppDrawer.startLoading();
     },
     endLoading() {
-      this.$refs.attachmentsAppDrawer.endLoading();
+      if (this.uploadFinished) {
+        this.$refs.attachmentsAppDrawer.endLoading();
+      }
     },
     handleProvidedFiles() {
       if (this.files && this.files.length>0){

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
@@ -288,6 +288,13 @@ export default {
       }
     }
   },
+  watch: {
+    attachmentInProgress(newVal) {
+      if (!newVal) {
+        this.$root.$emit('end-loading-attachment-drawer');
+      }
+    },
+  },
   methods: {
     markDocumentAsViewed() {
       document.dispatchEvent(new CustomEvent('mark-attachment-as-viewed', {detail: {file: this.attachment}}));

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
@@ -231,7 +231,9 @@ export default {
         if (actions.length > 0) {
           file.actions = actions;
           file.waitAction = true;
-          this.$root.$emit('alert-message', this.$t('attachments.upload.conflict.message'), 'warning');
+          if (this.$i18n) {
+            this.$root.$emit('alert-message', this.$t('attachments.upload.conflict.message'), 'warning');
+          }
           this.$root.$emit('start-loading-attachment-drawer');
         }
         this.$root.$emit('add-new-uploaded-file', file);

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
@@ -231,9 +231,7 @@ export default {
         if (actions.length > 0) {
           file.actions = actions;
           file.waitAction = true;
-          if (this.$i18n) {
-            this.$root.$emit('alert-message', this.$t('attachments.upload.conflict.message'), 'warning');
-          }
+          this.$root.$emit('alert-message', this.$root.$t('attachments.upload.conflict.message'), 'warning');
           this.$root.$emit('start-loading-attachment-drawer');
         }
         this.$root.$emit('add-new-uploaded-file', file);

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadedFiles.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadedFiles.vue
@@ -160,6 +160,7 @@ export default {
   created() {
     this.$root.$on('refresh-uploaded-files-list', () => {
       this.$forceUpdate();
+      this.endLoadingAttachmentDrawer();
     });
   },
   computed: {
@@ -173,6 +174,12 @@ export default {
   methods: {
     openSelectDestinationFolderDrawer() {
       this.$root.$emit('open-drive-explorer-drawer', this.currentDrive);
+    },
+    endLoadingAttachmentDrawer() {
+      const isLoadingDrawer =  this.attachments && this.attachments.some(val => val.waitAction || val.uploadProgress < 100);
+      if (!isLoadingDrawer) {
+        this.$root.$emit('end-loading-attachment-drawer');
+      }
     }
   }
 };


### PR DESCRIPTION
Before this change, when In spaceX Doc app upload files twice, on the second drawer displays infinite loading even if choice selected and times only one uploaded file is displayed on drawer. After this change, the contents of the drawer are displayed correctly.