### PR TITLE
fix: Can't resize snv images in Mozilla - EXO-71264 .

### DIFF
--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/selectImage/plugin.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/selectImage/plugin.js
@@ -1105,7 +1105,7 @@
       attachToDocuments( 'mousemove', onMouseMove, listeners );
 
       // Clean up the mousemove listener. Update widget data if valid.
-      attachToDocuments( 'mouseup', onMouseUp, listeners );
+      attachToDocuments( 'pointerup', onMouseUp, listeners );
 
       // The entire editable will have the special cursor while resizing goes on.
       editable.addClass( cursorClass );


### PR DESCRIPTION
Before this change, In an snv add two images image1 takes the full page length an another small one image2, first We can't resize the image1 there is a horizental scroll that blocks the resizing on both inline and on full edition page and second Can 't easily resize image2 when clicking on left button of the mouse the image still selected and the resizing never stops. After this change, The images are easily resized regardless of their original size.