### PR TITLE
fix: Remove warning during server startup - EXO-74323

### DIFF
--- a/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/dms-extension/dms/dms-actions-configuration.xml
+++ b/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/dms-extension/dms/dms-actions-configuration.xml
@@ -68,22 +68,6 @@
                    		</field>
                     </object>  
                   </value>
-
-                  <value>
-                    <object type="org.exoplatform.services.cms.actions.impl.ActionConfig$Action">
-                      <field  name="type"><string>exo:move</string></field>
-                      <field  name="name"><string>moveNode</string></field>
-                      <field  name="description"><string>cut and past a node in a new destination</string></field>
-                      <field  name="srcWorkspace"><string>collaboration</string></field>
-                      <field  name="srcPath"><string>/</string></field>
-                      <field  name="isDeep"><boolean>true</boolean></field>
-                      <field  name="lifecyclePhase">
-                        <collection type="java.util.ArrayList">
-                          <value><string>node_moved</string></value>
-                        </collection>
-                      </field>
-                    </object>
-                  </value>
                 </collection>   
               </field>  
             </object>


### PR DESCRIPTION
Before this fix, during the server startup, we try to add an action in root folder of collaboration workspace. As this node is protected, the action cannot be added and the warn is displayed As the action seems not used, I remove it