### PR TITLE
fix: Image properties context menu option appears even if the selection is not an image - EXO-72349

### DIFF
--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/selectImage/plugin.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/selectImage/plugin.js
@@ -107,7 +107,7 @@
 
       if ( editor.contextMenu ) {
           editor.contextMenu.addListener( function( element ) {
-              if ( element) {
+            if (!element?.is('body') && element?.$?.querySelector('img[data-plugin-name=selectImage]')) {
                   return { selectImageItem: CKEDITOR.TRISTATE_OFF };
               }
           });


### PR DESCRIPTION
Image properties context menu option appears even if the selection is not an image