### PR TITLE
fix: Reindex Files only when Favorites Changed

### DIFF
--- a/core/search/src/main/java/org/exoplatform/services/wcm/search/listener/DocumentsMetadataListener.java
+++ b/core/search/src/main/java/org/exoplatform/services/wcm/search/listener/DocumentsMetadataListener.java
@@ -22,7 +22,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.search.index.IndexingService;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
-import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.metadata.favorite.FavoriteService;
 import org.exoplatform.social.metadata.model.MetadataItem;
 
@@ -42,7 +41,8 @@ public class DocumentsMetadataListener extends Listener<Long, MetadataItem> {
     MetadataItem metadataItem = event.getData();
     String objectType = event.getData().getObjectType();
     String objectId = metadataItem.getObjectId();
-    if (StringUtils.equals(objectType, FILE_METADATA_OBJECT_TYPE)) {
+    if (StringUtils.equals(objectType, FILE_METADATA_OBJECT_TYPE)
+        && metadataItem.getMetadataTypeName().equals(FavoriteService.METADATA_TYPE.getName())) {
       indexingService.reindex(FILE_METADATA_OBJECT_TYPE, objectId);
     }
   }


### PR DESCRIPTION
Prior to this change, when any Metadata is changed in Files, including when `viewing` the file, the file is re-indexed. This change ensures to not trigger a file re-indexing only when necessary (`DocumentsMetadataListener` was meant for Favorites only).