### PR TITLE
fix : In rest service getFoldersAndFiles, name have the same value than title - EXO-79569

### DIFF
--- a/core/viewer/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
+++ b/core/viewer/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
@@ -595,7 +595,7 @@ public class ManageDocumentService implements ResourceContainer {
     AutoVersionService autoVersionService=WCMCoreUtils.getService(AutoVersionService.class);
     boolean canRemove = true;
     String sourcePath = sourceNode.getPath();
-    file.setAttribute("name", Utils.getTitle(displayNode));
+    file.setAttribute("name", displayNode.getName());
     file.setAttribute("title", Utils.getTitle(displayNode));
     file.setAttribute("workspaceName", workspaceName);
     file.setAttribute("id", sourceNode.getUUID()); 


### PR DESCRIPTION
Before this fix, the rest service getFoldersAndFiles return an xml object representing a file. If the title have capital letters, and the filename have not, the propery name and title, are the same, both with capital letters This fix ensure to use the file name in the property name