### PR TITLE
fix: add property to deactivate computing documents size including versions - EXO-78104

### DIFF
--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/connector/FileindexingConnector.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/connector/FileindexingConnector.java
@@ -243,7 +243,7 @@ public class FileindexingConnector extends ElasticIndexingServiceConnector {
 
         Property dataProperty = contentNode.getProperty(NodetypeConstant.JCR_DATA);
         long fileSize = dataProperty.getLength();
-        long fileSizeWithVersion = fileSize;
+        long fileSizeWithVersion = 0;
         if (this.indexVersionSize) {
           fileSizeWithVersion = VersionHistoryUtils.computeVersionsSize(node);
         }


### PR DESCRIPTION
Before this fix, when a document is modified, the indexation compute the size including all versions of a document This can lead to platform outage when documents have a lot of versions (in case of coedition in OO)

When setting the property documents.content.compute.version.size to false, the sizeWithVersions is not computed and use current fileSize. This modification also apply in documents app when displaying file informations.