### PR TITLE
fix: Remove old portlet "DocumentsPortlet" from categories - EXO-78661

### DIFF
--- a/core/services/src/main/resources/portlet-instances.json
+++ b/core/services/src/main/resources/portlet-instances.json
@@ -66,22 +66,6 @@
         "*:/platform/administrators"
       ],
       "system":true
-    },
-    {
-      "nameId":"DocumentsPortlet",
-      "categoryNameId":"tools",
-      "portletName":"DocumentsPortlet",
-      "names":{
-        "en":"layout.portletInstance.DocumentsPortlet.name"
-      },
-      "descriptions":{
-        "en":"layout.portletInstance.DocumentsPortlet.description"
-      },
-      "illustrationPath":"war:/../skin/DefaultSkin/portletIcons/DocumentsPortlet.png",
-      "permissions":[
-        "*:/platform/administrators"
-      ],
-      "system":true
     }
   ]
 }


### PR DESCRIPTION
This change will remove Documents portlet from list of categories