### PR TITLE
fix : ecms error management when clouddrive connector plugin is not present - EXO-83316

### DIFF
--- a/core/viewer/src/main/java/org/exoplatform/ecm/connector/clouddrives/ConnectService.java
+++ b/core/viewer/src/main/java/org/exoplatform/ecm/connector/clouddrives/ConnectService.java
@@ -981,25 +981,27 @@ public class ConnectService implements ResourceContainer {
     ConnectResponse resp = new ConnectResponse();
     try {
       CloudProvider provider = cloudDrives.getProvider(providerId);
-      ConversationState convo = ConversationState.getCurrent();
-      if (convo != null) {
-        String localUser = convo.getIdentity().getUserId();
-        String host = locator.getServiceHost(uriInfo.getRequestUri().getHost());
+      if (provider != null) {
+        ConversationState convo = ConversationState.getCurrent();
+        if (convo != null) {
+          String localUser = convo.getIdentity().getUserId();
+          String host = locator.getServiceHost(uriInfo.getRequestUri().getHost());
 
-        UUID initId = generateId(localUser);
-        initiated.put(initId, new ConnectInit(localUser, provider, host));
-        timeline.put(initId, System.currentTimeMillis() + (INIT_COOKIE_EXPIRE * 1000) + 5000);
+          UUID initId = generateId(localUser);
+          initiated.put(initId, new ConnectInit(localUser, provider, host));
+          timeline.put(initId, System.currentTimeMillis() + (INIT_COOKIE_EXPIRE * 1000) + 5000);
 
-        resp.cookie(INIT_COOKIE, initId.toString(), INIT_COOKIE_PATH, host, "Cloud Drive init ID", INIT_COOKIE_EXPIRE, false);
-        return resp.entity(provider).ok().build();
+          resp.cookie(INIT_COOKIE, initId.toString(), INIT_COOKIE_PATH, host, "Cloud Drive init ID", INIT_COOKIE_EXPIRE, false);
+          return resp.entity(provider).ok().build();
+        } else {
+          LOG.warn("ConversationState not set to initialize connect to " + provider.getName());
+          return resp.error("User not authenticated to connect " + provider.getName()).status(Status.UNAUTHORIZED).build();
+        }
       } else {
-        LOG.warn("ConversationState not set to initialize connect to " + provider.getName());
-        return resp.error("User not authenticated to connect " + provider.getName()).status(Status.UNAUTHORIZED).build();
+        LOG.warn("Provider not found for id '" + providerId + "'");
+        return resp.error("Provider not found.").status(Status.BAD_REQUEST).build();
       }
-    } catch (ProviderNotAvailableException e) {
-      LOG.warn("Provider not found for id '" + providerId + "'", e);
-      return resp.error("Provider not found.").status(Status.BAD_REQUEST).build();
-    } catch (Throwable e) {
+    } catch(Throwable e){
       LOG.error("Error initializing user request for drive provider " + providerId, e);
       return resp.error("Error initializing user request.").status(Status.INTERNAL_SERVER_ERROR).build();
     }

--- a/core/viewer/src/main/java/org/exoplatform/ecm/connector/clouddrives/FeaturesService.java
+++ b/core/viewer/src/main/java/org/exoplatform/ecm/connector/clouddrives/FeaturesService.java
@@ -124,9 +124,8 @@ public class FeaturesService implements ResourceContainer {
       if (path != null) {
         CloudProvider provider;
         if (providerId != null && providerId.length() > 0) {
-          try {
-            provider = cloudDrives.getProvider(providerId);
-          } catch (ProviderNotAvailableException e) {
+          provider = cloudDrives.getProvider(providerId);
+          if (provider == null) {
             LOG.warn("Unknown provider: " + providerId);
             return Response.status(Status.BAD_REQUEST).entity("Unknown provider.").build();
           }

--- a/core/viewer/src/main/java/org/exoplatform/ecm/connector/clouddrives/ProviderService.java
+++ b/core/viewer/src/main/java/org/exoplatform/ecm/connector/clouddrives/ProviderService.java
@@ -84,12 +84,12 @@ public class ProviderService implements ResourceContainer {
   @RolesAllowed("users")
   @Path("/{providerid}")
   public Response getById(@PathParam("providerid") String providerId) {
-
-    try {
+    CloudProvider provider = cloudDrives.getProvider(providerId);
+    if (provider == null) {
+      LOG.warn("Cannot return provider by id " + providerId);
+      return Response.status(Status.BAD_REQUEST).entity("Cannot return provider by id " + providerId).build();
+    } else {
       return Response.ok().entity(cloudDrives.getProvider(providerId)).build();
-    } catch (CloudDriveException e) {
-      LOG.warn("Cannot return prvider by id " + providerId + ": " + e.getMessage());
-      return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();
     }
   }
 

--- a/core/viewer/src/main/java/org/exoplatform/services/cms/clouddrives/CloudDriveService.java
+++ b/core/viewer/src/main/java/org/exoplatform/services/cms/clouddrives/CloudDriveService.java
@@ -110,9 +110,8 @@ public interface CloudDriveService {
    *
    * @param id the id
    * @return CloudProvider
-   * @throws ProviderNotAvailableException if no such provider with given id
    */
-  CloudProvider getProvider(String id) throws ProviderNotAvailableException;
+  CloudProvider getProvider(String id);
 
   /**
    * Set of available providers.

--- a/core/viewer/src/main/java/org/exoplatform/services/cms/clouddrives/CloudDriveServiceImpl.java
+++ b/core/viewer/src/main/java/org/exoplatform/services/cms/clouddrives/CloudDriveServiceImpl.java
@@ -267,13 +267,13 @@ public class CloudDriveServiceImpl implements CloudDriveService, Startable {
    * {@inheritDoc}
    */
   @Override
-  public CloudProvider getProvider(String id) throws ProviderNotAvailableException {
+  public CloudProvider getProvider(String id) {
     for (CloudProvider p : connectors.keySet()) {
       if (p.getId().equals(id)) {
         return p;
       }
     }
-    throw new ProviderNotAvailableException("No such provider '" + id + "'");
+    return null;
   }
 
   /**
@@ -453,13 +453,17 @@ public class CloudDriveServiceImpl implements CloudDriveService, Startable {
    */
   @Override
   public void start() {
-    try {
-      loadConnected(jcrService.getCurrentRepository());
-    } catch (RepositoryException e) {
-      LOG.error("Error reading current repository: " + e.getMessage());
-      throw new RuntimeException("Error loading connected drives: cannot read current repository", e);
+    if (!getProviders().isEmpty()) {
+      try {
+        loadConnected(jcrService.getCurrentRepository());
+      } catch (RepositoryException e) {
+        LOG.error("Error reading current repository: " + e.getMessage());
+        throw new RuntimeException("Error loading connected drives: cannot read current repository", e);
+      }
+      LOG.info("Cloud Drive service successfuly started");
+    } else {
+      LOG.info("No Cloud Drive providers configured.");
     }
-    LOG.info("Cloud Drive service successfuly started");
   }
 
   /**
@@ -539,17 +543,14 @@ public class CloudDriveServiceImpl implements CloudDriveService, Startable {
               // performance a bit. So, to avoid reading of the same we do it here once.
               if (drive.getProperty("ecd:connected").getBoolean()) {
                 String providerId = drive.getProperty("ecd:provider").getString();
-                try {
-                  CloudProvider provider = getProvider(providerId);
+                CloudProvider provider = getProvider(providerId);
+                if (provider != null) {
                   Set<Node> driveNodes = repoDrives.get(provider);
                   if (driveNodes == null) {
                     driveNodes = new HashSet<Node>();
                     repoDrives.put(provider, driveNodes);
                   }
                   driveNodes.add(drive);
-                } catch (CloudDriveException e) {
-                  LOG.error("Error loading provider (" + providerId + ") of stored drive " + drive.getPath() + ": "
-                      + e.getMessage(), e);
                 }
               }
             }


### PR DESCRIPTION
Before this fix, when a provider is not present it generates an error, which is loggued in server log This commit change this to not have an error if the provider is not present