### PR TITLE
fix : 3dots menu in documents preview do not opens - EXO-78073

### DIFF
--- a/apps/resources-wcm/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/apps/resources-wcm/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -218,6 +218,9 @@
     <depends>
       <module>editorbuttons</module>
     </depends>
+    <depends>
+      <module>bts_dropdown</module>
+    </depends>
   </module>
 
   <module>


### PR DESCRIPTION
Before this fix, the 3 dots menu does not open when clicking on it

This is due to missing dependency on js module bts_dorpdown This dependency was brought by chat addon before which is no more present

This commit add the missing dependency for document preview