### PR TITLE
fix: some events in webconferencing are not correctly configured - EXO-70693

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/cometd/CometdDocumentsService.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/collaboration/cometd/CometdDocumentsService.java
@@ -17,8 +17,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import jakarta.inject.Inject;
 import javax.jcr.RepositoryException;
 


### PR DESCRIPTION
Before this fix,  some listener not correctly added when CometDocumentService starts : This listeners are added in postConstruct method, which is no more call, because the used annotation is the old javax.annotation.PostConstruct.

This commit update the annotion to use jakarta.annotation.PostConstruct. It also change PreDestroy and Inject annotations