### PR TITLE
fix: Add missing Portlet Instance Cleanup Configuration File - EXO-77297 - Meeds-io/MIPs#181

### DIFF
--- a/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/ecm-wcm-extension/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -57,5 +57,6 @@
   <import>war:/conf/social/integration-configuration.xml</import>
   <import>war:/conf/social/css-class-configuration.xml</import>
   <import>war:/conf/wcm-extension/dynamic-container-configuration.xml</import>
+  <import>war:/conf/wcm-extension/portal/portal-upgrade-configuration.xml</import>
 
 </configuration>


### PR DESCRIPTION
This change will include the configuration file of Upgrade Plugin which will clean previously deleted WebUI portlets.