### PR TITLE
fix: Article attachments lost when cancel the scheduling - MEED-8390 - Meeds-io/meeds#2935 (#2450)

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/notes/NotesAttachment.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/notes/NotesAttachment.vue
@@ -113,9 +113,9 @@ export default {
     });
   },
   beforeDestroy() {
-    document.removeEventListener('note-draft-auto-save-done');
-    document.removeEventListener('open-notes-attachments');
-    document.addEventListener('attachments-app-drawer-closed');
+    document.removeEventListener('open-notes-attachments', this.openAttachmentDrawer);
+    document.removeEventListener('attachments-app-drawer-closed', this.handleDrawerClosedEvent);
+    document.removeEventListener('article-draft-auto-save-done');
   },
   methods: {
     openAttachmentDrawer() {

--- a/core/services/src/main/java/org/exoplatform/services/attachments/listener/NoteAttachmentUpdateListener.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/listener/NoteAttachmentUpdateListener.java
@@ -54,10 +54,15 @@ public class NoteAttachmentUpdateListener extends Listener<String, Map<String, O
         String draftPageId = (String) data.get("draftPageId");
         String pageVersionId = (String) data.get("pageVersionId");
         String draftForExistingPageId = (String) data.get("draftForExistingPageId");
+        String unscheduledPageVersionId = (String) data.get("unscheduledPageVersionId");
 
 
         if (draftPageId != null && pageVersionId != null) {
           moveAttachments(draftPageId, pageVersionId, WIKI_DRAFT_PAGES, WIKI_PAGE_VERSIONS);
+        }
+
+        if (draftPageId != null && unscheduledPageVersionId != null) {
+          moveAttachments(unscheduledPageVersionId, draftPageId, WIKI_PAGE_VERSIONS ,WIKI_DRAFT_PAGES);
         }
 
         if (draftForExistingPageId != null && pageVersionId != null) {

--- a/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/social/integration-configuration.xml
+++ b/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/social/integration-configuration.xml
@@ -98,6 +98,11 @@
       <set-method>addListener</set-method>
       <type>org.exoplatform.services.attachments.listener.NoteAttachmentUpdateListener</type>
     </component-plugin>
+    <component-plugin>
+      <name>note.draft.for.new.page.created</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.services.attachments.listener.NoteAttachmentUpdateListener</type>
+    </component-plugin>
 
   </external-component-plugins>
 


### PR DESCRIPTION
Prior to this change, when canceling the scheduling of an article with attachments, the article's attachments were not linked to the newly created draft. This change ensures that the attachments from the deleted article are moved to the newly created draft