### PR TITLE
fix: Prevent filename collision from special character normalization - EXO-87618

### DIFF
--- a/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
+++ b/core/services/src/main/java/org/exoplatform/services/cms/impl/Utils.java
@@ -741,7 +741,7 @@ public class Utils {
     if (StringUtils.isEmpty(oldName)) {
       return oldName;
     }
-    return replaceSpecialChars(oldName, "&#*?!@.'\"\t\r\n$\\><:;[]/|’", nodeType);
+    return replaceSpecialChars(oldName, "&#*.'\"\t\r\n$\\><:;[]/|’", nodeType);
   }
 
   /** Return name after cleaning


### PR DESCRIPTION
This change will removed @, ?, ! from the special characters list, they are valid JCR node name characters.