### PR TITLE
fix: Fix Content Explorer Display in Vuetify Layout - MEED-5649 - Meeds-io/MIPs#120

### DIFF
--- a/apps/resources-wcm/src/main/webapp/skin/less/ecms/portlets/explorer/ecms-explorer.less
+++ b/apps/resources-wcm/src/main/webapp/skin/less/ecms/portlets/explorer/ecms-explorer.less
@@ -6,6 +6,11 @@
 @import "UIFileView/Style.less";
 @import "Xeditable/bootstrap3-editable.less";
 
+.VuetifyApp .UIJCRExplorerPortlet *:not(.ignore-vuetify-classes) {
+  &, &::before, &::after {
+    box-sizing: unset;
+  }
+}
 .UIJCRExplorerPortlet {
 	padding: 25px 10px;
 	background: @lightGrey !important;


### PR DESCRIPTION
This change will override Vuetify based apps style to be applied on Content Explorer.