### PR TITLE
fix: Redirect should be to related to current page after editing attachment  - EXO-71706

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachment-document-creator/AttachmentCreateDocumentInput.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachment-document-creator/AttachmentCreateDocumentInput.vue
@@ -182,7 +182,7 @@ export default {
         this.$root.$emit('add-new-created-document', doc);
         this.$root.$emit('alert-message', this.$t('attachments.upload.success'), 'success');
         this.resetNewDocInput();
-        window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/oeditor?docId=${doc.id}`, '_blank');
+        window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/oeditor?docId=${doc.id}&backTo=${window.location.pathname}`, '_blank');
       }
     }
   }

--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentItem.vue
@@ -316,7 +316,7 @@ export default {
     },
     openFileInEditor() {
       if (this.attachment && this.attachment.id) {
-        window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/oeditor?docId=${this.attachment.id}`, '_blank');
+        window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/oeditor?docId=${this.attachment.id}&backTo=${window.location.pathname}`, '_blank');
       }
     },
     openFile() {


### PR DESCRIPTION
Before this fix, after editing a document, the back button always opens the location of the document in the document app.
Since a document can be editfrom different locations (process, task, activities...) the back button should open the location where rhe edit were requested. this fix add a bew path param whith the go back location to be opened when clicking on the back button on the oo editor