### PR TITLE
fix: Image properties context menu option appears even if the selection is not an image - EXO-72349

### DIFF
--- a/apps/resources-wcm/src/main/webapp/eXoPlugins/selectImage/plugin.js
+++ b/apps/resources-wcm/src/main/webapp/eXoPlugins/selectImage/plugin.js
@@ -107,7 +107,7 @@
 
       if ( editor.contextMenu ) {
           editor.contextMenu.addListener( function( element ) {
-              if ( element) {
+            if (!element?.is('body') && element?.$?.querySelector('img[data-plugin-name=selectImage]')) {
                   return { selectImageItem: CKEDITOR.TRISTATE_OFF };
               }
           });


### PR DESCRIPTION
Fix Image properties context menu option appears even if the selection is not an image

(cherry picked from commit 38881e333051e9d0ffe3e918f70d194df31609c2)