### PR TITLE
fix: shared document not marked as viewed when the collaborator has view-only permission - EXO-82372

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/service/AttachmentServiceImpl.java
@@ -553,7 +553,7 @@ public class AttachmentServiceImpl implements AttachmentService {
   public long markAttachmentAsViewed(String nodeId, String viewer) {
     long views = 0L;
     try {
-      Session session = Utils.getSession(sessionProviderService, repositoryService);
+      Session session = Utils.getSystemSession(sessionProviderService, repositoryService);
       views = Utils.markDocumentAsViewed(session, nodeId, viewer);
     } catch (Exception e) {
       LOG.error("Error while marking document as viewed {}", nodeId, e);

--- a/core/services/src/test/java/org/exoplatform/services/attachments/service/AttachmentServiceTest.java
+++ b/core/services/src/test/java/org/exoplatform/services/attachments/service/AttachmentServiceTest.java
@@ -367,7 +367,7 @@ public class AttachmentServiceTest extends BaseExoTestCase {
     Session session = mock(Session.class);
     MockedStatic<Utils> UTILS = mockStatic(Utils.class);
     Node node = mock(Node.class);
-    UTILS.when(() -> Utils.getSession(sessionProviderService, repositoryService)).thenReturn(session);
+    UTILS.when(() -> Utils.getSystemSession(sessionProviderService, repositoryService)).thenReturn(session);
     UTILS.when(() -> Utils.getNodeByIdentifier(session, "123")).thenReturn(node);
     UTILS.when(() -> Utils.markDocumentAsViewed(session, "123", "user")).thenCallRealMethod();
     lenient().when(node.canAddMixin(DOCUMENTS_VIEW_MIXIN)).thenReturn(true);


### PR DESCRIPTION
Prior to this change, when a document was shared with view-only permission and the collaborator accessed it, an exception was thrown. This issue occurred because the “mark as viewed” operation used the current user session to update the viewer count node property, which they were not allowed to modify. This change uses the system session to mark the document as viewed, resolving the issue.