### PR TITLE
fix: Hide shared layout on OO Editor page - EXO-72989

### DIFF
--- a/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/wcm-extension/dynamic-container-configuration.xml
+++ b/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/wcm-extension/dynamic-container-configuration.xml
@@ -37,35 +37,6 @@
           <value>bottom-all-container</value>
         </value-param>
         <object-param>
-          <name>EditorSupportPortlet</name>
-          <description>Editor Support Portlet</description>
-          <object type="org.exoplatform.portal.config.serialize.PortletApplication">
-            <field name="state">
-              <object type="org.exoplatform.portal.config.model.TransientApplicationState">
-                <field name="contentId">
-                  <string>editors/EditorSupportPortlet</string>
-                </field>
-              </object>
-            </field>
-          </object>
-        </object-param>
-      </init-params>
-    </component-plugin>
-    <component-plugin>
-      <name>addPlugin</name>
-      <set-method>addPlugin</set-method>
-      <type>org.exoplatform.commons.addons.AddOnPluginImpl</type>
-      <description>add application Config</description>
-      <init-params>
-        <value-param>
-          <name>priority</name>
-          <value>10</value>
-        </value-param>
-        <value-param>
-          <name>containerName</name>
-          <value>bottom-all-container</value>
-        </value-param>
-        <object-param>
           <name>attachment-app-portlet</name>
           <description></description>
           <object type="org.exoplatform.commons.addons.PortletModel">


### PR DESCRIPTION
This commit remove the EditorSupportPortlet from the bottom-all-container, as it is now added in EditorPage