### PR TITLE
Fix: Special chars are converted to underscores when files are uploaded one by one - EXO-83146

### DIFF
--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>7.2.x-SNAPSHOT</version>
+    <version>7.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps</artifactId>
   <packaging>pom</packaging>

--- a/apps/portlet-editors/pom.xml
+++ b/apps/portlet-editors/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>7.2.x-SNAPSHOT</version>
+    <version>7.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-editors</artifactId>
   <packaging>war</packaging>

--- a/apps/portlet-transferrules/pom.xml
+++ b/apps/portlet-transferrules/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>7.2.x-SNAPSHOT</version>
+    <version>7.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-portlet-transferrules</artifactId>
   <packaging>war</packaging>

--- a/apps/resources-wcm/pom.xml
+++ b/apps/resources-wcm/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-apps</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>7.2.x-SNAPSHOT</version>
+    <version>7.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-apps-resources-wcm</artifactId>
   <packaging>war</packaging>

--- a/core/connector/pom.xml
+++ b/core/connector/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>7.2.x-SNAPSHOT</version>
+    <version>7.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-connector</artifactId>
   <packaging>jar</packaging>

--- a/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
+++ b/core/connector/src/main/java/org/exoplatform/wcm/connector/FileUploadHandler.java
@@ -560,9 +560,9 @@ public class FileUploadHandler {
             String suffix = "(" + (indexSuffix - 1) + ")";
             exoTitle = getNewName(exoTitle, suffix);
           }
-          file.setProperty(NodetypeConstant.EXO_TITLE, Utils.cleanDocumentTitle(exoTitle));
+          file.setProperty(NodetypeConstant.EXO_TITLE, exoTitle);
         } else if (!file.hasProperty(NodetypeConstant.EXO_TITLE)) {
-          file.setProperty(NodetypeConstant.EXO_TITLE, Utils.cleanDocumentTitle(exoTitle));
+          file.setProperty(NodetypeConstant.EXO_TITLE, exoTitle);
         }
         jcrContent = file.addNode("jcr:content","nt:resource");
       }else if(parent.hasNode(nodeName)){

--- a/core/core-configuration/pom.xml
+++ b/core/core-configuration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>7.2.x-SNAPSHOT</version>
+    <version>7.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-webapp</artifactId>
   <packaging>war</packaging>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>7.2.x-SNAPSHOT</version>
+    <version>7.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core</artifactId>
   <packaging>pom</packaging>

--- a/core/search/pom.xml
+++ b/core/search/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>7.2.x-SNAPSHOT</version>
+    <version>7.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-search</artifactId>
   <name>eXo PLF:: WCM Search Service</name>

--- a/core/services/pom.xml
+++ b/core/services/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>7.2.x-SNAPSHOT</version>
+    <version>7.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-services</artifactId>
   <name>eXo PLF:: CMS Service</name>

--- a/core/viewer/pom.xml
+++ b/core/viewer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-core</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>7.2.x-SNAPSHOT</version>
+    <version>7.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-core-viewer</artifactId>
   <name>eXo PLF:: DMS Document Viewer</name>

--- a/ecm-wcm-extension/pom.xml
+++ b/ecm-wcm-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>7.2.x-SNAPSHOT</version>
+    <version>7.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecm-wcm-extension</artifactId>
   <packaging>war</packaging>

--- a/ecms-packaging/pom.xml
+++ b/ecms-packaging/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.exoplatform.ecms</groupId>
     <artifactId>ecms</artifactId>
-    <version>7.2.x-SNAPSHOT</version>
+    <version>7.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-packaging</artifactId>
   <packaging>pom</packaging>

--- a/ecms-social-integration/pom.xml
+++ b/ecms-social-integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.exoplatform.ecms</groupId>
     <artifactId>ecms</artifactId>
-    <version>7.2.x-SNAPSHOT</version>
+    <version>7.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-social-integration</artifactId>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.exoplatform.ecms</groupId>
   <artifactId>ecms</artifactId>
-  <version>7.2.x-SNAPSHOT</version>
+  <version>7.2.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo PLF:: ECM Suite</name>
   <description>eXo Entreprise Content Management Suite</description>
@@ -39,7 +39,7 @@
     <!-- **************************************** -->
     <!-- Project Dependencies                     -->
     <!-- **************************************** -->
-    <addon.exo.jcr.version>7.2.x-SNAPSHOT</addon.exo.jcr.version>
+    <addon.exo.jcr.version>7.2.x-maintenance-SNAPSHOT</addon.exo.jcr.version>
 
     <!-- **************************************** -->
     <!-- Apache Chemistry (OpenCMIS) API -->

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>7.2.x-SNAPSHOT</version>
+    <version>7.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-testsuite</artifactId>
   <packaging>pom</packaging>

--- a/testsuite/test/pom.xml
+++ b/testsuite/test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>ecms-testsuite</artifactId>
     <groupId>org.exoplatform.ecms</groupId>
-    <version>7.2.x-SNAPSHOT</version>
+    <version>7.2.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>ecms-testsuite-test</artifactId>
   <name>eXo PLF:: ECMS Testing</name>


### PR DESCRIPTION
Before this change, go to doc app of spacex and upload files whose title contain special chars, all the mentioned chars are replaced by underscores. To fix this problem, remove the clean from title when saving file. After this change, the title is displayed with these tanks.