### PR TITLE
fix: document never saved when upload existing document  - EXO-70777

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
@@ -286,12 +286,12 @@ export default {
                 } else {
                   file.uploadProgress = file.inProcess && 100 || Number(percent);
                   if (!file.uploadProgress || file.uploadProgress < 100) {
-                    this.controlUpload(file);
+                    this.controlUpload(file, continueAction);
                   } else {
                     this.uploadingCount--;
                     this.processNextQueuedUpload();
                   }
-                  if (file.uploadProgress === 100 && continueAction && !file.inProcess) {
+                  if (file.uploadProgress === 100 && !file.inProcess) {
                     file.inProcess = true;
                     this.$root.$emit('continue-upload-to-destination-path', file);
                     const index = this.newUploadedFiles.findIndex(f => f.id === file.id);


### PR DESCRIPTION
Before this change, when upload a document which size is more than 1mb in space X document app and upload again the same document, document uploaded but never saved. After this change, document saved for new version or keep both cases.

(cherry picked from commit 6ee0d39fcf30b7f810900e6468dcdd47cbd8c402)