### PR TITLE
fix: Edit button displayed twice in a shared file preview mode - EXO-74839.

### DIFF
--- a/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
+++ b/apps/resources-wcm/src/main/webapp/javascript/eXo/ecm/document-preview.js
@@ -637,7 +637,9 @@
       if(!this.isDownloadStatusActivated && !documentPreview.defaultSettings.doc.isCloudDrive) {
         var editorButtonsLoader = editorbuttons.initPreviewButtons(this.settings.doc.id, this.settings.doc.workspace, 'dropup');
         editorButtonsLoader.done(function ($buttonsContainer) {
-          $(".previewBtn").append($buttonsContainer);
+          if ($(".previewBtn").find('.editorButtonContainer').length === 0){
+            $(".previewBtn").append($buttonsContainer);
+          }
         });
       }
 


### PR DESCRIPTION
Before this change, when open link of shared file in a new tab, two edit buttons are displayed in the opened preview page. To resolve this problem, make a condition on the edit button insertion to ensure that it is inserted only once. After this change, only one edit button is displayed and no reload page.