### PR TITLE
fix: add property to deactivate computing documents size including versions - EXO-78104

### DIFF
--- a/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-search-configuration.xml
+++ b/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/core-search-configuration.xml
@@ -61,6 +61,10 @@
                   <name>documents.content.indexing.mimetypes</name>
                   <value>${exo.unified-search.indexing.supportedMimeTypes: text/.*, application/ms.* , application/vnd.* , application/xml , application/excel , application/powerpoint , application/xls, application/ppt , application/pdf , application/xhtml+xml , application/javascript , application/x-javascript , application/x-jaxrs+groovy , script/groovy}</value>
                 </value-param>
+                <value-param>
+                    <name>documents.content.compute.version.size</name>
+                    <value>${documents.content.compute.version.size:true}</value>
+                </value-param>
                 <properties-param>
                     <name>constructor.params</name>
                     <property name="index_alias" value="file_alias"/>

--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/connector/FileindexingConnector.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/connector/FileindexingConnector.java
@@ -75,6 +75,7 @@ public class FileindexingConnector extends ElasticIndexingServiceConnector {
   private List<String>         supportedContentIndexingMimetypes;
 
   private long                 contentMaxSizeToIndexInBytes;
+  private boolean              indexVersionSize;
 
   public FileindexingConnector(InitParams initParams) {
     super(initParams);
@@ -94,6 +95,11 @@ public class FileindexingConnector extends ElasticIndexingServiceConnector {
       this.contentMaxSizeToIndexInBytes = Long.parseLong(contentMaxSizeToIndex) * 1024 * 1024;
     } else {
       this.contentMaxSizeToIndexInBytes = DEFAULT_MAX_FILE_SIZE_TO_INDEX * 1024l * 1024l;
+    }
+    if (initParams.containsKey("documents.content.compute.version.size")) {
+      this.indexVersionSize = Boolean.parseBoolean(initParams.getValueParam("documents.content.compute.version.size").getValue());
+    } else {
+      this.indexVersionSize = true;
     }
   }
 
@@ -237,7 +243,11 @@ public class FileindexingConnector extends ElasticIndexingServiceConnector {
 
         Property dataProperty = contentNode.getProperty(NodetypeConstant.JCR_DATA);
         long fileSize = dataProperty.getLength();
-        long fileSizeWithVersion = VersionHistoryUtils.computeVersionsSize(node);
+        long fileSizeWithVersion = fileSize;
+        if (this.indexVersionSize) {
+          fileSizeWithVersion = VersionHistoryUtils.computeVersionsSize(node);
+        }
+
         canIndexContent = canIndexContent && fileSize < this.contentMaxSizeToIndexInBytes;
 
         if (canIndexContent) {


### PR DESCRIPTION
Before this fix, when a document is modified, the indexation compute the size including all versions of a document This can lead to platform outage when documents have a lot of versions (in case of coedition in OO)

When setting the property documents.content.compute.version.size to false, the sizeWithVersions is not computed and use current fileSize. This modification also apply in documents app when displaying file informations.