### PR TITLE
fix: Remove configuration file loading which no  more exists - EXO-74311

### DIFF
--- a/apps/portlet-clouddrives/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/apps/portlet-clouddrives/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -4,6 +4,5 @@
   xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd http://www.exoplatform.org/xml/ns/kernel_1_3.xsd"
   xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
 
-  <import>war:/conf/clouddrive/portal/portal-configuration.xml</import>
   <import>war:/conf/clouddrive/dynamic-container-configuration.xml</import>
 </configuration>


### PR DESCRIPTION
Before this fix, the file portal-configuration.xml was loaded but no more exists, and it generates a warning at startup This commit remove the reference to the xml file