### PR TITLE
fix: drag & drop document/folder on space root folder should apply space's access properties - EXO-85034 (#2547)

### DIFF
--- a/core/viewer/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
+++ b/core/viewer/src/main/java/org/exoplatform/ecm/connector/platform/ManageDocumentService.java
@@ -743,12 +743,8 @@ public class ManageDocumentService implements ResourceContainer {
         newNode.setProperty(NodetypeConstant.EXO_TITLE, org.exoplatform.services.cms.impl.Utils.cleanDocumentTitle(folder));
 
         // Update permissions
-        if (newNode.canAddMixin("exo:privilegeable")) {
-          newNode.addMixin("exo:privilegeable");
-        }
-        String groupId = driveData.getParameters().get(ManageDriveServiceImpl.DRIVE_PARAMATER_GROUP_ID);
-        if(StringUtils.isNotBlank(groupId) && groupId.startsWith("/spaces/")) {
-          ((ExtendedNode) newNode).setPermission("*:" + groupId, new String[]{PermissionType.READ, PermissionType.ADD_NODE, PermissionType.SET_PROPERTY});
+        if (newNode.canAddMixin("mix:referenceable")) {
+          newNode.addMixin("mix:referenceable");
         }
 
         node.save();


### PR DESCRIPTION
Before this change, when a Space was created with Restrict Content Creation enabled and a folder or document was uploaded via drag & drop to the root folder of the space, the edit permission remained enabled for the created file or folder. To fix this issue, the mix:referenceable mixin is now added when creating the folder node. After this change, the edit permission is correctly disabled for files and folders created via drag & drop when Restrict Content Creation is enabled.