### PR TITLE
fix: [BUG] Process :Document+parent Folder lost in case of Upload from existing document (new process/new request) - EXO-74485

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-drive-explorer/AttachmentsDriveExplorerDrawer.vue
@@ -753,7 +753,7 @@ export default {
         file.isSelectedFromDrives = true;
         const alreadyAttachedFile = this.attachedFiles.find(f => f.id === file.id);
         if (!alreadyAttachedFile) {
-          this.selectedFiles.push({...file, space: this.fromSpace});
+          this.selectedFiles.push({...file, space: this.fromSpace , eXoDrive: true});
         }
         const alreadyRemovedFileIndex = this.removedFiles.findIndex(f => f.id === file.id);
         if (alreadyRemovedFileIndex !== -1) {

--- a/core/services/src/main/java/org/exoplatform/services/attachments/model/Attachment.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/model/Attachment.java
@@ -58,6 +58,8 @@ public class Attachment implements Cloneable {
   
   private boolean                       cloudDrive;
 
+  private boolean                       eXoDrive;
+
   @Override
   public Attachment clone() { // NOSONAR
     return new Attachment(id,
@@ -75,6 +77,7 @@ public class Attachment implements Cloneable {
                           openUrl,
                           previewBreadcrumb,
                           version,
-                          cloudDrive);
+                          cloudDrive,
+                          eXoDrive);
   }
 }

--- a/core/services/src/main/java/org/exoplatform/services/attachments/rest/model/AttachmentEntity.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/rest/model/AttachmentEntity.java
@@ -60,6 +60,8 @@ public class AttachmentEntity {
   
   private boolean                       cloudDrive;
 
+  private boolean                       eXoDrive;
+
   @Override
   public AttachmentEntity clone() { // NOSONAR
     return new AttachmentEntity(id,
@@ -77,7 +79,8 @@ public class AttachmentEntity {
                                 openUrl,
                                 previewBreadcrumb,
                                 version,
-                                cloudDrive);
+                                cloudDrive,
+                                eXoDrive);
   }
 
 }

--- a/core/services/src/main/java/org/exoplatform/services/attachments/utils/EntityBuilder.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/utils/EntityBuilder.java
@@ -62,7 +62,8 @@ public class EntityBuilder {
                                 attachment.getOpenUrl(),
                                 attachment.getPreviewBreadcrumb(),
                                 attachment.getVersion(),
-                                attachment.isCloudDrive()
+                                attachment.isCloudDrive(),
+                                attachment.isEXoDrive()
 
     );
   }


### PR DESCRIPTION
Prior to this fix, there is no way to know if the attached file is from eXo internal drives, this information is needs for process application, this commit add this information to attachments.