### PR TITLE
fix: Update to JDK21 - EXO-71474 - Meeds-io/MIPs#91

### DIFF
--- a/ext/authoring/services/pom.xml
+++ b/ext/authoring/services/pom.xml
@@ -91,14 +91,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <argLine>@{argLine} --add-opens=java.management/java.lang.management=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED  --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED </argLine>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
Remove usage of SecurityManager as it is deprecated for removal in jdk21 Remove also usage of classes
- SecurityHelper
- PrivilegedSystemHelper
- PrivilegedFileHelper
- SecureList
- SecureSet
- SecureCollections

These classes are here only to use securityManager, and as it is removed, it is no more necessary