### PR TITLE
fix: Exclude trashed nodes from retrieved attachments - EXO-83534

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/attachments/storage/AttachmentStorageImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/storage/AttachmentStorageImpl.java
@@ -97,7 +97,9 @@ public class AttachmentStorageImpl implements AttachmentStorage {
                                                                    workspace,
                                                                    userSession,
                                                                    attachmentId);
-          attachments.add(attachment);
+          if (attachment != null) {
+            attachments.add(attachment);
+          }
         }
         attachments = Utils.removeDuplicatedAttachments(userSession, attachments);
       }

--- a/core/services/src/main/java/org/exoplatform/services/attachments/utils/EntityBuilder.java
+++ b/core/services/src/main/java/org/exoplatform/services/attachments/utils/EntityBuilder.java
@@ -80,6 +80,9 @@ public class EntityBuilder {
     ExtendedSession extendedSession = (ExtendedSession) session;
     try {
       attachmentNode = extendedSession.getNodeByIdentifier(attachmentId);
+      if (documentService.isDocumentTrashed(attachmentNode)) {
+        return null;
+      }
     } catch (AccessDeniedException e) {
       Attachment privateAttachment = new Attachment();
       acl.setCanAccess(false);

--- a/core/services/src/main/java/org/exoplatform/services/cms/documents/DocumentService.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/documents/DocumentService.java
@@ -396,4 +396,23 @@ public interface DocumentService {
     }
   }
 
+  /**
+   * Determines whether the given JCR node represents a document that is currently
+   * in a "trash" (soft-deleted) state.
+   *
+   * <p>The exact detection strategy depends on the repository implementation and/or
+   * business rules. Typical approaches include checking whether the node resides
+   * under a dedicated trash path (for example, <code>/Trash</code>) or verifying a
+   * specific metadata flag or mixin that marks the document as trashed.</p>
+   *
+   * <p>This default implementation is not provided and must be overridden by
+   * implementations that support the concept of trash.</p>
+   *
+   * @param node the JCR node representing the document (must not be {@code null})
+   * @return {@code true} if the document is considered trashed; {@code false} otherwise
+   * @throws UnsupportedOperationException if the method is not implemented
+   */
+  default Boolean isDocumentTrashed(Node node) throws RepositoryException {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImpl.java
@@ -141,6 +141,7 @@ public class DocumentServiceImpl implements DocumentService {
   private FavoriteService favoriteService;
   private Authenticator       authenticator;
   private final IdentityRegistry identityRegistry;
+  private final TrashService trashService;
   
   /**
    * Instantiates a new {@link DocumentService} implementation.
@@ -168,7 +169,7 @@ public class DocumentServiceImpl implements DocumentService {
                              OrganizationService organizationService,
                              SettingService settingService,
                              IdentityManager identityManager,
-                             IDGeneratorService idGenerator, FavoriteService favoriteService, IdentityRegistry identityRegistry, Authenticator authenticator) {
+                             IDGeneratorService idGenerator, FavoriteService favoriteService, IdentityRegistry identityRegistry, Authenticator authenticator, TrashService trashService) {
     this.configurationManager = configurationManager;
     this.manageDriveService = manageDriveService;
     this.sessionProviderService = sessionProviderService;
@@ -186,6 +187,7 @@ public class DocumentServiceImpl implements DocumentService {
     
     // Online editors support
     this.editorsRuntimeId = idGenerator.generateStringID(this);
+    this.trashService = trashService;
     EditorProvidersHelper.init(this);
   }
 
@@ -1401,8 +1403,10 @@ public class DocumentServiceImpl implements DocumentService {
     } catch (RepositoryException e) {
       throw new IllegalStateException("Can't build a SessionProvider", e);
     }
-
-
   }
-  
+
+  @Override
+  public Boolean isDocumentTrashed(Node node) throws RepositoryException {
+    return trashService.isInTrash(node);
+  }
 }

--- a/core/services/src/test/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImplTest.java
+++ b/core/services/src/test/java/org/exoplatform/services/cms/documents/impl/DocumentServiceImplTest.java
@@ -8,6 +8,7 @@ import org.exoplatform.portal.config.UserPortalConfigService;
 import org.exoplatform.portal.config.model.PortalConfig;
 import org.exoplatform.services.cms.documents.DocumentService;
 import org.exoplatform.services.cms.documents.FavoriteService;
+import org.exoplatform.services.cms.documents.TrashService;
 import org.exoplatform.services.cms.drives.DriveData;
 import org.exoplatform.services.cms.drives.ManageDriveService;
 import org.exoplatform.services.cms.drives.impl.ManageDriveServiceImpl;
@@ -40,10 +41,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import javax.jcr.Node;
-import javax.jcr.PathNotFoundException;
-import javax.jcr.Repository;
-import javax.jcr.Session;
+import javax.jcr.*;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -104,6 +102,9 @@ public class DocumentServiceImplTest {
   @Mock
   UserPortalConfig userPortalConfig;
 
+  @Mock
+  TrashService trashService;
+
   MockedStatic<Utils> UTILS = mockStatic(Utils.class);
   MockedStatic<WCMCoreUtils> WCM_CORE_UTILS = mockStatic(WCMCoreUtils.class);
 
@@ -132,7 +133,8 @@ public class DocumentServiceImplTest {
                                               idGenerator,
                                               favoriteService,
                                               identityRegistry,
-                                              authenticator);
+                                              authenticator,
+                                              trashService);
     when(sessionProviderService.getSystemSessionProvider(any())).thenReturn(sessionProvider);
     when(repository.getConfiguration()).thenReturn(repositoryEntry);
     when(repositoryEntry.getDefaultWorkspaceName()).thenReturn("collaboration");
@@ -287,5 +289,14 @@ public class DocumentServiceImplTest {
     when((folderB.getIdentifier())).thenReturn(identifier);
     link = documentService.getLinkInDocumentsApp(nodePath, generalDrive);
     assertTrue(link.contains(identifier));
+  }
+
+  @Test
+  public void isDocumentTrashed_shouldReturnTrue_whenNodeIsInTrash() throws RepositoryException {
+    Node node = mock(Node.class);
+    when(trashService.isInTrash(node)).thenReturn(true, false);
+
+    assertTrue(documentService.isDocumentTrashed(node));
+    assertFalse(documentService.isDocumentTrashed(node));
   }
 }


### PR DESCRIPTION
Exclude trashed nodes from retrieved attachments