### PR TITLE
fix: Note attachments lost after publishing - MEED-8446 - Meeds-io/meeds#2966

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/attachments/listener/NoteAttachmentUpdateListener.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/listener/NoteAttachmentUpdateListener.java
@@ -55,6 +55,7 @@ public class NoteAttachmentUpdateListener extends Listener<String, Map<String, O
         String pageVersionId = (String) data.get("pageVersionId");
         String draftForExistingPageId = (String) data.get("draftForExistingPageId");
         String unscheduledPageVersionId = (String) data.get("unscheduledPageVersionId");
+        String previousPageVersionId = (String) data.get("previousPageVersionId");
 
 
         if (draftPageId != null && pageVersionId != null) {
@@ -67,6 +68,9 @@ public class NoteAttachmentUpdateListener extends Listener<String, Map<String, O
 
         if (draftForExistingPageId != null && pageVersionId != null) {
           copyAttachments(pageVersionId, draftForExistingPageId, WIKI_PAGE_VERSIONS, WIKI_DRAFT_PAGES);
+        }
+        if (previousPageVersionId != null && pageVersionId != null) {
+          moveAttachments(previousPageVersionId, pageVersionId, WIKI_PAGE_VERSIONS, WIKI_PAGE_VERSIONS);
         }
       } catch (Exception e) {
         LOG.error("error when updating note attachments", e);


### PR DESCRIPTION
Prior to this change, note attachments were lost after publishing. This issue was caused by a missing link between the attachment and the newly created version during publishing. This update ensures that attachments are properly linked during publishing, resolving the issue.
