### PR TITLE
fix: When uploading a file if the request upload have a little delay (more than 200ms), the upload fails - EXO-77268

### DIFF
--- a/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
+++ b/apps/portlet-documents/src/main/webapp/vue-app/attachment/components/attachments-upload-components/AttachmentsUploadInput.vue
@@ -282,8 +282,12 @@ export default {
       } else {
         if (file.uploadId) {
           window.setTimeout(() => {
+            if (!file.countFirstProgressError) {
+              file.countFirstProgressError=0;
+            }
             this.$uploadService.getUploadProgress(file.uploadId)
               .then(percent => {
+                delete file.countFirstProgressError;
                 if (this.abortUploading) {
                   return;
                 } else {
@@ -302,9 +306,16 @@ export default {
                   }
                 }
               })
-              .catch(() => {
-                this.removeAttachedFile(file);
-                this.$root.$emit('alert-message', this.$t('attachments.link.failed'), 'error');
+              .catch((err) => {
+                if (err.message==='Uploaded resource not found' && file.countFirstProgressError != null && file.countFirstProgressError < 5) {
+                  //if the upload request take more than 200ms to initialize, then the progress request arrives too early.
+                  //In this case, redo the progress, until 5 errors to be sure
+                  file.countFirstProgressError++;
+                  this.controlUpload(file, continueAction);
+                } else {
+                  this.removeAttachedFile(file);
+                  this.$root.$emit('alert-message', this.$t('attachments.link.failed'), 'error');
+                }
               });
           }, 200);
         }


### PR DESCRIPTION
Before this fix, if the progress request is treaten by the server before the upload request (due to latency problem for example), the upload fails on browser side This commit add a replay of the progress request (5 times max) in order to accept some latency on upload request
