### PR TITLE
fix: Fix UserACL API usage - MEED-7574 - Meeds-io/MIPs#151

### DIFF
--- a/core/connector/src/main/java/org/exoplatform/portal/webui/util/NavigationUtils.java
+++ b/core/connector/src/main/java/org/exoplatform/portal/webui/util/NavigationUtils.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (C) 2003-2024 eXo Platform SAS.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see<http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.portal.webui.util;
+
+import java.lang.reflect.Constructor;
+import java.util.Map;
+
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.portal.config.UserPortalConfig;
+import org.exoplatform.portal.config.UserPortalConfigService;
+import org.exoplatform.portal.mop.SiteKey;
+import org.exoplatform.portal.mop.SiteType;
+import org.exoplatform.portal.mop.navigation.NavigationContext;
+import org.exoplatform.portal.mop.navigation.Scope;
+import org.exoplatform.portal.mop.service.LayoutService;
+import org.exoplatform.portal.mop.user.UserNavigation;
+import org.exoplatform.portal.mop.user.UserPortal;
+import org.exoplatform.portal.mop.user.UserPortalImpl;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.security.ConversationState;
+
+/**
+ * Created by The eXo Platform SAS Author : Phan Le Thanh Chuong
+ * chuong.phan@exoplatform.com, phan.le.thanh.chuong@gmail.com Nov 21, 2008
+ */
+public class NavigationUtils {
+
+  public static final Scope                       ECMS_NAVIGATION_SCOPE = Scope.CHILDREN;
+
+  private static ThreadLocal<Map<String, String>> gotNavigationKeeper   = new ThreadLocal<Map<String, String>>();
+
+  private static Constructor<UserNavigation>      userNavigationCtor    = null;
+
+  private static final Log                        LOG                   = ExoLogger.getLogger(NavigationUtils.class.getName());
+  static {
+    try {
+      // reflection here to get UserNavigation to avoid for using such as:
+      // spaceNav = userPortal.getNavigation(SiteKey.group(groupId));
+      userNavigationCtor = UserNavigation.class.getDeclaredConstructor(
+                                                                       new Class[] { UserPortalImpl.class,
+                                                                                     NavigationContext.class, boolean.class });
+      userNavigationCtor.setAccessible(true);
+    } catch (Exception e) {
+      if (LOG.isErrorEnabled()) {
+        LOG.error(e);
+      }
+    }
+  } // of static reflection
+
+  public static boolean gotNavigation(String portal, String user) {
+    return gotNavigation(portal, user, "");
+  }
+
+  public static boolean gotNavigation(String portal, String user, String scope) {
+    Map<String, String> navigations = gotNavigationKeeper.get();
+    if (navigations == null)
+      return false;
+    String navigation = navigations.get(portal + " " + user + " " + scope);
+    return (navigation != null);
+  }
+
+  public static UserNavigation getUserNavigationOfPortal(UserPortal userPortal, String portalName) throws Exception {
+    UserACL userACL = ExoContainerContext.getService(UserACL.class);
+    UserPortalConfigService userPortalConfigService = ExoContainerContext.getService(UserPortalConfigService.class);
+    NavigationContext portalNav = userPortalConfigService.getNavigationService()
+                                                         .loadNavigation(new SiteKey(SiteType.PORTAL, portalName));
+    if (portalNav == null) {
+      return null;
+    }
+    UserPortalConfig userPortalCfg = userPortalConfigService.getUserPortalConfig(portalName,
+                                                                                 ConversationState.getCurrent()
+                                                                                                  .getIdentity()
+                                                                                                  .getUserId());
+    return userNavigationCtor.newInstance(
+                                          userPortal,
+                                          portalNav,
+                                          userACL.hasEditPermission(userPortalCfg.getPortalConfig(),
+                                                                    ConversationState.getCurrent()
+                                                                                     .getIdentity()));
+  }
+
+  /**
+   * Get UserNavigation of a specified element
+   * 
+   * @param userPortal
+   * @param siteKey Key
+   * @return UserNavigation of group
+   */
+  public static UserNavigation getUserNavigation(UserPortal userPortal, SiteKey siteKey) throws Exception {
+    if (siteKey.getTypeName().equalsIgnoreCase(SiteType.PORTAL.getName())) {
+      return getUserNavigationOfPortal(userPortal, siteKey.getName());
+    }
+    UserACL userACL = ExoContainerContext.getService(UserACL.class);
+    UserPortalConfigService userPortalConfigService = ExoContainerContext.getService(UserPortalConfigService.class);
+    // userPortalConfigService.get
+    NavigationContext portalNav = userPortalConfigService.getNavigationService().loadNavigation(siteKey);
+    if (portalNav == null) {
+      return null;
+    } else {
+      LayoutService layoutService = ExoContainerContext.getService(LayoutService.class);
+      return userNavigationCtor.newInstance(userPortal,
+                                            portalNav,
+                                            userACL.hasEditPermission(layoutService.getPortalConfig(siteKey),
+                                                                      ConversationState.getCurrent()
+                                                                                       .getIdentity()));
+    }
+  }
+}

--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/fckeditor/PortalLinkConnector.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/fckeditor/PortalLinkConnector.java
@@ -214,8 +214,7 @@ public class PortalLinkConnector implements ResourceContainer {
     rootElement.appendChild(foldersElement);
     for (Object object : pageList.getAll()) {
       PortalConfig config = (PortalConfig) object;
-//      if (!portalUserACL.hasPermission(config, userId)) {
-      if (!portalUserACL.hasPermission(config)) {
+      if (!portalUserACL.hasAccessPermission(config, ConversationState.getCurrent().getIdentity())) {
         continue;
       }
       Element folderElement = rootElement.getOwnerDocument().createElement("Folder");

--- a/core/publication-plugins/src/main/java/org/exoplatform/services/wcm/publication/lifecycle/stageversion/ui/UIPublicationPagesContainer.java
+++ b/core/publication-plugins/src/main/java/org/exoplatform/services/wcm/publication/lifecycle/stageversion/ui/UIPublicationPagesContainer.java
@@ -27,6 +27,7 @@ import org.exoplatform.portal.config.Query;
 import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.portal.config.model.PortalConfig;
 import org.exoplatform.portal.webui.util.Util;
+import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.webui.config.annotation.ComponentConfig;
 import org.exoplatform.webui.core.UIContainer;
@@ -79,7 +80,7 @@ public class UIPublicationPagesContainer extends UIContainer {
     UserACL userACL = WCMCoreUtils.getService(UserACL.class);
     for(Object object:pageList.getAll()) {
       PortalConfig portalConfig = (PortalConfig)object;
-      if(userACL.hasPermission(portalConfig)) {
+      if(userACL.hasAccessPermission(portalConfig, ConversationState.getCurrent().getIdentity())) {
         listPortalName.add(portalConfig.getName());
       }
     }

--- a/core/publication/src/test/java/org/exoplatform/services/wcm/publication/DumpPublicationPlugin.java
+++ b/core/publication/src/test/java/org/exoplatform/services/wcm/publication/DumpPublicationPlugin.java
@@ -53,6 +53,7 @@ import org.exoplatform.services.ecm.publication.IncorrectStateUpdateLifecycleExc
 import org.exoplatform.services.ecm.publication.PublicationService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
 import org.exoplatform.services.resources.ResourceBundleService;
+import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.wcm.portal.LivePortalManagerService;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 import org.exoplatform.webui.core.UIComponent;
@@ -244,7 +245,7 @@ public class DumpPublicationPlugin extends WebpagePublicationPlugin{
     List<PortalConfig> portalConfigs = WCMCoreUtils.getAllElementsOfListAccess(pageList);
     UserACL userACL = WCMCoreUtils.getService(UserACL.class);
     for(PortalConfig portalConfig : portalConfigs) {
-      if(userACL.hasPermission(portalConfig)) {
+      if(userACL.hasAccessPermission(portalConfig, ConversationState.getCurrent().getIdentity())) {
         listPortalName.add(portalConfig.getName());
       }
     }

--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/FileSearchRestService.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/FileSearchRestService.java
@@ -114,7 +114,7 @@ public class FileSearchRestService implements ResourceContainer {
     }
     recentFilters.add(getFileTypesFilter(myWork));
     UserACL userACL = PortalContainer.getInstance().getComponentInstanceOfType(UserACL.class);
-    if (!userACL.isSuperUser() && !userACL.isUserInGroup(userACL.getAdminGroups())) {
+    if (!userACL.isSuperUser(ConversationState.getCurrent().getIdentity()) && !userACL.isUserInGroup(ConversationState.getCurrent().getIdentity(), userACL.getAdminGroups())) {
       recentFilters.add(getPathsFilter(Arrays.asList(Utils.SPACES_NODE_PATH, getUserPrivateNode().getPath())));
     }
     if (StringUtils.isNotBlank(query)) {

--- a/core/search/src/test/java/org/exoplatform/services/wcm/search/DumpPublicationPlugin.java
+++ b/core/search/src/test/java/org/exoplatform/services/wcm/search/DumpPublicationPlugin.java
@@ -51,6 +51,8 @@ import org.exoplatform.portal.mop.user.UserPortal;
 import org.exoplatform.services.ecm.publication.IncorrectStateUpdateLifecycleException;
 import org.exoplatform.services.ecm.publication.PublicationService;
 import org.exoplatform.services.jcr.ext.common.SessionProvider;
+import org.exoplatform.services.security.ConversationState;
+import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.wcm.portal.LivePortalManagerService;
 import org.exoplatform.services.wcm.publication.PublicationDefaultStates;
 import org.exoplatform.services.wcm.publication.PublicationUtil;
@@ -247,7 +249,7 @@ public class DumpPublicationPlugin extends WebpagePublicationPlugin{
     List<PortalConfig> portalConfigs = WCMCoreUtils.getAllElementsOfListAccess(pageList);
     UserACL userACL = WCMCoreUtils.getService(UserACL.class);
     for(PortalConfig portalConfig : portalConfigs) {
-      if(userACL.hasPermission(portalConfig)) {
+      if(userACL.hasAccessPermission(portalConfig, getCurrentIdentity())) {
         listPortalName.add(portalConfig.getName());
       }
     }
@@ -357,4 +359,10 @@ public class DumpPublicationPlugin extends WebpagePublicationPlugin{
     changeState(node, newState, context);
 
   }
+
+  private static Identity getCurrentIdentity() {
+    ConversationState conversationState = ConversationState.getCurrent();
+    return conversationState == null ? null : conversationState.getIdentity();
+  }
+
 }

--- a/core/search/src/test/resources/conf/wcm/test-search-configuration.xml
+++ b/core/search/src/test/resources/conf/wcm/test-search-configuration.xml
@@ -443,21 +443,6 @@
   </component>
 
   <component>
-    <key>org.gatein.api.oauth.OAuthProviderAccessor</key>
-    <type>org.gatein.api.oauth.BasicOAuthProviderAccessorImpl</type>
-  </component>
-
-  <component>
-    <key>org.gatein.security.oauth.spi.OAuthProviderTypeRegistry</key>
-    <type>org.gatein.security.oauth.registry.OAuthProviderTypeRegistryImpl</type>
-  </component>
-
-  <component>
-    <key>org.gatein.security.oauth.spi.SocialNetworkService</key>
-    <type>org.gatein.security.oauth.data.SocialNetworkServiceImpl</type>
-  </component>
-
-  <component>
     <type>org.exoplatform.web.security.codec.CodecInitializer</type>
     <init-params>
       <value-param>

--- a/core/webui/src/main/java/org/exoplatform/wcm/webui/Utils.java
+++ b/core/webui/src/main/java/org/exoplatform/wcm/webui/Utils.java
@@ -70,6 +70,7 @@ import org.exoplatform.services.jcr.access.PermissionType;
 import org.exoplatform.services.jcr.core.ExtendedNode;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
+import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.IdentityRegistry;
 import org.exoplatform.services.security.MembershipEntry;
@@ -913,9 +914,10 @@ public class Utils {
     UserACL userACL = portalApp.getApplicationComponent(UserACL.class);
 
     if (uiPage != null) {
-      return userACL.hasEditPermissionOnPage(uiPage.getOwnerType(),
-                                             uiPage.getOwnerId(),
-                                             uiPage.getEditPermission());
+      return userACL.hasEditPermission(ConversationState.getCurrent().getIdentity(),
+                                       uiPage.getOwnerType(),
+                                       uiPage.getOwnerId(),
+                                       uiPage.getEditPermission());
     }
     UIPortal currentUIPortal = portalApp.<UIWorkingWorkspace> findComponentById(UIPortalApplication.UI_WORKING_WS_ID)
     .findFirstComponentOfType(UIPortal.class);
@@ -929,7 +931,7 @@ public class Utils {
     if (page == null) {
       return false;
     }
-    return userACL.hasEditPermission(page);
+    return userACL.hasEditPermission(page, ConversationState.getCurrent().getIdentity());
   }
 
   public static boolean hasEditPermissionOnNavigation() throws Exception {
@@ -943,9 +945,10 @@ public class Utils {
     UIPortal currentUIPortal = portalApp.<UIWorkingWorkspace> findComponentById(UIPortalApplication.UI_WORKING_WS_ID)
                                         .findFirstComponentOfType(UIPortal.class);
     UserACL userACL = portalApp.getApplicationComponent(UserACL.class);
-    return userACL.hasEditPermissionOnPortal(currentUIPortal.getSiteKey().getTypeName(),
-                                             currentUIPortal.getSiteKey().getName(),
-                                             currentUIPortal.getEditPermission());
+    return userACL.hasEditPermission(ConversationState.getCurrent().getIdentity(),
+                                     currentUIPortal.getSiteKey().getTypeName(),
+                                     currentUIPortal.getSiteKey().getName(),
+                                     currentUIPortal.getEditPermission());
   }
 
   public static UserNavigation getSelectedNavigation() throws Exception { 
@@ -1134,7 +1137,7 @@ public class Utils {
    */
   public static boolean isAdministratorUser() {
     UserACL userACL = WCMCoreUtils.getService(UserACL.class);
-    return userACL.isUserInGroup(userACL.getAdminGroups());
+    return userACL.isUserInGroup(ConversationState.getCurrent().getIdentity(), userACL.getAdminGroups());
   }
   
   public static String getProfileLink(String userId) {

--- a/ecms-social-integration/src/main/java/org/exoplatform/social/space/customization/SpaceCustomizationService.java
+++ b/ecms-social-integration/src/main/java/org/exoplatform/social/space/customization/SpaceCustomizationService.java
@@ -316,11 +316,7 @@ public class SpaceCustomizationService {
                                           customSpaceHomePage.getFactoryId(),
                                           customSpaceHomePage.getAccessPermissions() != null ? Arrays.asList(customSpaceHomePage.getAccessPermissions())
                                                                                              : null,
-                                          customSpaceHomePage.getEditPermission(),
-                                          customSpaceHomePage.getMoveAppsPermissions() != null ? Arrays.asList(customSpaceHomePage.getMoveAppsPermissions())
-                                                                                               : null,
-                                          customSpaceHomePage.getMoveContainersPermissions() != null ? Arrays.asList(customSpaceHomePage.getMoveContainersPermissions())
-                                                                                                     : null);
+                                          customSpaceHomePage.getEditPermission());
 
       pageService.savePage(new PageContext(pageKey, pageState));
       dataStorageService.save(customSpaceHomePage);

--- a/ext/authoring/services/src/main/java/org/exoplatform/services/wcm/extensions/publication/lifecycle/authoring/AuthoringPublicationPlugin.java
+++ b/ext/authoring/services/src/main/java/org/exoplatform/services/wcm/extensions/publication/lifecycle/authoring/AuthoringPublicationPlugin.java
@@ -43,6 +43,8 @@ import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.resources.ResourceBundleService;
+import org.exoplatform.services.security.ConversationState;
+import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.IdentityConstants;
 import org.exoplatform.services.wcm.extensions.publication.impl.PublicationManagerImpl;
 import org.exoplatform.services.wcm.extensions.publication.lifecycle.authoring.ui.UIPublicationContainer;
@@ -653,10 +655,15 @@ public class AuthoringPublicationPlugin extends  WebpagePublicationPlugin {
     UserACL userACL = WCMCoreUtils.getService(UserACL.class);
     for(Object object:pageList.getAll()) {
       PortalConfig portalConfig = (PortalConfig)object;
-      if(userACL.hasPermission(portalConfig)) {
+      if(userACL.hasAccessPermission(portalConfig, getCurrentIdentity())) {
         listPortalName.add(portalConfig.getName());
       }
     }
     return listPortalName;
+  }
+
+  private Identity getCurrentIdentity() {
+    ConversationState conversationState = ConversationState.getCurrent();
+    return conversationState == null ? null : conversationState.getIdentity();
   }
 }


### PR DESCRIPTION
This change will adapt the usage of UserACL Service Layer API to explicitly use ConversationState.getCurrent() instead of using it implicitly. At the same time, this will move removed `NavigationUtils` class from Portal in order to preserve Business Logic of ECMS Services.