### PR TITLE
feat: Add categories to a document - EXO-79557 - eXIP-14

### DIFF
--- a/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/nodetypes/nodetypes-config-extended.xml
+++ b/core/core-configuration/src/main/webapp/WEB-INF/conf/wcm-core/nodetypes/nodetypes-config-extended.xml
@@ -753,5 +753,14 @@
       </propertyDefinition>
     </propertyDefinitions>
   </nodeType>
+
+  <nodeType name="mix:documentsCategory" isMixin="true" hasOrderableChildNodes="false" primaryItemName="">
+    <propertyDefinitions>
+      <propertyDefinition name="exo:categoryIds" requiredType="String" autoCreated="false" mandatory="false"
+                          onParentVersion="COPY" protected="false" multiple="false">
+        <valueConstraints/>
+      </propertyDefinition>
+    </propertyDefinitions>
+  </nodeType>
   
 </nodeTypes>


### PR DESCRIPTION
This change will implement a new mixin type that will need to use for document linked category ids