### PR TITLE
feat: Retrieve Memberships from User ACL instead of OrganizationService - MEED-10149 - Meeds-io/MIPs#240

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/drives/impl/ManageDriveServiceImpl.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/drives/impl/ManageDriveServiceImpl.java
@@ -31,8 +31,11 @@ import javax.jcr.PathNotFoundException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
+import org.apache.commons.lang3.StringUtils;
 import org.picocontainer.Startable;
 
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.cache.CacheService;
 import org.exoplatform.services.cache.ExoCache;
 import org.exoplatform.services.cms.BasePath;
@@ -50,6 +53,7 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.services.organization.Membership;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.security.ConversationState;
+import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.wcm.utils.WCMCoreUtils;
 
 /**
@@ -716,15 +720,15 @@ public class ManageDriveServiceImpl implements ManageDriveService, Startable {
   }
 
   protected List<String> getUserMemberships(String userId) throws Exception {
-    List<String> memberships = null;
-    String currentUser = ConversationState.getCurrent() != null ? ConversationState.getCurrent().getIdentity().getUserId() : null;
-    if(currentUser != null && currentUser.equals(userId)) {
-      memberships = Utils.getMemberships();
+    if(StringUtils.isBlank(userId)) {
+      return Collections.emptyList();
     } else {
-      Collection<Membership> colMemberships = organizationService.getMembershipHandler().findMembershipsByUser(userId);
-      memberships = colMemberships.stream().map(m -> m.getMembershipType() + ":" + m.getGroupId()).collect(Collectors.toList());
+      Identity userAclIdentity = ExoContainerContext.getService(UserACL.class).getUserIdentity(userId);
+      return userAclIdentity.getMemberships()
+                            .stream()
+                            .map(m -> "%s:%s".formatted(m.getMembershipType(), m.getGroup()))
+                            .collect(Collectors.toList());
     }
-    return memberships;
   }
 
   /**

--- a/core/services/src/main/java/org/exoplatform/services/wcm/utils/WCMCoreUtils.java
+++ b/core/services/src/main/java/org/exoplatform/services/wcm/utils/WCMCoreUtils.java
@@ -190,31 +190,14 @@ public class WCMCoreUtils {
     try {
       OrganizationService organizationService = WCMCoreUtils.getService(OrganizationService.class);
       startRequest(organizationService);
-      Identity identity = ConversationState.getCurrent().getIdentity();
-      Collection<?> memberships = null;
-      if (userId.equals(identity.getUserId())){
-        Collection<MembershipEntry> membershipsEntries = identity.getMemberships();
-        HashSet<MembershipImpl> membershipsHash = new HashSet<MembershipImpl>();
-        for (MembershipEntry membershipEntry : membershipsEntries) {
-          MembershipImpl m = new MembershipImpl();
-          m.setGroupId(membershipEntry.getGroup());
-          m.setMembershipType(membershipEntry.getMembershipType());
-          m.setUserName(userId);
-          membershipsHash.add(m);
-        }
-        memberships =  new LinkedList<>(membershipsHash);
-      } else {
-        memberships = organizationService.getMembershipHandler().findMembershipsByUser(userId);
-      }
+      Identity identity = ExoContainerContext.getService(UserACL.class).getUserIdentity(userId);
       String userMembershipTmp;
-      Membership userMembership;
       int count = 0;
       String permissionTmp = "";
       for (String permission : permissions) {
         if (!permissionTmp.equals(permission)) count = 0;
-        for (Object userMembershipObj : memberships) {
-          userMembership = (Membership) userMembershipObj;
-          if (permission.equals(userMembership.getUserName())) {
+        for (MembershipEntry userMembership : identity.getMemberships()) {
+          if (permission.equals(userId)) {
             return true;
           } else if ("any".equals(permission)) {
             if (isNeedFullAccess) {
@@ -222,14 +205,14 @@ public class WCMCoreUtils {
               if (count == 4) return true;
             }
             else return true;
-          } else if (permission.startsWith("*") && permission.contains(userMembership.getGroupId())) {
+          } else if (permission.startsWith("*") && permission.contains(userMembership.getGroup())) {
             if (isNeedFullAccess) {
               count++;
               if (count == 4) return true;
             }
             else return true;
           } else {
-            userMembershipTmp = userMembership.getMembershipType() + ":" + userMembership.getGroupId();
+            userMembershipTmp = userMembership.getMembershipType() + ":" + userMembership.getGroup();
             if (permission.equals(userMembershipTmp)) {
               if (isNeedFullAccess) {
                 count++;


### PR DESCRIPTION
This change will centralize the users memberships retrieval to be made from `UserACL` Service rather than `OrganizationService`. This centralization will allow to optimize the Code enhancements and evolutivity.